### PR TITLE
Check for SMTP class before blindly requiring it

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -791,7 +791,7 @@ class PHPMailer {
    * @return bool
    */
   protected function SmtpSend($header, $body) {
-    require_once $this->PluginDir . 'class.smtp.php';
+    if (!class_exists('SMTP')) require_once $this->PluginDir . 'class.smtp.php';
     $bad_rcpt = array();
 
     if(!$this->SmtpConnect()) {


### PR DESCRIPTION
To allow more flexibility, SMTP class may already be included, or may be able to be autoloaded. It makes sense to check for it before requiring it.
