### PR TITLE
Added Timeout support to SMTP class when reading from remote server

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -864,6 +864,7 @@ class PHPMailer {
   public function SmtpConnect() {
     if(is_null($this->smtp)) {
       $this->smtp = new SMTP();
+      $this->smtp->timeout = $this->Timeout;
     }
 
     $this->smtp->do_debug = $this->SMTPDebug;

--- a/class.smtp.php
+++ b/class.smtp.php
@@ -73,6 +73,7 @@ class SMTP {
    * @var string
    */
   public $Version         = '5.2.1';
+  public $timeout = 3;
 
   /////////////////////////////////////////////////
   // PROPERTIES, PRIVATE AND PROTECTED
@@ -84,6 +85,7 @@ class SMTP {
 
   /**
    * Initialize the class so that the data is in a known state.
+   *
    * @access public
    * @return void
    */
@@ -797,6 +799,8 @@ class SMTP {
    */
   private function get_lines() {
     $data = "";
+    $now = microtime(true);
+    $this->timeout = isset($this->timeout) ? $this->timeout : 3;
     while(!feof($this->smtp_conn)) {
       $str = @fgets($this->smtp_conn,515);
       if($this->do_debug >= 4) {
@@ -808,7 +812,7 @@ class SMTP {
         echo "SMTP -> get_lines(): \$data is \"$data\"" . $this->CRLF . '<br />';
       }
       // if 4th character is a space, we are done reading, break the loop
-      if(substr($str,3,1) == " ") { break; }
+      if(substr($str,3,1) == " " || ((microtime(true) - $now) > $this->timeout)) { break; }
     }
     return $data;
   }


### PR DESCRIPTION
From commit log:

Adding timeout support to the SMTP class. Adjusted phpmailer class to pass its timeout value onto the SMTP class when instantiated. (Boo on not designing this stuff to be passed into the constructor as options.) Fixes issue logged at http://code.google.com/a/apache-extras.org/p/phpmailer/issues/detail?id=71"

The timeout default is inherited from the phpmailer class (assuming normal usage) but defaults to a low setting of only 3 seconds. Please review and comment as you see fit.
