### PR TITLE
Change README to markdown and reorganize

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,108 @@
-/*******************************************************************
-*     http://code.google.com/a/apache-extras.org/p/phpmailer/      *
-********************************************************************/
+# PHPMailer - Full Featured Email Transfer Class for PHP
 
-PHPMailer
-Full Featured Email Transfer Class for PHP
-==========================================
+## License 
+
+This software is licenced under the LGPL.  Please read LICENSE for information on the
+software availability and distribution.
+
+## Class Features:
+
+- Send emails with multiple TOs, CCs, BCCs and REPLY-TOs
+- Redundant SMTP servers
+- Multipart/alternative emails for mail clients that do not read HTML email
+- Support for 8bit, base64, binary, and quoted-printable encoding
+- Uses the same methods as the very popular AspEmail active server (COM) component
+- SMTP authentication
+- Native language support
+- Word wrap, and more!
+
+## Why you might need it:
+
+Many PHP developers utilize email in their code.  The only PHP function
+that supports this is the mail() function.  However, it does not expose
+any of the popular features that many email clients use nowadays like
+HTML-based emails and attachments. There are two proprietary
+development tools out there that have all the functionality built into
+easy to use classes: AspEmail(tm) and AspMail.  Both of these
+programs are COM components only available on Windows.  They are also a
+little pricey for smaller projects.
+
+Since I do Linux development I've missed these tools for my PHP coding.
+So I built a version myself that implements the same methods (object
+calls) that the Windows-based components do. It is open source and the
+LGPL license allows you to place the class in your proprietary PHP
+projects.
+
+## Installation:
+
+Copy class.phpmailer.php into your php.ini include_path. If you are
+using the SMTP mailer then place class.smtp.php in your path as well.
+In the language directory you will find several files like
+phpmailer.lang-en.php.  If you look right before the .php extension
+that there are two letters.  These represent the language type of the
+translation file.  For instance "en" is the English file and "br" is
+the Portuguese file.  Choose the file that best fits with your language
+and place it in the PHP include path.  If your language is English
+then you have nothing more to do.  If it is a different language then
+you must point PHPMailer to the correct translation.  To do this, call
+the PHPMailer SetLanguage method like so:
+
+```php
+// To load the Portuguese version
+$mail->SetLanguage("br", "/optional/path/to/language/directory/");
+```
+
+That's it.  You should now be ready to use PHPMailer!
+
+## A Simple Example:
+
+```php
+<?php
+require("class.phpmailer.php");
+
+$mail = new PHPMailer();
+
+$mail->IsSMTP();                                      // set mailer to use SMTP
+$mail->Host = "smtp1.example.com;smtp2.example.com";  // specify main and backup server
+$mail->SMTPAuth = true;     // turn on SMTP authentication
+$mail->Username = "jswan";  // SMTP username
+$mail->Password = "secret"; // SMTP password
+
+$mail->From = "from@example.com";
+$mail->FromName = "Mailer";
+$mail->AddAddress("josh@example.net", "Josh Adams");
+$mail->AddAddress("ellen@example.com");                  // name is optional
+$mail->AddReplyTo("info@example.com", "Information");
+
+$mail->WordWrap = 50;                                 // set word wrap to 50 characters
+$mail->AddAttachment("/var/tmp/file.tar.gz");         // add attachments
+$mail->AddAttachment("/tmp/image.jpg", "new.jpg");    // optional name
+$mail->IsHTML(true);                                  // set email format to HTML
+
+$mail->Subject = "Here is the subject";
+$mail->Body    = "This is the HTML message body <b>in bold!</b>";
+$mail->AltBody = "This is the body in plain text for non-HTML mail clients";
+
+if(!$mail->Send())
+{
+   echo "Message could not be sent. <p>";
+   echo "Mailer Error: " . $mail->ErrorInfo;
+   exit;
+}
+
+echo "Message has been sent";
+?>
+```
+
+## CHANGELOG
+
+See ChangeLog.txt
+
+Download: http://sourceforge.net/project/showfiles.php?group_id=26031
+
+Andy Prevost
+
+## History (see changelog.txt for more)
 
 Version 5.2.1 (January 16, 2012)
 
@@ -125,101 +223,7 @@ and indicate your interest.
 
 **
 
+## See also
+
 http://phpmailer.sourceforge.net/
-
-This software is licenced under the LGPL.  Please read LICENSE for information on the
-software availability and distribution.
-
-Class Features:
-- Send emails with multiple TOs, CCs, BCCs and REPLY-TOs
-- Redundant SMTP servers
-- Multipart/alternative emails for mail clients that do not read HTML email
-- Support for 8bit, base64, binary, and quoted-printable encoding
-- Uses the same methods as the very popular AspEmail active server (COM) component
-- SMTP authentication
-- Native language support
-- Word wrap, and more!
-
-Why you might need it:
-
-Many PHP developers utilize email in their code.  The only PHP function
-that supports this is the mail() function.  However, it does not expose
-any of the popular features that many email clients use nowadays like
-HTML-based emails and attachments. There are two proprietary
-development tools out there that have all the functionality built into
-easy to use classes: AspEmail(tm) and AspMail.  Both of these
-programs are COM components only available on Windows.  They are also a
-little pricey for smaller projects.
-
-Since I do Linux development I�ve missed these tools for my PHP coding.
-So I built a version myself that implements the same methods (object
-calls) that the Windows-based components do. It is open source and the
-LGPL license allows you to place the class in your proprietary PHP
-projects.
-
-
-Installation:
-
-Copy class.phpmailer.php into your php.ini include_path. If you are
-using the SMTP mailer then place class.smtp.php in your path as well.
-In the language directory you will find several files like
-phpmailer.lang-en.php.  If you look right before the .php extension
-that there are two letters.  These represent the language type of the
-translation file.  For instance "en" is the English file and "br" is
-the Portuguese file.  Chose the file that best fits with your language
-and place it in the PHP include path.  If your language is English
-then you have nothing more to do.  If it is a different language then
-you must point PHPMailer to the correct translation.  To do this, call
-the PHPMailer SetLanguage method like so:
-
-// To load the Portuguese version
-$mail->SetLanguage("br", "/optional/path/to/language/directory/");
-
-That's it.  You should now be ready to use PHPMailer!
-
-
-A Simple Example:
-
-<?php
-require("class.phpmailer.php");
-
-$mail = new PHPMailer();
-
-$mail->IsSMTP();                                      // set mailer to use SMTP
-$mail->Host = "smtp1.example.com;smtp2.example.com";  // specify main and backup server
-$mail->SMTPAuth = true;     // turn on SMTP authentication
-$mail->Username = "jswan";  // SMTP username
-$mail->Password = "secret"; // SMTP password
-
-$mail->From = "from@example.com";
-$mail->FromName = "Mailer";
-$mail->AddAddress("josh@example.net", "Josh Adams");
-$mail->AddAddress("ellen@example.com");                  // name is optional
-$mail->AddReplyTo("info@example.com", "Information");
-
-$mail->WordWrap = 50;                                 // set word wrap to 50 characters
-$mail->AddAttachment("/var/tmp/file.tar.gz");         // add attachments
-$mail->AddAttachment("/tmp/image.jpg", "new.jpg");    // optional name
-$mail->IsHTML(true);                                  // set email format to HTML
-
-$mail->Subject = "Here is the subject";
-$mail->Body    = "This is the HTML message body <b>in bold!</b>";
-$mail->AltBody = "This is the body in plain text for non-HTML mail clients";
-
-if(!$mail->Send())
-{
-   echo "Message could not be sent. <p>";
-   echo "Mailer Error: " . $mail->ErrorInfo;
-   exit;
-}
-
-echo "Message has been sent";
-?>
-
-CHANGELOG
-
-See ChangeLog.txt
-
-Download: http://sourceforge.net/project/showfiles.php?group_id=26031
-
-Andy Prevost
+http://code.google.com/a/apache-extras.org/p/phpmailer/


### PR DESCRIPTION
Take a look at my fork to see how it looks with the changes.

The main thing I wanted to change was the fact that, as a newcomer, I had to scroll through a bunch of project history to see any usage examples. I was going to move all the history into a new changelog file, but there's already a changelog file, so I'm not sure where that info should go.

Using Github-flavored markdown also means that the code gets nicely syntax highlighted.
