### PR TITLE
Support for composer (change amenadiel to Synchro for it to work)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,3 @@
+{
+"name":"phpmailer/phpmailer"
+}


### PR DESCRIPTION
adss composer.json naming this project "phpmailer/phpmailer" so you can
add it as a dependence. You have to add it as a repository too:

{
"repositories": [
{   "type": "git",
"url":  "git@github.com:amenadiel/PHPMailer.git"  }
],
"require": {
"php"                   : ">=5.3.3",
"phpmailer/phpmailer" : "dev-master"

}
}
