### PR TITLE
Language string failed to load: tls

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1064,7 +1064,7 @@ class PHPMailer {
 
           if ($tls) {
             if (!$this->smtp->StartTLS()) {
-              throw new phpmailerException($this->Lang('tls'));
+              throw new phpmailerException($this->Lang('connect_host'));
             }
 
             //We must resend HELO after tls negotiation


### PR DESCRIPTION
language string 'tls' is missing on line 1067. can use 'connect_host' instead
