### PR TITLE
PATH directory

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -968,7 +968,7 @@ class PHPMailer {
    * @return bool
    */
   protected function SmtpSend($header, $body) {
-    require_once $this->PluginDir . 'class.smtp.php';
+    require_once __DIR__ . $this->PluginDir . 'class.smtp.php';
     $bad_rcpt = array();
 
     if(!$this->SmtpConnect()) {


### PR DESCRIPTION
Using constant "**DIR**" is helpful when using the class as an extension of a application framework, such as integration with Yii (http://www.yiiframework.com/).

Example:

require_once $this->PluginDir . 'class.smtp.php'; // require_once(class.smtp.php): failed to open stream: No such file or directory

require_once **DIR** . $this->PluginDir . '/class.smtp.php'; // Success (/var/www/project/protected/extensions/class.smtp.php)
