### PR TITLE
Esperanto/French translations

### DIFF
--- a/language/phpmailer.lang-eo.php
+++ b/language/phpmailer.lang-eo.php
@@ -1,0 +1,23 @@
+<?php
+/**
+* PHPMailer language file: refer to English translation for definitive list
+* Esperanto version
+*/
+
+$PHPMAILER_LANG['authenticate']         = 'Eraro de servilo SMTP : aŭtentigo malsukcesis.';
+$PHPMAILER_LANG['connect_host']         = 'Eraro de servilo SMTP : konektado al servilo malsukcesis.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Eraro de servilo SMTP : neĝustaj datumoj.';
+$PHPMAILER_LANG['empty_message']        = 'Teksto de mesaĝo mankas.';
+$PHPMAILER_LANG['encoding']             = 'Nekonata kodoprezento: ';
+$PHPMAILER_LANG['execute']              = 'Lanĉi rulumadon ne eblis: ';
+$PHPMAILER_LANG['file_access']          = 'Aliro al dosiero ne sukcesis: ';
+$PHPMAILER_LANG['file_open']            = 'Eraro de dosiero: malfermo neeblas: ';
+$PHPMAILER_LANG['from_failed']          = 'Jena adreso de sendinto malsukcesis: ';
+$PHPMAILER_LANG['instantiate']          = 'Genero de retmesaĝa funkcio neeblis.';
+$PHPMAILER_LANG['invalid_address']      = 'Retadreso ne validas: ';
+$PHPMAILER_LANG['provide_address']      = 'Vi devas tajpi almenaŭ unu recevontan retadreson.';
+$PHPMAILER_LANG['recipients_failed']    = 'Eraro de servilo SMTP : la jenaj poŝtrecivuloj kaŭzis eraron: ';
+$PHPMAILER_LANG['signing']              = 'Eraro de subskribo: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP konektado malsukcesis.';
+$PHPMAILER_LANG['smtp_error']           = 'Eraro de servilo SMTP : ';
+$PHPMAILER_LANG['variable_set']         = 'Variablo ne pravalorizeblas aŭ ne repravalorizeblas: ';

--- a/language/phpmailer.lang-fr.php
+++ b/language/phpmailer.lang-fr.php
@@ -4,21 +4,21 @@
 * French Version
 */
 
-$PHPMAILER_LANG['authenticate']         = 'Erreur SMTP : Echec de l\'authentification.';
-$PHPMAILER_LANG['connect_host']         = 'Erreur SMTP : Impossible de se connecter au serveur SMTP.';
-$PHPMAILER_LANG['data_not_accepted']    = 'Erreur SMTP : Données incorrectes.';
+$PHPMAILER_LANG['authenticate']         = 'Erreur SMTP : échec de l\'authentification.';
+$PHPMAILER_LANG['connect_host']         = 'Erreur SMTP : impossible de se connecter au serveur SMTP.';
+$PHPMAILER_LANG['data_not_accepted']    = 'Erreur SMTP : données incorrectes.';
 $PHPMAILER_LANG['empty_message']        = 'Corps de message vide';
-$PHPMAILER_LANG['encoding']             = 'Encodage inconnu : ';
-$PHPMAILER_LANG['execute']              = 'Impossible de lancer l\'exécution : ';
-$PHPMAILER_LANG['file_access']          = 'Impossible d\'accéder au fichier : ';
-$PHPMAILER_LANG['file_open']            = 'Erreur Fichier : ouverture impossible : ';
-$PHPMAILER_LANG['from_failed']          = 'L\'adresse d\'expéditeur suivante a échouée : ';
+$PHPMAILER_LANG['encoding']             = 'Encodage inconnu : ';
+$PHPMAILER_LANG['execute']              = 'Impossible de lancer l\'exécution : ';
+$PHPMAILER_LANG['file_access']          = 'Impossible d\'accéder au fichier : ';
+$PHPMAILER_LANG['file_open']            = 'Erreur de fichier : ouverture impossible : ';
+$PHPMAILER_LANG['from_failed']          = 'L\'adresse d\'expéditeur suivante a échouée : ';
 $PHPMAILER_LANG['instantiate']          = 'Impossible d\'instancier la fonction mail.';
-$PHPMAILER_LANG['invalid_address']        = 'L\'adresse courriel n\'est pas valide: ';
+$PHPMAILER_LANG['invalid_address']      = 'L\'adresse courriel n\'est pas valide : ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' client de messagerie non supporté.';
 $PHPMAILER_LANG['provide_address']      = 'Vous devez fournir au moins une adresse de destinataire.';
-$PHPMAILER_LANG['recipients_failed']    = 'Erreur SMTP : Les destinataires suivants sont en erreur : ';
-$PHPMAILER_LANG['signing']              = 'Erreur de signature : ';
+$PHPMAILER_LANG['recipients_failed']    = 'Erreur SMTP : les destinataires suivants sont en erreur : ';
+$PHPMAILER_LANG['signing']              = 'Erreur de signature : ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'Échec de la connexion SMTP.';
-$PHPMAILER_LANG['smtp_error']           = 'Erreur du serveur SMTP: ';
-$PHPMAILER_LANG['variable_set']         = 'Ne peut initialiser ou réinitialiser une variable : ';
+$PHPMAILER_LANG['smtp_error']           = 'Erreur du serveur SMTP : ';
+$PHPMAILER_LANG['variable_set']         = 'Ne peut initialiser ou réinitialiser une variable : ';


### PR DESCRIPTION
Hi Marcus, Salut Marcus,

I'm using PHPMailer for years, and just discovered that error messages can be translated (previously I used a module using PHPMailer).

I added the Esperanto translation, corrected typography (unbreakable spaces) and found that $PHPMAILER_LANG['authenticate'] is not used.

Best regards

Merci pour cette très utile bibliothèque !

Olivier
