### PR TITLE
Fix good reply from the server for CRAM-MD5

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -444,7 +444,7 @@ class SMTP {
         $rply = $this->get_lines();
         $code = substr($rply, 0, 3);
 
-        if($code != 334) {
+        if($code != 235) {
           $this->error =
             array('error' => 'Credentials not accepted from server',
                   'smtp_code' => $code,


### PR DESCRIPTION
A good reply from the server is 235, not 334 here.

Please, see RFC2554, section 4, the AUTH command, page 2.
