### PR TITLE
html2text non-advanced mode ignore case

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2526,7 +2526,7 @@ class PHPMailer {
       $h = new html2text($html);
       return $h->get_text();
     }
-    return html_entity_decode(trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/s', '', $html))), ENT_QUOTES, $this->CharSet);
+    return html_entity_decode(trim(strip_tags(preg_replace('/<(head|title|style|script)[^>]*>.*?<\/\\1>/si', '', $html))), ENT_QUOTES, $this->CharSet);
   }
 
   /**


### PR DESCRIPTION
make html2text non-advanced mode to ignore case of head, title, style script tags. just in case!
