### PR TITLE
Fixed typo in DKIM_Add function.

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2888,7 +2888,7 @@ class PHPMailer {
         $current = 'to_header';
       } else {
         if($current && strpos($header, ' =?') === 0){
-          $$current .= $header;
+          $current .= $header;
         } else {
           $current = '';
         }


### PR DESCRIPTION
Fixed typo in DKIM_Add function.

Came across a double-dollar sign where there shouldn't be one, interfered with DKIM signing.
