### PR TITLE
Added a function, GetLastMessageID, for accessing the last message ID

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -469,6 +469,11 @@ class PHPMailer {
    */
   protected   $CustomHeader   = array();
   /**
+   * @var string The most recent Message-ID (including angular brackets)
+   * @access protected
+   */
+  protected   $lastMessageID   = '';
+  /**
    * @var string The message's MIME type
    * @access protected
    */
@@ -755,6 +760,17 @@ class PHPMailer {
       }
     }
     return true;
+  }
+
+  /**
+   * Return the Message-ID header of the last email.
+   * Technically this is the value from the last time the headers were created,
+   * but it also the message ID of the last sent message except in
+   * pathological cases.
+   * @return string
+   */
+  public function GetLastMessageID() {
+    return $this->lastMessageID;
   }
 
   /**
@@ -1461,10 +1477,11 @@ class PHPMailer {
     }
 
     if($this->MessageID != '') {
-      $result .= $this->HeaderLine('Message-ID', $this->MessageID);
+      $this->lastMessageID = $this->MessageID;
     } else {
-      $result .= sprintf("Message-ID: <%s@%s>%s", $uniq_id, $this->ServerHostname(), $this->LE);
+      $this->lastMessageID = sprintf("<%s@%s>", $uniq_id, $this->ServerHostname());
     }
+    $result .= $this->HeaderLine('Message-ID', $this->lastMessageID);
     $result .= $this->HeaderLine('X-Priority', $this->Priority);
     if ($this->XMailer == '') {
         $result .= $this->HeaderLine('X-Mailer', 'PHPMailer '.$this->Version.' (https://github.com/PHPMailer/PHPMailer/)');


### PR DESCRIPTION
Added a function, GetLastMessageID, for accessing the last message ID.  It returns whatever message ID was used when the headers were last created, which is also the message ID of the last sent message except in failure cases.  If the client sends multiple messages using the same PHPMailer object, the value returned by GetLastMessageID() will be updated each time.  In issue #57, it was pointed out that a client wanting the message ID could just explicitly set the message ID via $this->MessageID, but that would require the client to understand how to create a good message ID.
