### PR TITLE
Allow implementation of additional sending mechanisms by setting Mailer ...

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1021,7 +1021,12 @@ class PHPMailer
                 case 'mail':
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
                 default:
-                    return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
+                    if (method_exists($this,$this->Mailer.'Send')) {
+                      $sendMethod = $this->Mailer.'Send';
+                      return $this->$sendMethod($this->MIMEHeader, $this->MIMEBody);
+                    } else {
+                      return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
+                    }
             }
         } catch (phpmailerException $e) {
             $this->setError($e->getMessage());


### PR DESCRIPTION
This change allows implementing additional send methods. Eg you set "$ph->Mailer" to be "mymailer" and then you implement the method "mymailerSend". This of course in a derived class.

I'd like to use it to implement AmazonSES, which I did in https://github.com/michield/phplist/blob/master/public_html/lists/admin/class.phplistmailer.php but this change allows for a much cleaner way of extending phpMailer.
