### PR TITLE
fix parse error under php 5.2.17

### DIFF
--- a/test/phpmailerTest.php
+++ b/test/phpmailerTest.php
@@ -743,7 +743,7 @@ class PHPMailerTest extends PHPUnit_Framework_TestCase
         $this->Mail->isHTML(true);
         $this->Mail->Subject .= ": HTML only";
 
-        $this->Mail->Body = <<<'EOT'
+        $this->Mail->Body = <<<EOT
 <html>
     <head>
         <title>HTML email test</title>


### PR DESCRIPTION
```
$ php -l test/phpmailerTest.php
PHP Parse error:  syntax error, unexpected T_SL in
test/phpmailerTest.php on line 746
Errors parsing test/phpmailerTest.php
```
