### PR TITLE
accept a larger variety of email address formats (more than just bare!)

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -757,6 +757,10 @@ class PHPMailer
      */
     protected function addAnAddress($kind, $address, $name = '')
     {
+        if (count($parts=preg_split('/[<[]/',$address))==2){ // handle 'fancy' address
+           $address=trim(substr($parts[1],0,-1),']>');
+           $name=trim($parts[0]);
+        }
         if (!preg_match('/^(to|cc|bcc|Reply-To)$/', $kind)) {
             $this->setError($this->lang('Invalid recipient array') . ': ' . $kind);
             if ($this->exceptions) {
@@ -800,6 +804,10 @@ class PHPMailer
      */
     public function setFrom($address, $name = '', $auto = true)
     {
+        if (count($parts=preg_split('/[<[]/',$address))==2){ // handle 'fancy' address
+           $address=trim(substr($parts[1],0,-1),']>');
+           $name=trim($parts[0]);
+        }
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         if (!$this->validateAddress($address)) {


### PR DESCRIPTION
These changes allow you to for example:

$mail->setFrom('"This is" (RFC-Compliant) [user@email.net]');

I've been manually making this change for the last 5 years!  Now that it's on GitHub, I figured I'd share my reduced frustration with others!  ;-)
