### PR TITLE
emptyGroupName, setEmptyGroupName implementation to allow override of "u...

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3092,7 +3092,7 @@ class PHPMailer
      *      $mailer->setEmptyGroupName('FakeToHeader');
      *
      * @access public
-     * @param string $name
+     * @param string $EmptyGroupName
      * @return bool
      */
     public function setEmptyGroupName($EmptyGroupName)


### PR DESCRIPTION
emptyGroupName, setEmptyGroupName implementation to allow override of "undisclosed-recipients:;" when the To field would be empty.

This PR was the original one: https://github.com/PHPMailer/PHPMailer/pull/151

(I though it is cleaner to create a new patch/branch/pr.)
