### PR TITLE
Add Extra certificates for S/MIME so to include root CA, etc

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -517,6 +517,13 @@ class PHPMailer
     protected $sign_cert_file = '';
 
     /**
+     * The S/MIME extra certificate file path.
+     * @type string
+     * @access protected
+     */
+    protected $sign_extra_cert_file = '';
+
+    /**
      * The S/MIME key file path.
      * @type string
      * @access protected
@@ -1874,12 +1881,15 @@ class PHPMailer
                 $file = tempnam(sys_get_temp_dir(), 'mail');
                 file_put_contents($file, $body); //TODO check this worked
                 $signed = tempnam(sys_get_temp_dir(), 'signed');
+                if ( !isset($sign_extra_cert_file)) {
+                    $sign_extra_cert_file = '';
+                }
                 if (@openssl_pkcs7_sign(
                     $file,
                     $signed,
                     'file://' . realpath($this->sign_cert_file),
                     array('file://' . realpath($this->sign_key_file), $this->sign_key_pass),
-                    null
+                    array(), PKCS7_DETACHED, $sign_extra_cert_file
                 )
                 ) {
                     @unlink($file);
@@ -3097,17 +3107,19 @@ class PHPMailer
 
 
     /**
-     * Set the public and private key files and password for S/MIME signing.
+     * Set the public and private key files and password and/or extra certificates for S/MIME signing.
      * @access public
      * @param string $cert_filename
      * @param string $key_filename
      * @param string $key_pass Password for private key
+     * @param string $extra_cert_filename
      */
-    public function sign($cert_filename, $key_filename, $key_pass)
+    public function sign($cert_filename, $key_filename, $key_pass, $extra_cert_filename)
     {
         $this->sign_cert_file = $cert_filename;
         $this->sign_key_file = $key_filename;
         $this->sign_key_pass = $key_pass;
+        $this->sign_extra_cert_file = $extra_cert_filename;
     }
 
     /**


### PR DESCRIPTION
Adding extra certificates so that S/MIME items can verify in Mail Clients without having to first add root CA, makes signed mail work better.