### PR TITLE
fix mail validation when user sets multiple address at the same time

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -763,13 +763,16 @@ class PHPMailer
         }
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
-        if (!$this->validateAddress($address)) {
-            $this->setError($this->lang('invalid_address') . ': ' . $address);
-            $this->edebug($this->lang('invalid_address') . ': ' . $address);
-            if ($this->exceptions) {
-                throw new phpmailerException($this->lang('invalid_address') . ': ' . $address);
+        $address_array = explode(',', $address);
+        foreach ($address_array as $val) {
+            if (!$this->validateAddress(trim($val))) {
+                $this->setError($this->lang('invalid_address') . ': ' . $address);
+                $this->edebug($this->lang('invalid_address') . ': ' . $address);
+                if ($this->exceptions) {
+                    throw new phpmailerException($this->lang('invalid_address') . ': ' . $address);
+                }
+                return false;
             }
-            return false;
         }
         if ($kind != 'Reply-To') {
             if (!isset($this->all_recipients[strtolower($address)])) {


### PR DESCRIPTION
Hello,

I got a problem when I want to set multiple email addresses at the same time, I use $mail->AddAddress or $mail->AddBCC like this:

```
$mail->AddAddress('abc@example.com, def@example.com, ghi@example.com');
```

and I will always got an error message:

> you must provide at least one recipient email address

I traced to code and I found that was caused by the mail address validation, It won't pass the validate, and I think it does make no sense, I use this format in many mail client, in fact, if I add addresses bypass the validation, it works very well, that means the problem was the validation but nothing, even the note in **changelog.md, line 319, 'A note on sending bulk emails'** told us this can send faster and save the resource, so ...  I thought it is a bug and I did a patch here, separate the address(es) by comma, and validate each of them, if any of them failed on the validation, the validation is invalid, and I can add addresses in this format now!

So please merge this commit to fix this problem, thanks!

Regards,
Peter.
