### PR TITLE
Update class.phpmailer.php

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2730,8 +2730,10 @@ class PHPMailer
             $result = $this->Hostname;
         } elseif (isset($_SERVER) and array_key_exists('SERVER_NAME', $_SERVER) and !empty($_SERVER['SERVER_NAME'])) {
             $result = $_SERVER['SERVER_NAME'];
-        } elseif (gethostname() !== false) {
+        } elseif (function_exists("gethostname") && gethostname() !== false) {
             $result = gethostname();
+        }elseif (php_uname("n") !== false){
+            $result = php_uname("n");
         }
         return $result;
     }


### PR DESCRIPTION
Function "gethostname" unavailable before PHP 5.3, if function is not defined, use of php_uname('n').
