### PR TITLE
Better language path location

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1379,7 +1379,11 @@ class PHPMailer
         );
         //Load the language path from absolute position
         if(!$lang_path) {
-            $lang_path = __DIR__ . '/language/';
+            if (version_compare(PHP_VERSION, '5.3.0', 'lt')) {
+                $lang_path = dirname(__FILE__) . DIRECTORY_SEPARATOR . 'language' . DIRECTORY_SEPARATOR;
+            } else {
+                $lang_path = __DIR__ . DIRECTORY_SEPARATOR . 'language' . DIRECTORY_SEPARATOR;
+            }
         }
         //Overwrite language-specific strings.
         //This way we'll never have missing translations - no more "language string failed to load"!


### PR DESCRIPTION
Some frameworks, like Zend Framework 2, uses `chdir(__DIR__)` to make everything relative to the application root.

This fix is to improve and reduce the need to rewrite the folders path on the application.
