### PR TITLE
RFC 5321 - Flag to disable Return-Path header

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -101,12 +101,6 @@ class PHPMailer
     public $ReturnPath = '';
     
     /**
-     * If Return-Path header should be disabled.
-     * If strict compliance to RFC 5321 should be met.
-     * @type boolean
-     */
-    public $DisableReturnPath = false;
-    /**
      * The Subject of the message.
      * @type string
      */
@@ -1620,17 +1614,6 @@ class PHPMailer
             $result .= $this->headerLine('Date', self::rfcDate());
         } else {
             $result .= $this->headerLine('Date', $this->MessageDate);
-        }
-        
-        //rfc 5321 - only final delivery should include Return-Path
-        if(!$this->DisableReturnPath){
-            if ($this->ReturnPath) {
-                $result .= $this->headerLine('Return-Path', '<' . trim($this->ReturnPath) . '>');
-            } elseif ($this->Sender == '') {
-                $result .= $this->headerLine('Return-Path', '<' . trim($this->From) . '>');
-            } else {
-                $result .= $this->headerLine('Return-Path', '<' . trim($this->Sender) . '>');
-            }
         }
 
         // To be created automatically by mail()


### PR DESCRIPTION
Per RFC 5321 the return path header should only be included in the message when sent by final delivery client/server, which is very unlikely to be PHPMailer.  Thus a flag was added that will disable the Return-Path header, while leaving the default to send it as always, thus maintaining backwards compatibility.

Some modern SMTP servers may reject messages containing the Return-Path header, such as Haraka.

Resources:
https://tools.ietf.org/html/rfc5321
http://postmastery.net/2013/05/13/about-the-return-path-header/
http://haraka.github.io/
