### PR TITLE
Update class.phpmailer.php

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1636,10 +1636,10 @@ class PHPMailer
         $this->boundary[3] = 'b3_' . $uniq_id;
 
         if ($this->MessageDate == '') {
-            $result .= $this->headerLine('Date', self::rfcDate());
-        } else {
-            $result .= $this->headerLine('Date', $this->MessageDate);
+            $this->MessageDate = self::rfcDate();
         }
+        $result .= $this->headerLine('Date', $this->MessageDate);
+
 
         // To be created automatically by mail()
         if ($this->SingleTo === true) {


### PR DESCRIPTION
If MessageDate was not explicitly set before composing message, we get empty value if we need to retrieve message date later (i.e. for debug or log purposes).
