### PR TITLE
Remove unreachable code from the constructor

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -567,9 +567,6 @@ class PHPMailer
      */
     public function __construct($exceptions = false)
     {
-        if (version_compare(PHP_VERSION, '5.0.0', '<')) {
-            exit("Sorry, PHPMailer will only run on PHP version 5 or greater!\n");
-        }
         $this->exceptions = ($exceptions == true);
         //Make sure our autoloader is loaded
         if (version_compare(PHP_VERSION, '5.1.2', '>=')) {


### PR DESCRIPTION
The PHP5-only termination message in `PHPMailer::__construct()` is never fired. PHP4 doesn't support PHP5 constructor methods and thus the condition is never reached to evaluate true.
