### PR TITLE
Set default charset to UTF-8

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -44,7 +44,7 @@ class PHPMailer
      * The character set of the message.
      * @type string
      */
-    public $CharSet = 'iso-8859-1';
+    public $CharSet = 'utf-8';
 
     /**
      * The MIME Content-type of the message.


### PR DESCRIPTION
Set default charset to UTF-8.
When charset=iso-8859-1 does not work for example Slovak diacritics.
