### PR TITLE
Add indent for multiline server replies

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -167,7 +167,9 @@ class SMTP
                 break;
             case 'echo':
             default:
-                echo gmdate('Y-m-d H:i:s')."\t".trim($str)."\n";
+                echo gmdate('Y-m-d H:i:s') . "\t" . str_replace(
+                    "\r\n", "\r\n                   \t                  ", trim($str)
+                )."\n";
         }
     }
 


### PR DESCRIPTION
Add indent for multiline server replies when printing debug log to console.
