### PR TITLE
SMTP::getLastReply() should be populated with last server reply…

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -712,7 +712,7 @@ class SMTP
         }
 
         if (!in_array($code, (array)$expect)) {
-            $this->last_reply = null;
+            $this->last_reply = $reply;
             $this->error = array(
                 'error' => "$command command failed",
                 'smtp_code' => $code,


### PR DESCRIPTION
…no matter what it was…

The SMTP::getLastReply() result is not populated in case of server error.
Truth be said, it should, for consistency's sake at the very least.
But real reason is that writing something like 

```
  if(!$inst->data($_message))
    throw new Exception('DATA command unsuccessful. Last server reply: ' . $inst->getLastReply());
```

is an order of magnitude cleaner, than a tantric dance with array values (you have to turn SMTP::getError() method call into variable somewhere first, too!)…

One day, someone have to turn all this into proper exceptions…
