### PR TITLE
Remove "hacked" from "hacked by Lance Rushing"

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -441,7 +441,7 @@ class SMTP
         // RFC 2104 HMAC implementation for php.
         // Creates an md5 HMAC.
         // Eliminates the need to install mhash to compute a HMAC
-        // Hacked by Lance Rushing
+        // by Lance Rushing
 
         $bytelen = 64; // byte length for md5
         if (strlen($key) > $bytelen) {


### PR DESCRIPTION
Remove "hacked" from "hacked by Lance Rushing", because it is a false positive for some malware scanner who check for the string "hacked by".
See also: https://core.trac.wordpress.org/ticket/27946
