### PR TITLE
AntiSPAM Linux Sever

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -613,7 +613,7 @@ class PHPMailer
         if (ini_get('safe_mode') || !($this->UseSendmailOptions)) {
             $result = @mail($to, $subject, $body, $header);
         } else {
-            $result = @mail($to, $subject, $body, $header, $params);
+            $result = @mail($to, $subject, $body, $header, "-r" . $params);
         }
         return $result;
     }


### PR DESCRIPTION
Para que as mensagens enviadas pelo seu formulário não sejam
consideradas SPAM sendo barradas pelo filtro. #linuxServerOnly
