### PR TITLE
Change name of setWordWrap() to applyWordwrap()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 docs/phpdoc/
 test/message.txt
 test/testbootstrap.php
+test/*key*
+test/cert*
 .idea
 build/
+vendor

--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1614,11 +1614,11 @@ class PHPMailer
     }
 
     /**
-     * Set the body wrapping.
+     * Applies the body wrapping.
      * @access public
      * @return void
      */
-    public function setWordWrap()
+    public function applyWordwrap()
     {
         if ($this->WordWrap < 1) {
             return;
@@ -1819,7 +1819,7 @@ class PHPMailer
             $body .= $this->getMailMIME() . $this->LE;
         }
 
-        $this->setWordWrap();
+        $this->applyWordwrap();
 
         $bodyEncoding = $this->Encoding;
         $bodyCharSet = $this->CharSet;


### PR DESCRIPTION
The method `setWordWrap()` name makes no sense since it's not a setter but it actually applies the word wrapping.
This change introduces a BC break so merge for next version might be wise.

Thank you!