### PR TITLE
`smtp_msg` was changed to `detail` in 5.2.7

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2820,8 +2820,8 @@ class PHPMailer
         $this->error_count++;
         if ($this->Mailer == 'smtp' and !is_null($this->smtp)) {
             $lasterror = $this->smtp->getError();
-            if (!empty($lasterror) and array_key_exists('smtp_msg', $lasterror)) {
-                $msg .= '<p>' . $this->lang('smtp_error') . $lasterror['smtp_msg'] . "</p>\n";
+            if (!empty($lasterror) and array_key_exists('detail', $lasterror)) {
+                $msg .= '<p>' . $this->lang('smtp_error') . $lasterror['detail'] . "</p>\n";
             }
         }
         $this->ErrorInfo = $msg;


### PR DESCRIPTION
When reading through the code, I just happened to notice that the contents of `$lasterror` were never going to end up in the message of the error being set.