### PR TITLE
Fix concatenation of headers for Dkim

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3411,8 +3411,8 @@ class PHPMailer
                 $to_header = $header;
                 $current = 'to_header';
             } else {
-                if ($current && strpos($header, ' =?') === 0) {
-                    $current .= $header;
+                if ($$current && strpos($header, ' =?') === 0) {
+                    $$current .= $header;
                 } else {
                     $current = '';
                 }

--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3411,7 +3411,7 @@ class PHPMailer
                 $to_header = $header;
                 $current = 'to_header';
             } else {
-                if ($$current && strpos($header, ' =?') === 0) {
+                if (!empty($$current) && strpos($header, ' =?') === 0) {
                     $$current .= $header;
                 } else {
                     $current = '';


### PR DESCRIPTION
Fix concatenation of headers for Dkim

If you have long headers like this
=?utf-8?B?QW5pbWUgTGluZSBHcm91cCAtINCh0YPQv9C10YDQvNCw0YDQutC10YIg0JA=?=
 =?utf-8?B?0L3QuNC80LU=?= <xxx@xxx.com>

Original code does not correct concatenate header