### PR TITLE
Add custom header getter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # ChangeLog
 
+* Add custom header getter
 * Use `application/javascript` for .js attachments
 * Improve RFC2821 compliance for timelimits, especially for end-of-data
 * Add Azerbaijani translations (Thanks to @mirjalal)

--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2953,6 +2953,16 @@ class PHPMailer
     }
 
     /**
+     * Returns all custom headers
+     *
+     * @return array
+     */
+    public function getCustomHeaders()
+    {
+        return $this->CustomHeader;
+    }
+
+    /**
      * Create a message from an HTML string.
      * Automatically makes modifications for inline images and backgrounds
      * and creates a plain-text version by converting the HTML.

--- a/test/phpmailerTest.php
+++ b/test/phpmailerTest.php
@@ -1680,6 +1680,33 @@ EOT;
             'SMTP connect with options failed'
         );
     }
+
+    /**
+     * Tests the Custom header getter
+     */
+    public function testCustomHeaderGetter()
+    {
+        $this->Mail->addCustomHeader('foo', 'bar');
+        $this->assertEquals(array(array('foo', 'bar')), $this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('foo', 'baz');
+        $this->assertEquals(array(
+            array('foo', 'bar'),
+            array('foo', 'baz')
+        ), $this->Mail->getCustomHeaders());
+
+        $this->Mail->clearCustomHeaders();
+        $this->assertEmpty($this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('yux');
+        $this->assertEquals(array(array('yux')), $this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('Content-Type: application/json');
+        $this->assertEquals(array(
+            array('yux'),
+            array('Content-Type', ' application/json')
+        ), $this->Mail->getCustomHeaders());
+    }
 }
 
 /**


### PR DESCRIPTION
Hello,

I couldn't believe PHPMailer is able to add and clear header but not able to get them. Let's say I added a wrong header, I'm not sure I want to restart all from scratch.

It would be nice to have this merged into next minor version.

Thank you :)