### PR TITLE
Improved Traditional Chinese PHPMailer language

### DIFF
--- a/language/phpmailer.lang-zh.php
+++ b/language/phpmailer.lang-zh.php
@@ -4,6 +4,7 @@
  * @package PHPMailer
  * @author liqwei <liqwei@liqwei.com>
  * @author Peter Dave Hello <@PeterDaveHello/>
+ * @author Jason Chiang <xcojad@gmail.com>
  */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP 錯誤：登入失敗。';
@@ -11,17 +12,17 @@ $PHPMAILER_LANG['connect_host']         = 'SMTP 錯誤：無法連線到 SMTP �
 $PHPMAILER_LANG['data_not_accepted']    = 'SMTP 錯誤：無法接受的資料。';
 $PHPMAILER_LANG['empty_message']        = '郵件內容為空';
 $PHPMAILER_LANG['encoding']             = '未知編碼: ';
+$PHPMAILER_LANG['execute']              = '無法執行：';
 $PHPMAILER_LANG['file_access']          = '無法存取檔案：';
 $PHPMAILER_LANG['file_open']            = '檔案錯誤：無法開啟檔案：';
 $PHPMAILER_LANG['from_failed']          = '發送地址錯誤：';
-$PHPMAILER_LANG['execute']              = '無法執行：';
 $PHPMAILER_LANG['instantiate']          = '未知函數呼叫。';
 $PHPMAILER_LANG['invalid_address']      = '因為電子郵件地址無效，無法傳送: ';
-$PHPMAILER_LANG['provide_address']      = '必須提供至少一個收件人地址。';
 $PHPMAILER_LANG['mailer_not_supported'] = '不支援的發信客戶端。';
-$PHPMAILER_LANG['recipients_failed']    = 'SMTP 錯誤：收件人地址錯誤：';
-$PHPMAILER_LANG['signing']              = '登入失敗: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP連線失敗';
-$PHPMAILER_LANG['smtp_error']           = 'SMTP伺服器錯誤: ';
+$PHPMAILER_LANG['provide_address']      = '必須提供至少一個收件人地址。';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP 錯誤：以下收件人地址錯誤：';
+$PHPMAILER_LANG['signing']              = '電子簽章錯誤: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 連線失敗';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP 伺服器錯誤: ';
 $PHPMAILER_LANG['variable_set']         = '無法設定或重設變數: ';
-//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+$PHPMAILER_LANG['extension_missing']    = '遺失模組 Extension: ';


### PR DESCRIPTION
1. Completed new language key $PHPMAILER_LANG['extension_missing']. 
2. fix translation error of $PHPMAILER_LANG['signing'] with correct meaning in Traditional Chinese 
3. Re-order the translation keys to make it the same with default english locale.