### PR TITLE
do not auto-replace inline images in body that are already replaced

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3108,7 +3108,7 @@ class PHPMailer
                             $message
                         );
                     }
-                } elseif (!preg_match('#^[A-z]+://#', $url) && substr($url, 0, 4) !== 'cid') {
+                } elseif (substr($url, 0, 4) !== 'cid:' && !preg_match('#^[A-z]+://#', $url)) {
                     // Do not change urls for absolute images (thanks to corvuscorax)
 					// Do not change urls that are already inline images
                     $filename = basename($url);

--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3108,8 +3108,9 @@ class PHPMailer
                             $message
                         );
                     }
-                } elseif (!preg_match('#^[A-z]+://#', $url)) {
+                } elseif (!preg_match('#^[A-z]+://#', $url) && !preg_match('#^cid:#', $url)) {
                     // Do not change urls for absolute images (thanks to corvuscorax)
+					// Do not change urls that are already inline images
                     $filename = basename($url);
                     $directory = dirname($url);
                     if ($directory == '.') {

--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3108,7 +3108,7 @@ class PHPMailer
                             $message
                         );
                     }
-                } elseif (!preg_match('#^[A-z]+://#', $url) && !preg_match('#^cid:#', $url)) {
+                } elseif (!preg_match('#^[A-z]+://#', $url) && substr($url, 0, 4) !== 'cid') {
                     // Do not change urls for absolute images (thanks to corvuscorax)
 					// Do not change urls that are already inline images
                     $filename = basename($url);


### PR DESCRIPTION
I ran across a problem where images in the body that are already in 'cid:name' format generate warnings because PHPMailer still attempts to auto-convert them to 'cid:name' format (and fails, because the file does not exist). Is this a useful fix to merge?