### PR TITLE
Update gmail.phps

### DIFF
--- a/examples/gmail.phps
+++ b/examples/gmail.phps
@@ -26,6 +26,9 @@ $mail->Debugoutput = 'html';
 
 //Set the hostname of the mail server
 $mail->Host = 'smtp.gmail.com';
+// use
+// $mail->Host = gethostbyname('smtp.gmail.com');
+// if your network does not support SMTP over IPv6
 
 //Set the SMTP port number - 587 for authenticated TLS, a.k.a. RFC4409 SMTP submission
 $mail->Port = 587;


### PR DESCRIPTION
The internet is littered with people trying to figure out why PHPMailer doesn't work for them with GMail.  ISPs like Digital Ocean do not support SMTP traffic over IPv6, but Google is IPv6 ready so PHPMailer waits a long time trying that before it tries IPv4.  That wait is either a major bottleneck, or a failure point as execution timeouts come into play.
See https://www.digitalocean.com/community/questions/outgoing-connections-on-port-25-587-143-blocked-over-ipv6
and
https://stackoverflow.com/questions/20068484/phpmailer-using-gmail-smtp-slow-when-sending-emails for example