### PR TITLE
Do no require a dependency that is not required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "phpunit/phpunit": "4.3.*"
     },
     "suggest": {
-        "league/oauth2-client": "0.10.*",
-        "guzzle/guzzle": "~3.7"
+        "league/oauth2-client": "Needed for Gmail's XOAUTH2 authentication system"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,15 @@
         }
     ],
     "require": {
-        "php": ">=5.0.0",
-        "league/oauth2-client": "0.10.*",
-        "guzzle/guzzle": "~3.7"
+        "php": ">=5.0.0"
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "*",
         "phpunit/phpunit": "4.3.*"
+    },
+    "suggest": {
+        "league/oauth2-client": "0.10.*",
+        "guzzle/guzzle": "~3.7"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
First of all, do not require dependencies that are not required for PHPMailer to work. It works perfectly without. Secondly, the majority of the users will not use Gmail's XOAUTH2 authentication system and do not need these additional dependencies. Thirdly, guzzle and league packages are used a lot. Therefore you make it hard for people that were already using these packages to upgrade to newer versions of PHPMailer. No offence, good work on the feature, but this should be considered.