### PR TITLE
Accept email addresses with an UTF-8 domain

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -840,6 +840,14 @@ class PHPMailer
             }
             return false;
         }
+        if (function_exists('idn_to_ascii') && $this->hasMultiBytes($address)) { ##@TODO: Write our own "idn_to_ascii" function for PHP 5.2 and earlier.
+            // can't use $this->parseAddresses, because it calls validateAddress, which will fail here
+            $elements = explode('@',strrev($address),2);
+            if (!empty($elements[0]) && !empty($elements[1])) {
+                $address = strrev($elements[1]).'@'.idn_to_ascii(strrev($elements[0]));
+            }
+            unset($elements);
+        }
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         if (!$this->validateAddress($address)) {


### PR DESCRIPTION
When using a UTF8 address it is rejected with "You must provide at least one recipient email address".

This patch will accept UTF8 addresses. You can try this with eg "phplist@phplíst.com"

It requires [idn_to_ascii](http://php.net/idn_to_ascii) to work which is PHP5.3 and up

It will still require the MTA to handle UTF8 addresses, which Postfix 3.0 does. But at least PHPMailer won't stop it.