### PR TITLE
Solving problems sending mail using SMTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ $mail = new PHPMailer;
 
 //$mail->SMTPDebug = 3;                               // Enable verbose debug output
 
+// $mail->isMail();											  // If isSMTP(); return error, use isMail();
+
 $mail->isSMTP();                                      // Set mailer to use SMTP
 $mail->Host = 'smtp1.example.com;smtp2.example.com';  // Specify main and backup SMTP servers
 $mail->SMTPAuth = true;                               // Enable SMTP authentication

--- a/examples/gmail.phps
+++ b/examples/gmail.phps
@@ -13,7 +13,12 @@ require '../PHPMailerAutoload.php';
 $mail = new PHPMailer;
 
 //Tell PHPMailer to use SMTP
-$mail->isSMTP();
+// $mail->isSMTP();
+
+$mail->isMail();
+
+// If isSMTP(); return error
+// set isMail(); and change the port address to 465
 
 //Enable SMTP debugging
 // 0 = off (for production use)
@@ -31,7 +36,9 @@ $mail->Host = 'smtp.gmail.com';
 // if your network does not support SMTP over IPv6
 
 //Set the SMTP port number - 587 for authenticated TLS, a.k.a. RFC4409 SMTP submission
-$mail->Port = 587;
+//$mail->Port = 587;
+
+$mail->Port = 465;
 
 //Set the encryption system to use - ssl (deprecated) or tls
 $mail->SMTPSecure = 'tls';


### PR DESCRIPTION
In order to solve Bug #525 and #149 using phpmailer lib, changed the line 16 in the file located in PHPMailer/examples/gmail.phps, corresponding to the SMTP server configuration pasting $mail->Ismail(); instead of $mail->isSMTP(); and it worked perfectly in my testing, both on localhost as in remote server.

 failures already discussed in issues #525 and #149.

  With this hope I can help other programmers have passed the problem.