### PR TITLE
Brackets in nameless recipient - $addBrackets flag

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -445,6 +445,13 @@ class PHPMailer
      * @var string
      */
     public $XMailer = '';
+	
+	/**
+     * Whether add angular brackets to nameless recipients
+     * to avoid SpamAssassin's "*NO_BRKTS*" rules
+     * @var boolean
+     */
+    public $addBrackets = false;
 
     /**
      * An instance of the SMTP sender class.
@@ -1730,6 +1737,7 @@ class PHPMailer
     public function addrFormat($addr)
     {
         if (empty($addr[1])) { // No name provided
+			if ($this->addBrackets) $addr[0] = '<'.$addr[0].'>';
             return $this->secureHeader($addr[0]);
         } else {
             return $this->encodeHeader($this->secureHeader($addr[1]), 'phrase') . ' <' . $this->secureHeader(


### PR DESCRIPTION
Even if bracketless recipients are RFC 5322 compliant, them activate
SpamAssassin "*NO_BRKTS*" rules.