### PR TITLE
Fix PHP <5.4 compatibility

### DIFF
--- a/class.phpmaileroauthgoogle.php
+++ b/class.phpmaileroauthgoogle.php
@@ -50,10 +50,10 @@ class PHPMailerOAuthGoogle
     }
 
     private function getProvider() {
-        return new League\OAuth2\Client\Provider\Google([
+        return new League\OAuth2\Client\Provider\Google(array(
             'clientId' => $this->oauthClientId,
             'clientSecret' => $this->oauthClientSecret
-        ]);
+        ));
     }
 
     private function getGrant()
@@ -65,7 +65,7 @@ class PHPMailerOAuthGoogle
     {
         $provider = $this->getProvider();
         $grant = $this->getGrant();
-        return $provider->getAccessToken($grant, ['refresh_token' => $this->oauthRefreshToken]);
+        return $provider->getAccessToken($grant, array('refresh_token' => $this->oauthRefreshToken));
     }
 
     public function getOauth64()


### PR DESCRIPTION
Replace short array syntax (`[...]`) with `array(...)` to restore
compatibility with PHP versions before 5.4.