### PR TITLE
Resolved Scope issues which resulted in GMail Auth failure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,7 @@
         "phpunit/phpunit": "4.7.*"
     },
     "suggest": {
-        "league/oauth2-client": "Needed for XOAUTH2 authentication",
-        "league/oauth2-google": "Needed for Gmail XOAUTH2"
+        "league/oauth2-client": "Needed for XOAUTH2 authentication"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
This is to solve issue #568 . 

As changes have been made to the OAuth Library for Google, the scope was set to default all times. This has been overridden now by writing a custom class into the _get_oauth_token.php_ file. Also changes have been made to _composer.json_.