### PR TITLE
Ability to not send to specific recipients using SMTP mailer

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -873,6 +873,10 @@ class PHPMailer
      */
     protected function addOrEnqueueAnAddress($kind, $address, $name, $send)
     {
+        if ( !$send && $this->Mailer != 'smtp') {
+            throw new phpmailerException('Non-send recipients only supported for SMTP Mailer');
+        }
+
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         if (($pos = strrpos($address, '@')) === false) {


### PR DESCRIPTION
This allows one to optionally designate certain recipients as "do-not-send-to-this-address" addresses while keeping the addresses in the mail headers. It only works with the SMTP mailer as far as I can tell--sendmail and mail do not allow this.

The use case is specialized but powerful--one can strip out 'internal' recipients if sending mail to recipients which are part of an internal system before passing to the MTA while keeping them in the headers. One can also send different versions of the message to different recipients, which is useful when it comes to supporting different or mixed encryption methods.
