### PR TITLE
Increase uniqueness of uniqueid

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2088,7 +2088,7 @@ class PHPMailer
     {
         $body = '';
         //Create unique IDs and preset boundaries
-        $this->uniqueid = md5(uniqid(time()));
+        $this->uniqueid = md5(time().mt_rand()); // md5(uniqid('', TRUE))
         $this->boundary[1] = 'b1_' . $this->uniqueid;
         $this->boundary[2] = 'b2_' . $this->uniqueid;
         $this->boundary[3] = 'b3_' . $this->uniqueid;


### PR DESCRIPTION
The uniqid() function does not always return truly unique id's, especially on Windows (try on Windows: `for ($i = 0; $i < 10; $i++) echo md5(uniqid(time()))."\n";`). Using uniqid(..., TRUE) for more entropy would improve the uniqueness but it is relatively slow. time().mt_rand() is faster and sufficiently unique