### PR TITLE
 Prevent invalid combinations of encryption algo and port

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1575,6 +1575,13 @@ class PHPMailer
             if ($tport > 0 and $tport < 65536) {
                 $port = $tport;
             }
+            //Check for invalid combination of encryption algorithm and port
+            if('tls'===$secure && 465 === $port){
+				throw new phpmailerException($this->lang('tls can\t be used with port 465 '), self::STOP_CRITICAL);
+			}
+			if('ssl'===$secure && 587 === $port){
+				throw new phpmailerException($this->lang('ssl can\'t be used with port 587'), self::STOP_CRITICAL);
+			}
             if ($this->smtp->connect($prefix . $host, $port, $this->Timeout, $options)) {
                 try {
                     if ($this->Helo) {


### PR DESCRIPTION
Added a check that prevents invalid combinations of encryption algorithm and port by throwing a critical exception.
