### PR TITLE
Xoauth

### DIFF
--- a/examples/gmail_xoauth.phps
+++ b/examples/gmail_xoauth.phps
@@ -81,10 +81,10 @@ $mail->setOAuth(new OAuthProvider\Base(
 
 //Set who the message is to be sent from
 //For gmail, this generally needs to be the same as the user you logged in as
-$mail->setFrom('sherryl4george@gmail.com', 'First Last');
+$mail->setFrom('someone@gmail.com', 'First Last');
 
 //Set who the message is to be sent to
-$mail->addAddress('gmathew016@gmail.com', 'John Doe');
+$mail->addAddress('someone@gmail.com', 'John Doe');
 
 //Set the subject line
 $mail->Subject = 'PHPMailer GMail SMTP test';

--- a/examples/gmail_xoauth.phps
+++ b/examples/gmail_xoauth.phps
@@ -1,8 +1,16 @@
 <?php
+
 /**
  * This example shows settings to use when sending via Google's Gmail servers.
  */
+
 namespace PHPMailer\PHPMailer;
+
+// Give alias to the League Provider Classes that may be used
+use League\OAuth2\Client\Provider\Google as Google;
+use Stevenmaguire\OAuth2\Client\Provider\Microsoft as Microsoft;
+use Hayageek\OAuth2\Client\Provider\Yahoo as Yahoo;
+
 
 //SMTP needs accurate times, and the PHP time zone MUST be set
 //This should be done in your php.ini, but this is how to do it if you don't have access to that
@@ -15,7 +23,7 @@ require '../vendor/autoload.php';
 require '../vendor/autoload.php';
 
 //Create a new PHPMailer instance
-$mail = new PHPMailerOAuth;
+$mail = new PHPMailer;
 
 //Tell PHPMailer to use SMTP
 $mail->isSMTP();
@@ -44,26 +52,39 @@ $mail->SMTPAuth = true;
 //Set AuthType
 $mail->AuthType = 'XOAUTH2';
 
-//User Email to use for SMTP authentication - Use the same Email used in Google Developer Console
-$mail->oauthUserEmail = "someone@gmail.com";
-
-//Obtained From Google Developer Console
-$mail->oauthClientId = "RANDOMCHARS-----duv1n2.apps.googleusercontent.com";
-
-//Obtained From Google Developer Console
-$mail->oauthClientSecret = "RANDOMCHARS-----lGyjPcRtvP";
+// Fill all necessary Authentication details here
+$email = 'someone@gmail.com';
+$clientId = 'RANDOMCHARS-----duv1n2.apps.googleusercontent.com';
+$clientSecret = 'RANDOMCHARS-----lGyjPcRtvP';
 
 //Obtained By running get_oauth_token.php after setting up APP in Google Developer Console.
 //Set Redirect URI in Developer Console as [https/http]://<yourdomain>/<folder>/get_oauth_token.php
 // eg: http://localhost/phpmail/get_oauth_token.php
-$mail->oauthRefreshToken = "RANDOMCHARS-----DWxgOvPT003r-yFUV49TQYag7_Aod7y0";
+$refreshToken = 'RANDOMCHARS-----DWxgOvPT003r-yFUV49TQYag7_Aod7y0';
+
+//Change the Class Name depending on the Provider Used
+if (!isset($provider)) {
+    $provider = new Google([
+        'clientId' => $clientId,
+        'clientSecret' => $clientSecret
+    ]);
+}
+
+$mail->setOAuth(new OAuthProvider\Base(
+        [
+    'provdier' => $provider,
+    'clientId' => $clientId,
+    'clientSecret' => $clientSecret,
+    'refreshToken' => $refreshToken,
+    'userName' => $email]
+));
 
 //Set who the message is to be sent from
 //For gmail, this generally needs to be the same as the user you logged in as
-$mail->setFrom('from@example.com', 'First Last');
+$mail->setFrom('sherryl4george@gmail.com', 'First Last');
 
 //Set who the message is to be sent to
-$mail->addAddress('whoto@example.com', 'John Doe');
+$mail->addAddress('gmathew016@gmail.com', 'John Doe');
 
 //Set the subject line
 $mail->Subject = 'PHPMailer GMail SMTP test';
@@ -77,6 +98,14 @@ $mail->AltBody = 'This is a plain-text message body';
 
 //Attach an image file
 $mail->addAttachment('images/phpmailer_mini.png');
+
+$mail->SMTPOptions = array(
+    'ssl' => array(
+        'verify_peer' => false,
+        'verify_peer_name' => false,
+        'allow_self_signed' => true
+    )
+);
 
 //send the message, check for errors
 if (!$mail->send()) {

--- a/src/OAuthProvider/Base.php
+++ b/src/OAuthProvider/Base.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * PHPMailer - PHP email creation and transport class.
  * PHP Version 5.4
@@ -19,25 +20,15 @@
 
 namespace PHPMailer\PHPMailer\OAuthProvider;
 
-use League\OAuth2\Client\Grant\RefreshToken;
-use League\OAuth2\Client\Provider\AbstractProvider;
-use League\OAuth2\Client\Token\AccessToken;
+class Base {
 
-/**
- * PHPMailer OAuthProvider Base class.
- * An abstract base class for service-provider-specific OAuth implementations.
- * Acts as a wrapper around the League OAuth2 classes.
- * @author Ravishanker Kusuma (hayageek@gmail.com)
- */
-abstract class Base
-{
     /**
-     * @var AbstractProvider
+     * @var League\OAuth2\Client\Provider\AbstractProvider
      */
     protected $provider = null;
 
     /**
-     * @var AccessToken
+     * @var League\OAuth2\Client\Token\AccessToken
      */
     protected $oauthToken = null;
 
@@ -60,83 +51,58 @@ abstract class Base
      * @var string
      */
     protected $refreshToken = '';
-    
+
     public function __construct(
-        $userEmail = '',
-        $clientSecret = '',
-        $clientId = '',
-        $refreshToken = ''
-    ) {
-        $this->oauthUserEmail = $userEmail;
-        $this->oauthClientSecret = $clientSecret;
-        $this->oauthClientId = $clientId;
-        $this->oauthRefreshToken = $refreshToken;
+    $options) {
+        $this->provider = $options['provdier'];
+        $this->oauthUserEmail = $options['userName'];
+        $this->oauthClientSecret = $options['clientSecret'];
+        $this->oauthClientId = $options['clientId'];
+        $this->oauthRefreshToken = $options['refreshToken'];
     }
 
     /**
-     * @return AbstractProvider
+     * @return League\OAuth2\Client\Provider\AbstractProvider
      */
-    abstract public function getProvider();
+//    abstract public function getProvider();
 
     /**
-     * Array of default options.
-     * @return array
+     * Returns the current value of the state parameter.
+     *
+     * This can be accessed by the redirect handler during authorization.
+     *
+     * @return string
      */
-    protected function getOptions()
-    {
-        return [];
+    public function getState() {
+        return $this->state;
     }
 
     /**
-     * @return RefreshToken
+     * @return \League\OAuth2\Client\Grant\RefreshToken
      */
-    protected function getGrant()
-    {
-        return new RefreshToken();
+    protected function getGrant() {
+        return new \League\OAuth2\Client\Grant\RefreshToken();
     }
 
     /**
-     * @return AccessToken
+     * @return League\OAuth2\Client\Token\AccessToken
      */
-    public function getToken()
-    {
-        return $this->getProvider()->getAccessToken(
-            $this->getGrant(),
-            ['refresh_token' => $this->oauthRefreshToken]
-        );
+    protected function getToken() {
+        $provider = $this->provider;
+        $grant = $this->getGrant();
+        return $provider->getAccessToken($grant, ['refresh_token' => $this->oauthRefreshToken]);
     }
 
     /**
      * Generate a base64-encoded OAuth token.
      * @return string
      */
-    public function getOauth64()
-    {
+    public function getOauth64() {
         // Get a new token if it's not available or has expired
         if (is_null($this->oauthToken) or $this->oauthToken->hasExpired()) {
             $this->oauthToken = $this->getToken();
         }
-        return base64_encode('user='.$this->oauthUserEmail."\001auth=Bearer ".$this->oauthToken."\001\001");
+        return base64_encode('user=' . $this->oauthUserEmail . "\001auth=Bearer " . $this->oauthToken . "\001\001");
     }
 
-    /**
-     * @param array $options
-     * @return string
-     */
-    public function getAuthorizationUrl($options = [])
-    {
-        //If no options provided, use defaults
-        if (empty($options)) {
-            $options = $this->getOptions();
-        }
-        return $this->getProvider()->getAuthorizationUrl($options);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getState()
-    {
-        return $this->getProvider()->getState();
-    }
 }


### PR DESCRIPTION
Below are the changes:
1. `get_xoauth_token.php` - Changes  are made to use the League classes directly inorder to obtain refresh tokens
2. `src/OAuthProvider/Base.php` - Only essential code is being kept and the rest is deleted making it a cleaner implementation. Changes to constructor is made. Please do a rename of this file if necessary. Other files in this folder can be omitted
3. `examples/gmail_xoauth.phps` - Has been changed as we discussed it above.
`//Change the Class Name depending on the Provider Used (Line 65)
if (!isset($provider)) {
    $provider = new Google([
        'clientId' => $clientId,
        'clientSecret' => $clientSecret
    ]);
}` - This piece of code is used to fetch the provider. To make a cleaner implementation this can be moved to `Base` class. But in that case there should be some identifier for each provider (Google, MS, Yahoo) etc. so that the provider can be created inside the `Base` class based on the identifier. One way can be to assign a numeric value for each provider and pass it to `Base` class. Do we have a cleaner way to do this?