### PR TITLE
Add unit test that shows how address parser returns its result

### DIFF
--- a/test/phpmailerTest.php
+++ b/test/phpmailerTest.php
@@ -1417,6 +1417,19 @@ EOT;
             ),
             'Failed to recognise address list (IMAP parser)'
         );
+        $this->assertEquals(
+            array(
+                array("name" => 'Joe User', 'address' => 'joe@example.com'),
+                array("name" => 'Jill User', 'address' => 'jill@example.net'),
+                array("name" => '', 'address' => 'frank@example.com'),
+            ),
+            $this->Mail->parseAddresses(
+                'Joe User <joe@example.com>,'
+                    . 'Jill User <jill@example.net>,'
+                    . 'frank@example.com,'
+            ),
+            'Parsed addresses'
+        );
         //Test simple address parser
         $this->assertCount(
             2,


### PR DESCRIPTION
Also I have 2 questions, if anyone could help:
1) What setup is needed after cloning the repo to have all unit tests pass?
2) Why are all the assert names ("Failed to recognise address list etc.") more like descriptions for when the test fails? Is it not obvious that a test failed, when it does? Why put it in the description? The description could be a good documentation.