### PR TITLE
Set BCC in header in case SMTP is used.

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -1957,7 +1957,7 @@ class PHPMailer
 
         // sendmail and mail() extract Bcc from the header before sending
         if ((
-                $this->Mailer == 'sendmail' or $this->Mailer == 'qmail' or $this->Mailer == 'mail'
+                $this->Mailer == 'sendmail' or $this->Mailer == 'qmail' or $this->Mailer == 'mail' or $this->Mailer == 'smtp'
             )
             and count($this->bcc) > 0
         ) {


### PR DESCRIPTION
BCC was not set in createHeader() function of PHPMailer class if SMTP was used.