### PR TITLE
Header overwrite support in PHPMailer::addCustomHeader()

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -3274,15 +3274,20 @@ class PHPMailer
      * @access public
      * @param string $name Custom header name
      * @param string $value Header value
+     * @param bool $overwrite Whether to overwrite if a header with name $name exists.
      * @return void
      */
-    public function addCustomHeader($name, $value = null)
+    public function addCustomHeader($name, $value = null, $overwrite = false)
     {
         if ($value === null) {
-            // Value passed in as name:value
-            $this->CustomHeader[] = explode(':', $name, 2);
-        } else {
-            $this->CustomHeader[] = array($name, $value);
+            $header = explode(':', $name, 2);
+            $name = $header[0];
+        }
+        if ($overwrite) {
+            $this->CustomHeader[$name] = isset($header) ? $header : array($name, $value);
+        }
+        else {
+            $this->CustomHeader[] = isset($header) ? $header : array($name, $value);
         }
     }
 
@@ -3292,7 +3297,7 @@ class PHPMailer
      */
     public function getCustomHeaders()
     {
-        return $this->CustomHeader;
+        return array_values($this->CustomHeader);
     }
 
     /**

--- a/test/phpmailerTest.php
+++ b/test/phpmailerTest.php
@@ -1946,6 +1946,13 @@ EOT;
             array('yux'),
             array('Content-Type', ' application/json')
         ), $this->Mail->getCustomHeaders());
+
+        $this->Mail->clearCustomHeaders();
+        $this->Mail->addCustomHeader('Date', 'Wed, 15 Jun 2016 14:30:16 GMT', true);
+        $this->Mail->addCustomHeader('Date', 'Wed, 15 Jun 2016 14:30:17 GMT', true);
+        $this->assertEquals(array(
+          array('Date', 'Wed, 15 Jun 2016 14:30:17 GMT')
+        ), $this->Mail->getCustomHeaders());
     }
 
     /**


### PR DESCRIPTION
Thank you for this great library, which I use almost everyday and love using it. 

In PHPMailer::addCustomHeader(), it appends headers to the headers list even a matching header already exists. This PR adds support (and passing tests for it) to add an extra option to overwrite the header if already exists. 

This can be useful when using PHPMailer to send lists. The object can be instantiated once, and can be used throughout the batch. Without the overwrite support, one would have to get the current headerss list, overwrite the header, and set them again. `List-unsubscribe` header for example will have the recipient information embeded in the header value. I'm sure there are other use cases as well. 

Technically, it is still a valid email if the same header is repeated. This PR does not intend to change the support for that. Instead, it makes it easier to quickly swap the header content when sending to a list:

```
$mailer = new PHPMailer();
$mailer->addCustomHeader('Date', 'Wed, 15 Jun 2016 14:30:17 GMT', true);
$mailer->addCustomHeader('Date', 'Wed, 15 Jun 2016 14:30:18 GMT', true);
```

After the second call, the `$mailer->CustomHeader` property would hold an associative array, indexed by the header name. It supports the single-field syntax as well, and can be combined too:

```
$mailer = new PHPMailer();
$mailer->addCustomHeader('Date:Wed, 15 Jun 2016 14:30:17 GMT', true);
$mailer->addCustomHeader('Date', 'Wed, 15 Jun 2016 14:30:18 GMT', true);
```

If the initial header was not set with the third parameter set to `TRUE`, it will not be overwritten. We could do an array search, but since the overwrite support is an optional one, the caller must be aware of it and should pass the third parameter `TRUE` everytime. 

Please review when you have time. 

Thank you. 
