### PR TITLE
Improve error handling for connection failures.

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -272,8 +272,8 @@ class SMTP
         $errstr = '';
         if ($streamok) {
             $socket_context = stream_context_create($options);
-            //Suppress errors; connection failures are handled at a higher level
-            $this->smtp_conn = @stream_socket_client(
+            set_error_handler(array('self', 'errorHandler'));
+            $this->smtp_conn = stream_socket_client(
                 $host . ":" . $port,
                 $errno,
                 $errstr,
@@ -281,12 +281,14 @@ class SMTP
                 STREAM_CLIENT_CONNECT,
                 $socket_context
             );
+            restore_error_handler();
         } else {
             //Fall back to fsockopen which should work in more places, but is missing some features
             $this->edebug(
                 "Connection: stream_socket_client not available, falling back to fsockopen",
                 self::DEBUG_CONNECTION
             );
+            set_error_handler(array('self', 'errorHandler'));
             $this->smtp_conn = fsockopen(
                 $host,
                 $port,
@@ -294,6 +296,7 @@ class SMTP
                 $errstr,
                 $timeout
             );
+            restore_error_handler();
         }
         // Verify we connected properly
         if (!is_resource($this->smtp_conn)) {
@@ -1188,5 +1191,24 @@ class SMTP
     public function getTimeout()
     {
         return $this->Timeout;
+    }
+
+    /**
+     * Reports an error number and string.
+     * @param integer $errno The error number returned by PHP.
+     * @param string $errmsg The error message returned by PHP.
+     */
+    function errorHandler($errno, $errmsg)
+    {
+        $notice = 'Connection: Failed to connect to server.';
+        $this->setError(
+            $notice,
+            $errno,
+            $errmsg
+        );
+        $this->edebug(
+            $notice . ' Error number ' . $errno . '. "Error notice: ' . $errmsg,
+            self::DEBUG_CONNECTION
+        );
     }
 }


### PR DESCRIPTION
Hello.

First off, I want to say thank you for your continued work with maintaining and improving this project. I have been using it for many years, even as far back as when it was hosted on SourceForge.

However, I feel that the way that the output for the call to stream_socket_client() (and fsockopen()) is handled is not good, in that it is suppressing all errors by proceeding it with an error control operator.

I am in the process upgrading the Drupal PHPMailer module (https://www.drupal.org/project/phpmailer) to work with Drupal 8. In my testing, I was troubleshooting problems with connecting to my mail server (which works just fine with other programs), and because the error control operator was there to suppress the errors, I only got the last of three errors and was troubleshooting the wrong problem.

Only by removing the error control operator and allowing all messages to be shown, was I able to see what the real problem was and correctly diagnose and fix it.

In searching through the issues for this repository for similar problems, it seems to me that there have been several instances where not having the error control operator in place might have resulted in the problem being solved quicker, and potentially, without even having an issue posted, especially with insecure SSL problems and this issue, where the author practically stated as much:
https://github.com/PHPMailer/PHPMailer/issues/243#issuecomment-45979467

I understand the reasoning for having the error control operator in place, but I think the reasons for not having it there are stronger.

During my research and troubleshooting of my problems, I came across this article titled HOW TO: Catch PHP Errors and Warnings:
https://www.cubewebsites.com/blog/development/php/how-to-catch-php-errors-and-warnings/

Using and tweaking the method presented in that post, I was able to modify the code in PHPMailer to not only not spew PHP notices all over the page, but to also save and record all of the errors that are reported by both stream_socket_client() and fsockopen(). (I actually started the process with PHPMailer 5.2.5, because for me, that was a known working version. Once I was positive I had everything working with my code there, I bumped PHPMailer up to the latest stable 5.x version (5.2.16) and made sure my code still worked there.)

I saw that some minor side discussion happened about something similar in this issue, starting at this comment:
https://github.com/PHPMailer/PHPMailer/pull/339#issuecomment-68200766
and continuing with this one for three comments:
https://github.com/PHPMailer/PHPMailer/pull/339#issuecomment-68433835
but it didn't go anywhere.

My pull request does not do anything with SSL/TLS, and is simply a generic method for catching and reporting multiple errors that could be used in other places.

Feel free to make recommendations for improvement.  Although my coding style is different than yours, I tried to mimic your style, but I might have missed something.

Thank you for you time and attention with this.
