### PR TITLE
Switch to UTF-8 default encoding

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,9 @@
     "suggest": {
         "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
         "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
-        "stevenmaguire/oauth2-microsoft": "Needed for Microsoft XOAUTH2 authentication"
+        "stevenmaguire/oauth2-microsoft": "Needed for Microsoft XOAUTH2 authentication",
+        "ext-mbstring": "Needed to send email in multibyte encoding charset",
+        "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR is about issue [#765](https://github.com/PHPMailer/PHPMailer/issues/765).

 * Add [`symfony/polyfill-mbstring`](https://github.com/symfony/polyfill-mbstring) dependency to provide a partial, native PHP implementation for the Mbstring extension.
 * Set `UTF-8` as default charset instead of `iso-8859-1`.

Please tell me if I should add or revert something, I'll be glad to help!
