### PR TITLE
6.0(Refactor and Improve documentation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,4 @@ test/testbootstrap.php
 test/*.pem
 build/
 vendor/
-
 *.pem

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ test/testbootstrap.php
 test/*.pem
 build/
 vendor/
+
+*.pem
+phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ build/
 vendor/
 
 *.pem
-phpunit.xml

--- a/src/Exception.php
+++ b/src/Exception.php
@@ -28,6 +28,7 @@ class Exception extends \Exception
 {
     /**
      * Prettify error message output
+     * @access public
      * @return string
      */
     public function errorMessage()

--- a/src/OAuth.php
+++ b/src/OAuth.php
@@ -35,12 +35,14 @@ class OAuth
 {
     /**
      * An instance of the League OAuth Client Provider.
+     * @access protected
      * @var AbstractProvider
      */
     protected $provider = null;
 
     /**
      * The current OAuth access token.
+     * @access protected
      * @var AccessToken
      */
     protected $oauthToken = null;
@@ -48,30 +50,35 @@ class OAuth
     /**
      * The user's email address, usually used as the login ID
      * and also the from address when sending email.
+     * @access protected
      * @var string
      */
     protected $oauthUserEmail = '';
 
     /**
      * The client secret, generated in the app definition of the service you're connecting to.
+     * @access protected
      * @var string
      */
     protected $oauthClientSecret = '';
 
     /**
      * The client ID, generated in the app definition of the service you're connecting to.
+     * @access protected
      * @var string
      */
     protected $oauthClientId = '';
 
     /**
      * The refresh token, used to obtain new AccessTokens.
+     * @access protected
      * @var string
      */
     protected $oauthRefreshToken = '';
 
     /**
      * OAuth constructor.
+     * @access public
      * @param array $options Associative array containing
      *   `provider`, `userName`, `clientSecret`, `clientId` and `refreshToken` elements
      */
@@ -86,6 +93,7 @@ class OAuth
 
     /**
      * Get a new RefreshToken.
+     * @access protected
      * @return RefreshToken
      */
     protected function getGrant()
@@ -95,6 +103,7 @@ class OAuth
 
     /**
      * Get a new AccessToken.
+     * @access protected
      * @return AccessToken
      */
     protected function getToken()
@@ -107,6 +116,7 @@ class OAuth
 
     /**
      * Generate a base64-encoded OAuth token.
+     * @access public
      * @return string
      */
     public function getOauth64()

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -33,18 +33,21 @@ class PHPMailer
      * Email priority.
      * Options: null (default), 1 = High, 3 = Normal, 5 = low.
      * When null, the header is not set at all.
+     * @access public
      * @var integer
      */
     public $Priority = null;
 
     /**
      * The character set of the message.
+     * @access public
      * @var string
      */
     public $CharSet = 'iso-8859-1';
 
     /**
      * The MIME Content-type of the message.
+     * @access public
      * @var string
      */
     public $ContentType = 'text/plain';
@@ -52,24 +55,28 @@ class PHPMailer
     /**
      * The message encoding.
      * Options: "8bit", "7bit", "binary", "base64", and "quoted-printable".
+     * @access public
      * @var string
      */
     public $Encoding = '8bit';
 
     /**
      * Holds the most recent mailer error message.
+     * @access public
      * @var string
      */
     public $ErrorInfo = '';
 
     /**
      * The From email address for the message.
+     * @access public
      * @var string
      */
     public $From = 'root@localhost';
 
     /**
      * The From name of the message.
+     * @access public
      * @var string
      */
     public $FromName = 'Root User';
@@ -77,12 +84,14 @@ class PHPMailer
     /**
      * The Sender email (Return-Path) of the message.
      * If not empty, will be sent via -f to sendmail or as 'MAIL FROM' in smtp mode.
+     * @access public
      * @var string
      */
     public $Sender = '';
 
     /**
      * The Subject of the message.
+     * @access public
      * @var string
      */
     public $Subject = '';
@@ -90,6 +99,7 @@ class PHPMailer
     /**
      * An HTML or plain text message body.
      * If HTML then call isHTML(true).
+     * @access public
      * @var string
      */
     public $Body = '';
@@ -99,6 +109,7 @@ class PHPMailer
      * This body can be read by mail clients that do not have HTML email
      * capability such as mutt & Eudora.
      * Clients that can read HTML will view the normal Body.
+     * @access public
      * @var string
      */
     public $AltBody = '';
@@ -107,6 +118,7 @@ class PHPMailer
      * An iCal message part body.
      * Only supported in simple alt or alt_inline message types
      * To generate iCal events, use the bundled extras/EasyPeasyICS.php class or iCalcreator
+     * @access public
      * @link http://sprain.ch/blog/downloads/php-class-easypeasyics-create-ical-files-with-php/
      * @link http://kigkonsult.se/iCalcreator/
      * @var string
@@ -122,21 +134,22 @@ class PHPMailer
 
     /**
      * The complete compiled MIME message headers.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $MIMEHeader = '';
 
     /**
      * Extra headers that createHeader() doesn't fold in.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $mailHeader = '';
 
     /**
      * Word-wrap the message body to this number of chars.
      * Set to 0 to not wrap. A useful value here is 78, for RFC2822 section 2.1.1 compliance.
+     * @access public
      * @var integer
      */
     public $WordWrap = 0;
@@ -144,12 +157,14 @@ class PHPMailer
     /**
      * Which method to use to send mail.
      * Options: "mail", "sendmail", or "smtp".
+     * @access public
      * @var string
      */
     public $Mailer = 'mail';
 
     /**
      * The path to the sendmail program.
+     * @access public
      * @var string
      */
     public $Sendmail = '/usr/sbin/sendmail';
@@ -157,12 +172,14 @@ class PHPMailer
     /**
      * Whether mail() uses a fully sendmail-compatible MTA.
      * One which supports sendmail's "-oi -f" options.
+     * @access public
      * @var boolean
      */
     public $UseSendmailOptions = true;
 
     /**
      * The email address that a reading confirmation should be sent to, also known as read receipt.
+     * @access public
      * @var string
      */
     public $ConfirmReadingTo = '';
@@ -172,6 +189,7 @@ class PHPMailer
      * If empty, PHPMailer attempts to find one with, in order,
      * $_SERVER['SERVER_NAME'], gethostname(), php_uname('n'), or the value
      * 'localhost.localdomain'.
+     * @access public
      * @var string
      */
     public $Hostname = '';
@@ -179,6 +197,7 @@ class PHPMailer
     /**
      * An ID to be used in the Message-ID header.
      * If empty, a unique id will be generated.
+     * @access public
      * @var string
      */
     public $MessageID = '';
@@ -186,6 +205,7 @@ class PHPMailer
     /**
      * The message Date to be used in the Date header.
      * If empty, the current date will be added.
+     * @access public
      * @var string
      */
     public $MessageDate = '';
@@ -199,12 +219,14 @@ class PHPMailer
      * You can also specify encryption type, for example:
      * (e.g. "tls://smtp1.example.com:587;ssl://smtp2.example.com:465").
      * Hosts will be tried in order.
+     * @access public
      * @var string
      */
     public $Host = 'localhost';
 
     /**
      * The default SMTP server port.
+     * @access public
      * @var integer
      */
     public $Port = 25;
@@ -213,6 +235,7 @@ class PHPMailer
      * The SMTP HELO of the message.
      * Default is $Hostname. If $Hostname is empty, PHPMailer attempts to find
      * one with the same method described above for $Hostname.
+     * @access public
      * @var string
      * @see PHPMailer::$Hostname
      */
@@ -221,6 +244,7 @@ class PHPMailer
     /**
      * What kind of encryption to use on the SMTP connection.
      * Options: '', 'ssl' or 'tls'
+     * @access public
      * @var string
      */
     public $SMTPSecure = '';
@@ -229,6 +253,7 @@ class PHPMailer
      * Whether to enable TLS encryption automatically if a server supports it,
      * even if `SMTPSecure` is not set to 'tls'.
      * Be aware that in PHP >= 5.6 this requires that the server's certificates are valid.
+     * @access public
      * @var boolean
      */
     public $SMTPAutoTLS = true;
@@ -236,6 +261,7 @@ class PHPMailer
     /**
      * Whether to use SMTP authentication.
      * Uses the Username and Password properties.
+     * @access public
      * @var boolean
      * @see PHPMailer::$Username
      * @see PHPMailer::$Password
@@ -244,18 +270,21 @@ class PHPMailer
 
     /**
      * Options array passed to stream_context_create when connecting via SMTP.
+     * @access public
      * @var array
      */
     public $SMTPOptions = [];
 
     /**
      * SMTP username.
+     * @access public
      * @var string
      */
     public $Username = '';
 
     /**
      * SMTP password.
+     * @access public
      * @var string
      */
     public $Password = '';
@@ -263,20 +292,22 @@ class PHPMailer
     /**
      * SMTP auth type.
      * Options are CRAM-MD5, LOGIN, PLAIN, XOAUTH2, attempted in that order if not specified
+     * @access public
      * @var string
      */
     public $AuthType = '';
 
     /**
      * An instance of the PHPMailer OAuth class.
-     * @var OAuth
      * @access protected
+     * @var OAuth
      */
     protected $oauth = null;
 
     /**
      * The SMTP server timeout in seconds.
      * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
+     * @access public
      * @var integer
      */
     public $Timeout = 300;
@@ -290,6 +321,7 @@ class PHPMailer
      * * `2` Data and commands
      * * `3` As 2 plus connection status
      * * `4` Low-level data output
+     * @access public
      * @var integer
      * @see SMTP::$do_debug
      */
@@ -306,6 +338,7 @@ class PHPMailer
      * <code>
      * $mail->Debugoutput = function($str, $level) {echo "debug level $level; message: $str";};
      * </code>
+     * @access public
      * @var string|callable
      * @see SMTP::$Debugoutput
      */
@@ -315,6 +348,7 @@ class PHPMailer
      * Whether to keep SMTP connection open after each message.
      * If this is set to true then to close the connection
      * requires an explicit call to smtpClose().
+     * @access public
      * @var boolean
      */
     public $SMTPKeepAlive = false;
@@ -323,12 +357,14 @@ class PHPMailer
      * Whether to split multiple to addresses into multiple messages
      * or send them all in one message.
      * Only supported in `mail` and `sendmail` transports, not in SMTP.
+     * @access public
      * @var boolean
      */
     public $SingleTo = false;
 
     /**
      * Storage for addresses when SingleTo is enabled.
+     * @access protected
      * @var array
      */
     protected $SingleToArray = [];
@@ -336,6 +372,7 @@ class PHPMailer
     /**
      * Whether to generate VERP addresses on send.
      * Only applicable when sending via SMTP.
+     * @access public
      * @link https://en.wikipedia.org/wiki/Variable_envelope_return_path
      * @link http://www.postfix.org/VERP_README.html Postfix VERP info
      * @var boolean
@@ -344,6 +381,7 @@ class PHPMailer
 
     /**
      * Whether to allow sending messages with an empty body.
+     * @access public
      * @var boolean
      */
     public $AllowEmpty = false;
@@ -352,12 +390,14 @@ class PHPMailer
      * The default line ending.
      * @note The default remains "\n". We force LE where we know
      *        it must be used via static::LE.
+     * @access public
      * @var string
      */
     public $LE = "\n";
 
     /**
      * DKIM selector.
+     * @access public
      * @var string
      */
     public $DKIM_selector = '';
@@ -365,6 +405,7 @@ class PHPMailer
     /**
      * DKIM Identity.
      * Usually the email address used as the source of the email.
+     * @access public
      * @var string
      */
     public $DKIM_identity = '';
@@ -372,12 +413,14 @@ class PHPMailer
     /**
      * DKIM passphrase.
      * Used if your key is encrypted.
+     * @access public
      * @var string
      */
     public $DKIM_passphrase = '';
 
     /**
      * DKIM signing domain name.
+     * @access public
      * @example 'example.com'
      * @var string
      */
@@ -385,6 +428,7 @@ class PHPMailer
 
     /**
      * DKIM private key file path.
+     * @access public
      * @var string
      */
     public $DKIM_private = '';
@@ -405,6 +449,7 @@ class PHPMailer
      *   string  $subject       the subject
      *   string  $body          the email body
      *   string  $from          email address of sender
+     * @access public
      * @var string
      */
     public $action_function = '';
@@ -412,6 +457,7 @@ class PHPMailer
     /**
      * What to put in the X-Mailer header.
      * Options: An empty string for PHPMailer default, whitespace for none, or a string to use
+     * @access public
      * @var string
      */
     public $XMailer = '';
@@ -419,6 +465,7 @@ class PHPMailer
     /**
      * Which validator to use by default when validating email addresses.
      * May be a callable to inject your own validator, but there are several built-in validators.
+     * @access public
      * @see PHPMailer::validateAddress()
      * @var string|callable
      * @static
@@ -427,45 +474,47 @@ class PHPMailer
 
     /**
      * An instance of the SMTP sender class.
-     * @var SMTP
      * @access protected
+     * @var SMTP
      */
     protected $smtp = null;
 
     /**
      * The array of 'to' names and addresses.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $to = [];
 
     /**
      * The array of 'cc' names and addresses.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $cc = [];
 
     /**
      * The array of 'bcc' names and addresses.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $bcc = [];
 
     /**
      * The array of reply-to names and addresses.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $ReplyTo = [];
 
     /**
      * An array of all kinds of addresses.
      * Includes all of $to, $cc, $bcc
-     * @var array
      * @access protected
-     * @see PHPMailer::$to @see PHPMailer::$cc @see PHPMailer::$bcc
+     * @var array
+     * @see PHPMailer::$to
+     * @see PHPMailer::$cc
+     * @see PHPMailer::$bcc
      */
     protected $all_recipients = [];
 
@@ -474,9 +523,11 @@ class PHPMailer
      * In send(), valid and non duplicate entries are moved to $all_recipients
      * and one of $to, $cc, or $bcc.
      * This array is used only for addresses with IDN.
-     * @var array
      * @access protected
-     * @see PHPMailer::$to @see PHPMailer::$cc @see PHPMailer::$bcc
+     * @var array
+     * @see PHPMailer::$to
+     * @see PHPMailer::$cc
+     * @see PHPMailer::$bcc
      * @see PHPMailer::$all_recipients
      */
     protected $RecipientsQueue = [];
@@ -485,101 +536,101 @@ class PHPMailer
      * An array of reply-to names and addresses queued for validation.
      * In send(), valid and non duplicate entries are moved to $ReplyTo.
      * This array is used only for addresses with IDN.
-     * @var array
      * @access protected
+     * @var array
      * @see PHPMailer::$ReplyTo
      */
     protected $ReplyToQueue = [];
 
     /**
      * The array of attachments.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $attachment = [];
 
     /**
      * The array of custom headers.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $CustomHeader = [];
 
     /**
      * The most recent Message-ID (including angular brackets).
-     * @var string
      * @access protected
+     * @var string
      */
     protected $lastMessageID = '';
 
     /**
      * The message's MIME type.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $message_type = '';
 
     /**
      * The array of MIME boundary strings.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $boundary = [];
 
     /**
      * The array of available languages.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $language = [];
 
     /**
      * The number of errors encountered.
-     * @var integer
      * @access protected
+     * @var integer
      */
     protected $error_count = 0;
 
     /**
      * The S/MIME certificate file path.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $sign_cert_file = '';
 
     /**
      * The S/MIME key file path.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $sign_key_file = '';
 
     /**
      * The optional S/MIME extra certificates ("CA Chain") file path.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $sign_extracerts_file = '';
 
     /**
      * The S/MIME password for the key.
      * Used only if the key is encrypted.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $sign_key_pass = '';
 
     /**
      * Whether to throw exceptions for errors.
-     * @var boolean
      * @access protected
+     * @var boolean
      */
     protected $exceptions = false;
 
     /**
      * Unique ID used for message ID and boundaries.
-     * @var string
      * @access protected
+     * @var string
      */
     protected $uniqueid = '';
 
@@ -616,6 +667,7 @@ class PHPMailer
 
     /**
      * Constructor.
+     * @access public
      * @param boolean $exceptions Should we throw external exceptions?
      */
     public function __construct($exceptions = null)
@@ -629,6 +681,7 @@ class PHPMailer
 
     /**
      * Destructor.
+     * @access public
      */
     public function __destruct()
     {
@@ -1473,6 +1526,11 @@ class PHPMailer
         return $this->smtp;
     }
 
+    /**
+     * Get the SMTP sender 
+     * @access public
+     * @return string
+     */
     public function getSMTPFrom()
     {
         if ('' === $this->Sender) {
@@ -2119,8 +2177,8 @@ class PHPMailer
      * Returns the whole MIME message.
      * Includes complete headers and body.
      * Only valid post preSend().
-     * @see PHPMailer::preSend()
      * @access public
+     * @see PHPMailer::preSend()
      * @return string
      */
     public function getSentMIMEMessage()
@@ -2484,6 +2542,7 @@ class PHPMailer
 
     /**
      * Return the array of attachments.
+     * @access public
      * @return array
      */
     public function getAttachments()
@@ -3292,6 +3351,7 @@ class PHPMailer
 
     /**
      * Returns all custom headers.
+     * @access public
      * @return array
      */
     public function getCustomHeaders()
@@ -3683,6 +3743,12 @@ class PHPMailer
         return $line;
     }
 
+    /**
+     * Get the privKey set
+     * @access private
+     * @param  string $privKeyStr
+     * @return string
+     */
     private function getPrivKey($privKeyStr)
     {
         if ('' != $this->DKIM_passphrase) {

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -817,7 +817,7 @@ class PHPMailer
         return $this->addOrEnqueueAnAddress('Reply-To', $address, $name);
     }
 
-    private function enqueue($address, $data)
+    private function enqueue($address, $data, $params)
     {
         if (!array_key_exists($address, $data)) {
             $data[$address] = $params;
@@ -860,9 +860,9 @@ class PHPMailer
         // Enqueue addresses with IDN until we know the PHPMailer::$CharSet.
         if ($this->has8bitChars(substr($address, ++$pos)) and $this->idnSupported()) {
             if ('Reply-To' != $kind) {
-                return $this->enqueue($address, $this->RecipientsQueue);
+                return $this->enqueue($address, $this->RecipientsQueue, $params);
             } else {
-                return $this->enqueue($address, $this->ReplyToQueue);
+                return $this->enqueue($address, $this->ReplyToQueue, $params);
             }
             return false;
         }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -740,24 +740,19 @@ class PHPMailer
         $this->Mailer = 'mail';
     }
 
-    private function transportAgent($type, $path)
-    {
-        $ini_sendmail_path = ini_get('sendmail_path');
-
-        if (!stristr($ini_sendmail_path, $type)) {
-            $this->Sendmail = $path;
-        } else {
-            $this->Sendmail = $ini_sendmail_path;
-        }
-    }
-
     /**
      * Send messages using $Sendmail.
      * @return void
      */
     public function isSendmail()
     {
-        $this->transportAgent('sendmail', '/usr/sbin/sendmail');
+        $ini_sendmail_path = ini_get('sendmail_path');
+
+        if (!stristr($ini_sendmail_path, 'sendmail')) {
+            $this->Sendmail = '/usr/sbin/sendmail';
+        } else {
+            $this->Sendmail = $ini_sendmail_path;
+        }
         $this->Mailer = 'sendmail';
     }
 
@@ -767,7 +762,13 @@ class PHPMailer
      */
     public function isQmail()
     {
-        $this->transportAgent('qmail', '/var/qmail/bin/qmail-inject');
+        $ini_sendmail_path = ini_get('sendmail_path');
+
+        if (!stristr($ini_sendmail_path, 'qmail')) {
+            $this->Sendmail = '/var/qmail/bin/qmail-inject';
+        } else {
+            $this->Sendmail = $ini_sendmail_path;
+        }
         $this->Mailer = 'qmail';
     }
 
@@ -817,21 +818,6 @@ class PHPMailer
         return $this->addOrEnqueueAnAddress('Reply-To', $address, $name);
     }
 
-    private function enqueue($address, $data)
-    {
-        if (!array_key_exists($address, $data)) {
-            $data[$address] = $params;
-            return true;
-        }
-    }
-
-    private function throwException($error_message)
-    {
-        if ($this->exceptions) {
-            throw new Exception($error_message);
-        }
-    }
-
     /**
      * Add an address to one of the recipient arrays or to the ReplyTo array. Because PHPMailer
      * can't validate addresses with an IDN without knowing the PHPMailer::$CharSet (that can still
@@ -853,16 +839,24 @@ class PHPMailer
             $error_message = $this->lang('invalid_address') . " (addAnAddress $kind): $address";
             $this->setError($error_message);
             $this->edebug($error_message);
-            $this->throwException($error_message);
+            if ($this->exceptions) {
+                throw new Exception($error_message);
+            }
             return false;
         }
         $params = [$kind, $address, $name];
         // Enqueue addresses with IDN until we know the PHPMailer::$CharSet.
         if ($this->has8bitChars(substr($address, ++$pos)) and $this->idnSupported()) {
             if ('Reply-To' != $kind) {
-                return $this->enqueue($address, $this->RecipientsQueue);
+                if (!array_key_exists($address, $this->RecipientsQueue)) {
+                    $this->RecipientsQueue[$address] = $params;
+                    return true;
+                }
             } else {
-                return $this->enqueue($address, $this->ReplyToQueue);
+                if (!array_key_exists($address, $this->ReplyToQueue)) {
+                    $this->ReplyToQueue[$address] = $params;
+                    return true;
+                }
             }
             return false;
         }
@@ -886,14 +880,18 @@ class PHPMailer
             $error_message = $this->lang('Invalid recipient kind: ') . $kind;
             $this->setError($error_message);
             $this->edebug($error_message);
-            $this->throwException($error_message);
+            if ($this->exceptions) {
+                throw new Exception($error_message);
+            }
             return false;
         }
         if (!$this->validateAddress($address)) {
             $error_message = $this->lang('invalid_address') . " (addAnAddress $kind): $address";
             $this->setError($error_message);
             $this->edebug($error_message);
-            $this->throwException($error_message);
+            if ($this->exceptions) {
+                throw new Exception($error_message);
+            }
             return false;
         }
         if ('Reply-To' != $kind) {
@@ -986,7 +984,9 @@ class PHPMailer
             $error_message = $this->lang('invalid_address') . " (setFrom) $address";
             $this->setError($error_message);
             $this->edebug($error_message);
-            $this->throwException($error_message);
+            if ($this->exceptions) {
+                throw new Exception($error_message);
+            }
             return false;
         }
         $this->From = $address;
@@ -1210,7 +1210,9 @@ class PHPMailer
                     $error_message = $this->lang('invalid_address') . ' (punyEncode) ' . $this->$address_kind;
                     $this->setError($error_message);
                     $this->edebug($error_message);
-                    $this->throwException($error_message);
+                    if ($this->exceptions) {
+                        throw new Exception($error_message);
+                    }
                     return false;
                 }
             }
@@ -1440,14 +1442,6 @@ class PHPMailer
         return $this->smtp;
     }
 
-    public function getSMTPFrom()
-    {
-        if ('' === $this->Sender) {
-            return $this->From;
-        }
-        return $this->Sender;
-    }
-
     /**
      * Send mail via SMTP.
      * Returns false if there is a bad MAIL FROM, RCPT, or DATA input.
@@ -1466,8 +1460,11 @@ class PHPMailer
         if (!$this->smtpConnect($this->SMTPOptions)) {
             throw new Exception($this->lang('smtp_connect_failed'), self::STOP_CRITICAL);
         }
-        $smtp_from = $this->getSMTPFrom();
-
+        if ('' == $this->Sender) {
+            $smtp_from = $this->From;
+        } else {
+            $smtp_from = $this->Sender;
+        }
         if (!$this->smtp->mail($smtp_from)) {
             $this->setError($this->lang('from_failed') . $smtp_from . ' : ' . implode(',', $this->smtp->getError()));
             throw new Exception($this->ErrorInfo, self::STOP_CRITICAL);
@@ -1752,10 +1749,11 @@ class PHPMailer
     {
         if (empty($addr[1])) { // No name provided
             return $this->secureHeader($addr[0]);
+        } else {
+            return $this->encodeHeader($this->secureHeader($addr[1]), 'phrase') . ' <' . $this->secureHeader(
+                $addr[0]
+            ) . '>';
         }
-        return $this->encodeHeader($this->secureHeader($addr[1]), 'phrase') . ' <' . $this->secureHeader(
-            $addr[0]
-        ) . '>';
     }
 
     /**
@@ -2715,9 +2713,9 @@ class PHPMailer
     {
         if (function_exists('mb_strlen')) {
             return (strlen($str) > mb_strlen($str, $this->CharSet));
+        } else { // Assume no multibytes (we can't handle without mbstring functions anyway)
+            return false;
         }
-        // Assume no multibytes (we can't handle without mbstring functions anyway)
-        return false;
     }
 
     /**
@@ -3188,9 +3186,10 @@ class PHPMailer
                 return $this->language[$key] . ' https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting';
             }
             return $this->language[$key];
+        } else {
+            //Return the key as a fallback
+            return $key;
         }
-        //Return the key as a fallback
-        return $key;
     }
 
     /**
@@ -3562,9 +3561,10 @@ class PHPMailer
         if (property_exists($this, $name)) {
             $this->$name = $value;
             return true;
+        } else {
+            $this->setError($this->lang('variable_set') . $name);
+            return false;
         }
-        $this->setError($this->lang('variable_set') . $name);
-        return false;
     }
 
     /**
@@ -3629,14 +3629,6 @@ class PHPMailer
         return $line;
     }
 
-    private function getPrivKey($privKeyStr)
-    {
-        if ('' != $this->DKIM_passphrase) {
-            return openssl_pkey_get_private($privKeyStr, $this->DKIM_passphrase);
-        }
-        return openssl_pkey_get_private($privKeyStr);
-    }
-
     /**
      * Generate a DKIM signature.
      * @access public
@@ -3653,8 +3645,11 @@ class PHPMailer
             return '';
         }
         $privKeyStr = file_get_contents($this->DKIM_private);
-        $privKey = $this->getPrivKey($privKeyStr);
-
+        if ('' != $this->DKIM_passphrase) {
+            $privKey = openssl_pkey_get_private($privKeyStr, $this->DKIM_passphrase);
+        } else {
+            $privKey = openssl_pkey_get_private($privKeyStr);
+        }
         if (openssl_sign($signHeader, $signature, $privKey, 'sha256WithRSAEncryption')) {
             openssl_pkey_free($privKey);
             return base64_encode($signature);

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -641,12 +641,12 @@ class PHPMailer
      * Also, unless sendmail_path points to sendmail (or something that
      * claims to be sendmail), don't pass params (not a perfect fix,
      * but it will do)
+     * @access private
      * @param string $to To
      * @param string $subject Subject
      * @param string $body Message Body
      * @param string $header Additional Header(s)
      * @param string $params Params
-     * @access private
      * @return boolean
      */
     private function mailPassthru($to, $subject, $body, $header, $params)
@@ -668,9 +668,11 @@ class PHPMailer
     /**
      * Output debugging info via user-defined method.
      * Only generates output if SMTP debug output is enabled (@see SMTP::$do_debug).
+     * @access protected
      * @see PHPMailer::$Debugoutput
      * @see PHPMailer::$SMTPDebug
      * @param string $str
+     * @return string
      */
     protected function edebug($str)
     {
@@ -710,6 +712,7 @@ class PHPMailer
 
     /**
      * Sets message type to HTML or plain.
+     * @access public
      * @param boolean $isHtml True for HTML mode.
      * @return void
      */
@@ -724,6 +727,7 @@ class PHPMailer
 
     /**
      * Send messages using SMTP.
+     * @access public
      * @return void
      */
     public function isSMTP()
@@ -733,6 +737,7 @@ class PHPMailer
 
     /**
      * Send messages using PHP's mail() function.
+     * @access public
      * @return void
      */
     public function isMail()
@@ -740,7 +745,14 @@ class PHPMailer
         $this->Mailer = 'mail';
     }
 
-    private function transportAgent($type, $path)
+    /**
+     * Get the actual type of transprot agent
+     * @access protected
+     * @param  string $type
+     * @param  string $path
+     * @return void
+     */
+    protected function transportAgent($type, $path)
     {
         $ini_sendmail_path = ini_get('sendmail_path');
 
@@ -753,6 +765,7 @@ class PHPMailer
 
     /**
      * Send messages using $Sendmail.
+     * @access public
      * @return void
      */
     public function isSendmail()
@@ -763,6 +776,7 @@ class PHPMailer
 
     /**
      * Send messages using qmail.
+     * @access public
      * @return void
      */
     public function isQmail()
@@ -773,6 +787,7 @@ class PHPMailer
 
     /**
      * Add a "To" address.
+     * @access public
      * @param string $address The email address to send to
      * @param string $name
      * @return boolean true on success, false if address already used or invalid in some way
@@ -785,6 +800,7 @@ class PHPMailer
     /**
      * Add a "CC" address.
      * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
+     * @access public
      * @param string $address The email address to send to
      * @param string $name
      * @return boolean true on success, false if address already used or invalid in some way
@@ -797,6 +813,7 @@ class PHPMailer
     /**
      * Add a "BCC" address.
      * @note: This function works with the SMTP mailer on win32, not with the "mail" mailer.
+     * @access public
      * @param string $address The email address to send to
      * @param string $name
      * @return boolean true on success, false if address already used or invalid in some way
@@ -808,6 +825,7 @@ class PHPMailer
 
     /**
      * Add a "Reply-To" address.
+     * @access public
      * @param string $address The email address to reply to
      * @param string $name
      * @return boolean true on success, false if address already used or invalid in some way
@@ -817,7 +835,13 @@ class PHPMailer
         return $this->addOrEnqueueAnAddress('Reply-To', $address, $name);
     }
 
-    private function throwException($error_message)
+    /**
+     * Throw exception of exception is set
+     * @access protected
+     * @param  string $error_message
+     * @throws Exception
+     */
+    protected function throwException($error_message)
     {
         if ($this->exceptions) {
             throw new Exception($error_message);
@@ -829,12 +853,12 @@ class PHPMailer
      * can't validate addresses with an IDN without knowing the PHPMailer::$CharSet (that can still
      * be modified after calling this function), addition of such addresses is delayed until send().
      * Addresses that have been added already return false, but do not throw exceptions.
+     * @access protected
      * @param string $kind One of 'to', 'cc', 'bcc', or 'ReplyTo'
      * @param string $address The email address to send, resp. to reply to
      * @param string $name
      * @throws Exception
      * @return boolean true on success, false if address already used or invalid in some way
-     * @access protected
      */
     protected function addOrEnqueueAnAddress($kind, $address, $name)
     {
@@ -873,12 +897,12 @@ class PHPMailer
     /**
      * Add an address to one of the recipient arrays or to the ReplyTo array.
      * Addresses that have been added already return false, but do not throw exceptions.
+     * @access protected
      * @param string $kind One of 'to', 'cc', 'bcc', or 'ReplyTo'
      * @param string $address The email address to send, resp. to reply to
      * @param string $name
      * @throws Exception
      * @return boolean true on success, false if address already used or invalid in some way
-     * @access protected
      */
     protected function addAnAddress($kind, $address, $name = '')
     {
@@ -916,11 +940,12 @@ class PHPMailer
      * of the form "display name <address>" into an array of name/address pairs.
      * Uses the imap_rfc822_parse_adrlist function if the IMAP extension is available.
      * Note that quotes in the name part are removed.
+     * @link http://www.andrew.cmu.edu/user/agreen1/testing/mrbs/web/Mail/RFC822.php A more careful implementation
+     * @access public
      * @param string $addrstr The address list string
      * @param bool $useimap Whether to use the IMAP extension to parse the list
      * @return array
      * @static
-     * @link http://www.andrew.cmu.edu/user/agreen1/testing/mrbs/web/Mail/RFC822.php A more careful implementation
      */
     public static function parseAddresses($addrstr, $useimap = true)
     {
@@ -969,6 +994,7 @@ class PHPMailer
 
     /**
      * Set the From and FromName properties.
+     * @access public
      * @param string $address
      * @param string $name
      * @param boolean $auto Whether to also set the Sender address, defaults to true
@@ -1004,6 +1030,7 @@ class PHPMailer
      * Technically this is the value from the last time the headers were created,
      * but it's also the message ID of the last sent message except in
      * pathological cases.
+     * @access public
      * @return string
      */
     public function getLastMessageID()
@@ -1013,6 +1040,7 @@ class PHPMailer
 
     /**
      * Check that a string looks like an email address.
+     * @access public
      * @param string $address The email address to check
      * @param string|callable $patternselect A selector for the validation pattern to use :
      * * `auto` Pick best pattern automatically;
@@ -1028,7 +1056,6 @@ class PHPMailer
      * You can also set the PHPMailer::$validator static to a callable, allowing built-in methods to use your validator.
      * @return boolean
      * @static
-     * @access public
      */
     public static function validateAddress($address, $patternselect = null)
     {
@@ -1118,6 +1145,7 @@ class PHPMailer
     /**
      * Tells whether IDNs (Internationalized Domain Names) are supported or not. This requires the
      * "intl" and "mbstring" PHP extensions.
+     * @access public
      * @return bool "true" if required functions for IDN support are present
      */
     public function idnSupported()
@@ -1132,6 +1160,7 @@ class PHPMailer
      * - No conversion is necessary (i.e. domain name is not an IDN, or is already in ASCII form)
      * - Conversion to punycode is impossible (e.g. required PHP functions are not available)
      *   or fails for any reason (e.g. domain has characters not allowed in an IDN)
+     * @access public
      * @see PHPMailer::$CharSet
      * @param string $address The email address to convert
      * @return string The encoded address in ASCII form
@@ -1159,6 +1188,7 @@ class PHPMailer
     /**
      * Create a message and send it.
      * Uses the sending method specified by $Mailer.
+     * @access public
      * @throws Exception
      * @return boolean false on error - See the ErrorInfo property for details of the error.
      */
@@ -1181,6 +1211,7 @@ class PHPMailer
 
     /**
      * Prepare a message for sending.
+     * @access public
      * @throws Exception
      * @return boolean
      */
@@ -1274,6 +1305,7 @@ class PHPMailer
     /**
      * Actually send a message.
      * Send the email via the selected mechanism
+     * @access public
      * @throws Exception
      * @return boolean
      */
@@ -1309,11 +1341,11 @@ class PHPMailer
 
     /**
      * Send mail using the $Sendmail program.
+     * @access protected
      * @param string $header The message headers
      * @param string $body The message body
      * @see PHPMailer::$Sendmail
      * @throws Exception
-     * @access protected
      * @return boolean
      */
     protected function sendmailSend($header, $body)
@@ -1378,11 +1410,11 @@ class PHPMailer
 
     /**
      * Send mail using the PHP mail() function.
+     * @link http://www.php.net/manual/en/book.mail.php
+     * @access protected
      * @param string $header The message headers
      * @param string $body The message body
-     * @link http://www.php.net/manual/en/book.mail.php
      * @throws Exception
-     * @access protected
      * @return boolean
      */
     protected function mailSend($header, $body)
@@ -1430,6 +1462,7 @@ class PHPMailer
     /**
      * Get an instance to use for SMTP operations.
      * Override this function to load your own SMTP implementation
+     * @access public
      * @return SMTP
      */
     public function getSMTPInstance()
@@ -1452,12 +1485,12 @@ class PHPMailer
      * Send mail via SMTP.
      * Returns false if there is a bad MAIL FROM, RCPT, or DATA input.
      * Uses the PHPMailerSMTP class by default.
+     * @access protected
      * @see PHPMailer::getSMTPInstance() to use a different class.
      * @param string $header The message headers
      * @param string $body The message body
      * @throws Exception
      * @uses SMTP
-     * @access protected
      * @return boolean
      */
     protected function smtpSend($header, $body)
@@ -1514,11 +1547,11 @@ class PHPMailer
     /**
      * Initiate a connection to an SMTP server.
      * Returns false if the operation failed.
-     * @param array $options An array of options compatible with stream_context_create()
-     * @return boolean
-     * @throws Exception
-     * @uses SMTP
      * @access public
+     * @param array $options An array of options compatible with stream_context_create()
+     * @throws Exception
+     * @return boolean
+     * @uses SMTP
      */
     public function smtpConnect($options = null)
     {
@@ -1634,6 +1667,7 @@ class PHPMailer
 
     /**
      * Close the active SMTP session if one exists.
+     * @access public
      * @return void
      */
     public function smtpClose()
@@ -1650,10 +1684,10 @@ class PHPMailer
      * Set the language for error messages.
      * Returns false if it cannot load the language file.
      * The default language is English.
+     * @access public
      * @param string $langcode ISO 639-1 2-character language code (e.g. French is "fr")
      * @param string $lang_path Path to the language file directory, with trailing separator (slash)
      * @return boolean
-     * @access public
      */
     public function setLanguage($langcode = 'en', $lang_path = '')
     {
@@ -1715,6 +1749,7 @@ class PHPMailer
 
     /**
      * Get the array of strings for the current language.
+     * @access public
      * @return array
      */
     public function getTranslations()
@@ -1763,10 +1798,10 @@ class PHPMailer
      * For use with mailers that do not automatically perform wrapping
      * and for quoted-printable encoded messages.
      * Original written by philippe.
+     * @access public
      * @param string $message The message to wrap
      * @param integer $length The line length to wrap to
      * @param boolean $qp_mode Whether to run in Quoted-Printable mode
-     * @access public
      * @return string
      */
     public function wrapText($message, $length, $qp_mode = false)
@@ -2400,6 +2435,7 @@ class PHPMailer
     /**
      * Add an attachment from a path on the filesystem.
      * Returns false if the file could not be found or read.
+     * @access public
      * @param string $path Path to the attachment.
      * @param string $name Overrides the attachment name.
      * @param string $encoding File encoding (see $Encoding).
@@ -2582,10 +2618,10 @@ class PHPMailer
     /**
      * Encode a file attachment in requested format.
      * Returns an empty string on failure.
+     * @access protected
      * @param string $path The full path to the file
      * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
      * @throws Exception
-     * @access protected
      * @return string
      */
     protected function encodeFile($path, $encoding = 'base64')
@@ -2606,9 +2642,9 @@ class PHPMailer
     /**
      * Encode a string in requested format.
      * Returns an empty string on failure.
+     * @access public
      * @param string $str The text to encode
      * @param string $encoding The encoding to use; one of 'base64', '7bit', '8bit', 'binary', 'quoted-printable'
-     * @access public
      * @return string
      */
     public function encodeString($str, $encoding = 'base64')
@@ -2722,6 +2758,7 @@ class PHPMailer
 
     /**
      * Does a string contain any 8-bit chars (in any charset)?
+     * @access public
      * @param string $text
      * @return boolean
      */
@@ -2788,6 +2825,7 @@ class PHPMailer
     /**
      * Encode a string using Q encoding.
      * @link http://tools.ietf.org/html/rfc2047
+     * @access public
      * @param string $str the text to encode
      * @param string $position Where the text is going to be used, see the RFC for what that means
      * @access public
@@ -2837,6 +2875,7 @@ class PHPMailer
      * Add a string or binary attachment (non-filesystem).
      * This method can be used to attach ascii or binary data,
      * such as a BLOB record from a database.
+     * @access public
      * @param string $string String attachment data.
      * @param string $filename Name of the attachment.
      * @param string $encoding File encoding (see $Encoding).
@@ -2875,6 +2914,7 @@ class PHPMailer
      * displayed inline with the message, not just attached for download.
      * This is used in HTML messages that embed the images
      * the HTML refers to using the $cid value.
+     * @access public
      * @param string $path Path to the attachment.
      * @param string $cid Content ID of the attachment; Use this to reference
      *        the content when using an embedded image in HTML.
@@ -2920,6 +2960,7 @@ class PHPMailer
      * This can include images, sounds, and just about any other document type.
      * Be sure to set the $type to an image type for images:
      * JPEG images use 'image/jpeg', GIF uses 'image/gif', PNG uses 'image/png'.
+     * @access public
      * @param string $string The attachment binary data.
      * @param string $cid Content ID of the attachment; Use this to reference
      *        the content when using an embedded image in HTML.
@@ -2989,6 +3030,7 @@ class PHPMailer
 
     /**
      * Check if an attachment (non-inline) is present.
+     * @access public
      * @return boolean
      */
     public function attachmentExists()
@@ -3003,6 +3045,7 @@ class PHPMailer
 
     /**
      * Check if this message has an alternative body set.
+     * @access public
      * @return boolean
      */
     public function alternativeExists()
@@ -3012,7 +3055,7 @@ class PHPMailer
 
     /**
      * Clear queued addresses of given kind.
-     * @access protected
+     * @access public
      * @param string $kind 'to', 'cc', or 'bcc'
      * @return void
      */
@@ -3028,6 +3071,7 @@ class PHPMailer
 
     /**
      * Clear all To recipients.
+     * @access public
      * @return void
      */
     public function clearAddresses()
@@ -3041,6 +3085,7 @@ class PHPMailer
 
     /**
      * Clear all CC recipients.
+     * @access public
      * @return void
      */
     public function clearCCs()
@@ -3054,6 +3099,7 @@ class PHPMailer
 
     /**
      * Clear all BCC recipients.
+     * @access public
      * @return void
      */
     public function clearBCCs()
@@ -3067,6 +3113,7 @@ class PHPMailer
 
     /**
      * Clear all ReplyTo recipients.
+     * @access public
      * @return void
      */
     public function clearReplyTos()
@@ -3077,6 +3124,7 @@ class PHPMailer
 
     /**
      * Clear all recipient types.
+     * @access public
      * @return void
      */
     public function clearAllRecipients()
@@ -3090,6 +3138,7 @@ class PHPMailer
 
     /**
      * Clear all filesystem, string, and binary attachments.
+     * @access public
      * @return void
      */
     public function clearAttachments()
@@ -3099,6 +3148,7 @@ class PHPMailer
 
     /**
      * Clear all custom headers.
+     * @access public
      * @return void
      */
     public function clearCustomHeaders()
@@ -3348,6 +3398,7 @@ class PHPMailer
      *     return $converter->get_text();
      * });
      * </code>
+     * @access public
      * @param string $html The HTML text to convert
      * @param boolean|callable $advanced Any boolean value to use the internal converter,
      *   or provide your own callable for custom conversion.
@@ -3367,8 +3418,8 @@ class PHPMailer
 
     /**
      * Get the MIME type for a file extension.
-     * @param string $ext File extension
      * @access public
+     * @param string $ext File extension
      * @return string MIME type of file.
      * @static
      */
@@ -3483,6 +3534,7 @@ class PHPMailer
     /**
      * Map a file name to a MIME type.
      * Defaults to 'application/octet-stream', i.e.. arbitrary binary data.
+     * @access public
      * @param string $filename A file name or full path, does not need to exist as a file
      * @return string
      * @static
@@ -3502,6 +3554,7 @@ class PHPMailer
      * Multi-byte-safe pathinfo replacement.
      * Drop-in replacement for pathinfo(), but multibyte- and cross-platform-safe
      * @link http://www.php.net/manual/en/function.pathinfo.php#107461
+     * @access public
      * @param string $path A filename or path, does not need to exist as a file
      * @param integer|string $options Either a PATHINFO_* constant,
      *      or a string name to return only the specified piece
@@ -3582,10 +3635,10 @@ class PHPMailer
      * Normalize line breaks in a string.
      * Converts UNIX LF, Mac CR and Windows LE line breaks into a single line break format.
      * Defaults to LE (for message bodies) and preserves consecutive breaks.
+     * @access public
      * @param string $text
      * @param string $breaktype What kind of line break to use, defaults to LE
      * @return string
-     * @access public
      * @static
      */
     public static function normalizeBreaks($text, $breaktype = "\r\n")
@@ -3600,6 +3653,7 @@ class PHPMailer
      * @param string $key_filename
      * @param string $key_pass Password for private key
      * @param string $extracerts_filename Optional path to chain certificate
+     * @return void
      */
     public function sign($cert_filename, $key_filename, $key_pass, $extracerts_filename = '')
     {
@@ -3804,6 +3858,7 @@ class PHPMailer
 
     /**
      * Detect if a string contains a line longer than the maximum line length allowed.
+     * @access public
      * @param string $str
      * @return boolean
      * @static
@@ -3871,6 +3926,7 @@ class PHPMailer
 
     /**
      * Perform a callback.
+     * @access protected
      * @param boolean $isSent
      * @param array $to
      * @param array $cc
@@ -3878,6 +3934,7 @@ class PHPMailer
      * @param string $subject
      * @param string $body
      * @param string $from
+     * @return void
      */
     protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from)
     {
@@ -3888,6 +3945,7 @@ class PHPMailer
 
     /**
      * Get the OAuth instance.
+     * @access public
      * @return OAuth
      */
     public function getOAuth()
@@ -3897,7 +3955,9 @@ class PHPMailer
 
     /**
      * Set an OAuth instance.
+     * @access public
      * @param OAuth $oauth
+     * @return void
      */
     public function setOAuth(OAuth $oauth)
     {

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -720,8 +720,9 @@ class PHPMailer
 
     /**
      * Output debugging info via user-defined method.
-     * Only generates output if SMTP debug output is enabled (@see SMTP::$do_debug).
+     * Only generates output if SMTP debug output is enabled.
      * @access protected
+     * @see SMTP::$do_debug
      * @see PHPMailer::$Debugoutput
      * @see PHPMailer::$SMTPDebug
      * @param string $str
@@ -1214,8 +1215,8 @@ class PHPMailer
      * - Conversion to punycode is impossible (e.g. required PHP functions are not available)
      *   or fails for any reason (e.g. domain has characters not allowed in an IDN)
      * @access public
-     * @see PHPMailer::$CharSet
      * @param string $address The email address to convert
+     * @see PHPMailer::$CharSet
      * @return string The encoded address in ASCII form
      */
     public function punyencodeAddress($address)
@@ -1544,9 +1545,9 @@ class PHPMailer
      * Returns false if there is a bad MAIL FROM, RCPT, or DATA input.
      * Uses the PHPMailerSMTP class by default.
      * @access protected
-     * @see PHPMailer::getSMTPInstance() to use a different class.
      * @param string $header The message headers
      * @param string $body The message body
+     * @see PHPMailer::getSMTPInstance() to use a different class.
      * @throws Exception
      * @uses SMTP
      * @return boolean
@@ -1608,8 +1609,8 @@ class PHPMailer
      * @access public
      * @param array $options An array of options compatible with stream_context_create()
      * @throws Exception
-     * @return boolean
      * @uses SMTP
+     * @return boolean
      */
     public function smtpConnect($options = null)
     {
@@ -2887,7 +2888,6 @@ class PHPMailer
      * @access public
      * @param string $str the text to encode
      * @param string $position Where the text is going to be used, see the RFC for what that means
-     * @access public
      * @return string
      */
     public function encodeQ($str, $position = 'text')
@@ -3369,7 +3369,8 @@ class PHPMailer
      * @param string $message HTML message string
      * @param string $basedir baseline directory for path, with or without a trailing slash
      * @param boolean|callable $advanced Whether to use the internal HTML to text converter
-     *    or your own custom converter @see PHPMailer::html2text()
+     *    or your own custom converter
+     * @see PHPMailer::html2text()
      * @return string $message
      */
     public function msgHTML($message, $basedir = '', $advanced = false)

--- a/src/POP3.php
+++ b/src/POP3.php
@@ -41,86 +41,86 @@ class POP3
 {
     /**
      * The POP3 PHPMailer Version number.
-     * @var string
      * @access public
+     * @var string
      */
     public $Version = '6.0.0';
 
     /**
      * Default POP3 port number.
-     * @var integer
      * @access public
+     * @var integer
      */
     public $POP3_PORT = 110;
 
     /**
      * Default timeout in seconds.
-     * @var integer
      * @access public
+     * @var integer
      */
     public $POP3_TIMEOUT = 30;
 
     /**
      * Debug display level.
      * Options: 0 = no, 1+ = yes
-     * @var integer
      * @access public
+     * @var integer
      */
     public $do_debug = 0;
 
     /**
      * POP3 mail server hostname.
-     * @var string
      * @access public
+     * @var string
      */
     public $host;
 
     /**
      * POP3 port number.
-     * @var integer
      * @access public
+     * @var integer
      */
     public $port;
 
     /**
      * POP3 Timeout Value in seconds.
-     * @var integer
      * @access public
+     * @var integer
      */
     public $tval;
 
     /**
      * POP3 username
-     * @var string
      * @access public
+     * @var string
      */
     public $username;
 
     /**
      * POP3 password.
-     * @var string
      * @access public
+     * @var string
      */
     public $password;
 
     /**
      * Resource handle for the POP3 connection socket.
-     * @var resource
      * @access protected
+     * @var resource
      */
     protected $pop_conn;
 
     /**
      * Are we connected?
-     * @var boolean
      * @access protected
+     * @var boolean
      */
     protected $connected = false;
 
     /**
      * Error container.
-     * @var array
      * @access protected
+     * @var array
      */
     protected $errors = [];
 
@@ -131,6 +131,7 @@ class POP3
 
     /**
      * Simple static wrapper for all-in-one POP before SMTP
+     * @access public
      * @param $host
      * @param integer|boolean $port The port number to connect to
      * @param integer|boolean $timeout The timeout value
@@ -318,6 +319,7 @@ class POP3
     /**
      * Disconnect from the POP3 server.
      * @access public
+     * @return void
      */
     public function disconnect()
     {
@@ -334,9 +336,9 @@ class POP3
     /**
      * Get a response from the POP3 server.
      * $size is the maximum number of bytes to retrieve
+     * @access protected
      * @param integer $size
      * @return string
-     * @access protected
      */
     protected function getResponse($size = 128)
     {
@@ -349,9 +351,9 @@ class POP3
 
     /**
      * Send raw data to the POP3 server.
+     * @access protected
      * @param string $string
      * @return integer
-     * @access protected
      */
     protected function sendString($string)
     {
@@ -367,9 +369,9 @@ class POP3
     /**
      * Checks the POP3 server response.
      * Looks for for +OK or -ERR.
+     * @access protected
      * @param string $string
      * @return boolean
-     * @access protected
      */
     protected function checkResponse($string)
     {
@@ -389,8 +391,9 @@ class POP3
     /**
      * Add an error to the internal error store.
      * Also display debug output if it's enabled.
-     * @param $error
      * @access protected
+     * @param $error
+     * @return  void
      */
     protected function setError($error)
     {
@@ -406,6 +409,7 @@ class POP3
 
     /**
      * Get an array of error messages, if any.
+     * @access public
      * @return array
      */
     public function getErrors()
@@ -415,11 +419,12 @@ class POP3
 
     /**
      * POP3 connection error handler.
+     * @access protected
      * @param integer $errno
      * @param string $errstr
      * @param string $errfile
      * @param integer $errline
-     * @access protected
+     * @return void
      */
     protected function catchWarning($errno, $errstr, $errfile, $errline)
     {

--- a/src/POP3.php
+++ b/src/POP3.php
@@ -152,6 +152,34 @@ class POP3
     }
 
     /**
+     * Check if port is set
+     * @access private
+     * @param  integer|boolean $port The number to connect to
+     * @return integer
+     */
+    private function getPort($port)
+    {
+        if (false === $port) {
+            return $this->POP3_PORT;
+        }
+        return (integer)$port;
+    }
+
+    /**
+     * Check if timeout is set
+     * @access private
+     * @param  integer|boolean $timeout The timeout value
+     * @return integer
+     */
+    private function getTimeout($timeout)
+    {
+        if (false === $timeout) {
+            return $this->POP3_TIMEOUT;
+        }
+        return (integer)$timeout;
+    }
+
+    /**
      * Authenticate with a POP3 server.
      * A connect, login, disconnect sequence
      * appropriate for POP-before SMTP authorisation.
@@ -168,17 +196,11 @@ class POP3
     {
         $this->host = $host;
         // If no port value provided, use default
-        if (false === $port) {
-            $this->port = $this->POP3_PORT;
-        } else {
-            $this->port = (integer)$port;
-        }
+        $this->port = $this->getPort($port);
+
         // If no timeout value provided, use default
-        if (false === $timeout) {
-            $this->tval = $this->POP3_TIMEOUT;
-        } else {
-            $this->tval = (integer)$timeout;
-        }
+        $this->tval = $this->getTimeout($timeout);
+
         $this->do_debug = $debug_level;
         $this->username = $username;
         $this->password = $password;
@@ -360,9 +382,8 @@ class POP3
                 ]
             );
             return false;
-        } else {
-            return true;
         }
+        return true;
     }
 
     /**

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -187,10 +187,10 @@ class SMTP
     /**
      * Output debugging info via a user-selected method.
      * @access protected
-     * @see SMTP::$Debugoutput
-     * @see SMTP::$do_debug
      * @param string $str Debug string to output
      * @param integer $level The debug level of this message; see DEBUG_* constants
+     * @see SMTP::$Debugoutput
+     * @see SMTP::$do_debug
      * @return void
      */
     protected function edebug($str, $level = 0)
@@ -356,11 +356,11 @@ class SMTP
      * Perform SMTP authentication.
      * Must be run after hello().
      * @access public
-     * @see hello()
      * @param string $username The user name
      * @param string $password The password
      * @param string $authtype The auth type (CRAM-MD5, PLAIN, LOGIN, XOAUTH2)
      * @param OAuth $OAuth An optional OAuth instance for XOAUTH2 authentication
+     * @see hello()
      * @return bool True if successfully authenticated.
      */
     public function authenticate(
@@ -664,9 +664,9 @@ class SMTP
      * Send an SMTP HELO or EHLO command.
      * Low-level implementation used by hello()
      * @access protected
-     * @see hello()
      * @param string $hello The HELO string
      * @param string $host The hostname to say we are
+     * @see hello()
      * @return boolean
      */
     protected function sendHello($hello, $host)

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -54,26 +54,31 @@ class SMTP
 
     /**
      * Debug level for no output
+     * @var integer
      */
     const DEBUG_OFF = 0;
 
     /**
      * Debug level to show client -> server messages
+     * @var integer
      */
     const DEBUG_CLIENT = 1;
 
     /**
      * Debug level to show client -> server and server -> client messages
+     * @var integer
      */
     const DEBUG_SERVER = 2;
 
     /**
      * Debug level to show connection status, client -> server and server -> client messages
+     * @var integer
      */
     const DEBUG_CONNECTION = 3;
 
     /**
      * Debug level to show all messages
+     * @var integer
      */
     const DEBUG_LOWLEVEL = 4;
 
@@ -85,6 +90,7 @@ class SMTP
      * * self::DEBUG_SERVER (`2`) Client commands and server responses
      * * self::DEBUG_CONNECTION (`3`) As DEBUG_SERVER plus connection status
      * * self::DEBUG_LOWLEVEL (`4`) Low-level data output, all messages
+     * @access public
      * @var integer
      */
     public $do_debug = self::DEBUG_OFF;
@@ -100,6 +106,7 @@ class SMTP
      * <code>
      * $smtp->Debugoutput = function($str, $level) {echo "debug level $level; message: $str";};
      * </code>
+     * @access public
      * @var string|callable
      */
     public $Debugoutput = 'echo';
@@ -108,6 +115,7 @@ class SMTP
      * Whether to use VERP.
      * @link http://en.wikipedia.org/wiki/Variable_envelope_return_path
      * @link http://www.postfix.org/VERP_README.html Info on VERP
+     * @access public
      * @var boolean
      */
     public $do_verp = false;
@@ -117,6 +125,7 @@ class SMTP
      * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
      * This needs to be quite high to function correctly with hosts using greetdelay as an anti-spam measure.
      * @link http://tools.ietf.org/html/rfc2821#section-4.5.3.2
+     * @access public
      * @var integer
      */
     public $Timeout = 300;
@@ -124,18 +133,21 @@ class SMTP
     /**
      * How long to wait for commands to complete, in seconds.
      * Default of 5 minutes (300sec) is from RFC2821 section 4.5.3.2
+     * @access public
      * @var integer
      */
     public $Timelimit = 300;
 
     /**
      * The socket for the server connection.
+     * @access protected
      * @var resource
      */
     protected $smtp_conn;
 
     /**
      * Error information, if any, for the last SMTP command.
+     * @access protected
      * @var array
      */
     protected $error = [
@@ -148,6 +160,7 @@ class SMTP
     /**
      * The reply the server sent to us for HELO.
      * If null, no HELO string has yet been received.
+     * @access protected
      * @var string|null
      */
     protected $helo_rply = null;
@@ -159,12 +172,14 @@ class SMTP
      * represents the server name. In case of HELO it is the only element of the array.
      * Other values can be boolean TRUE or an array containing extension options.
      * If null, no HELO/EHLO string has yet been received.
+     * @access protected
      * @var array|null
      */
     protected $server_caps = null;
 
     /**
      * The most recent reply received from the server.
+     * @access protected
      * @var string
      */
     protected $last_reply = '';
@@ -221,7 +236,6 @@ class SMTP
      * @param integer $port The port number to connect to
      * @param integer $timeout How long to wait for the connection to open
      * @param array $options An array of options for stream_context_create()
-     * @access public
      * @return boolean
      */
     public function connect($host, $port = null, $timeout = 30, $options = [])
@@ -348,7 +362,6 @@ class SMTP
      * @param string $authtype The auth type (CRAM-MD5, PLAIN, LOGIN, XOAUTH2)
      * @param OAuth $OAuth An optional OAuth instance for XOAUTH2 authentication
      * @return bool True if successfully authenticated.
-     * @access public
      */
     public function authenticate(
         $username,
@@ -673,6 +686,7 @@ class SMTP
      * In case of HELO, the only parameter that can be discovered is a server name.
      * @access protected
      * @param string $type - 'HELO' or 'EHLO'
+     * @return void
      */
     protected function parseHelloFields($type)
     {
@@ -1055,7 +1069,7 @@ class SMTP
 
     /**
      * Set error messages and codes.
-     * @access public
+     * @access protected
      * @param string $message The error message
      * @param string $detail Further detail on the error
      * @param string $smtp_code An associated SMTP error code
@@ -1076,6 +1090,7 @@ class SMTP
      * Set debug output method.
      * @access public
      * @param string|callable $method The name of the mechanism to use for debugging output, or a callable to handle it.
+     * @return void
      */
     public function setDebugOutput($method = 'echo')
     {
@@ -1096,6 +1111,7 @@ class SMTP
      * Set debug output level.
      * @access public
      * @param integer $level
+     * @return void
      */
     public function setDebugLevel($level = 0)
     {
@@ -1116,6 +1132,7 @@ class SMTP
      * Set SMTP timeout.
      * @access public
      * @param integer $timeout
+     * @return void
      */
     public function setTimeout($timeout = 0)
     {

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -171,6 +171,7 @@ class SMTP
 
     /**
      * Output debugging info via a user-selected method.
+     * @access protected
      * @see SMTP::$Debugoutput
      * @see SMTP::$do_debug
      * @param string $str Debug string to output
@@ -215,6 +216,7 @@ class SMTP
 
     /**
      * Connect to an SMTP server.
+     * @access public
      * @param string $host SMTP server IP or host name
      * @param integer $port The port number to connect to
      * @param integer $timeout How long to wait for the connection to open
@@ -339,6 +341,7 @@ class SMTP
     /**
      * Perform SMTP authentication.
      * Must be run after hello().
+     * @access public
      * @see hello()
      * @param string $username The user name
      * @param string $password The password
@@ -462,9 +465,9 @@ class SMTP
      * Calculate an MD5 HMAC hash.
      * Works like hash_hmac('md5', $data, $key)
      * in case that function is not available
+     * @access protected
      * @param string $data The data to hash
      * @param string $key  The key to hash with
-     * @access protected
      * @return string
      */
     protected function hmac($data, $key)
@@ -520,8 +523,8 @@ class SMTP
     /**
      * Close the socket and clean up the state of the class.
      * Don't use this function without first trying to use QUIT.
-     * @see quit()
      * @access public
+     * @see quit()
      * @return void
      */
     public function close()
@@ -545,8 +548,8 @@ class SMTP
      * on a single line followed by a <CRLF> with the message headers
      * and the message body being separated by an additional <CRLF>.
      * Implements rfc 821: DATA <CRLF>
-     * @param string $msg_data Message data to send
      * @access public
+     * @param string $msg_data Message data to send
      * @return boolean
      */
     public function data($msg_data)
@@ -634,8 +637,8 @@ class SMTP
      * This makes sure that client and server are in a known state.
      * Implements RFC 821: HELO <SP> <domain> <CRLF>
      * and RFC 2821 EHLO.
-     * @param string $host The host name or IP to connect to
      * @access public
+     * @param string $host The host name or IP to connect to
      * @return boolean
      */
     public function hello($host = '')
@@ -647,10 +650,10 @@ class SMTP
     /**
      * Send an SMTP HELO or EHLO command.
      * Low-level implementation used by hello()
+     * @access protected
      * @see hello()
      * @param string $hello The HELO string
      * @param string $host The hostname to say we are
-     * @access protected
      * @return boolean
      */
     protected function sendHello($hello, $host)
@@ -714,8 +717,8 @@ class SMTP
      * the mail transaction is started and then one or more recipient
      * commands may be called followed by a data command.
      * Implements rfc 821: MAIL <SP> FROM:<reverse-path> <CRLF>
-     * @param string $from Source address of this message
      * @access public
+     * @param string $from Source address of this message
      * @return boolean
      */
     public function mail($from)
@@ -732,8 +735,8 @@ class SMTP
      * Send an SMTP QUIT command.
      * Closes the socket if there is no error or the $close_on_error argument is true.
      * Implements from rfc 821: QUIT <CRLF>
-     * @param boolean $close_on_error Should the connection close if an error occurs?
      * @access public
+     * @param boolean $close_on_error Should the connection close if an error occurs?
      * @return boolean
      */
     public function quit($close_on_error = true)
@@ -752,8 +755,8 @@ class SMTP
      * Sets the TO argument to $toaddr.
      * Returns true if the recipient was accepted false if it was rejected.
      * Implements from rfc 821: RCPT <SP> TO:<forward-path> <CRLF>
-     * @param string $address The address the message is being sent to
      * @access public
+     * @param string $address The address the message is being sent to
      * @return boolean
      */
     public function recipient($address)
@@ -779,10 +782,10 @@ class SMTP
 
     /**
      * Send a command to an SMTP server and check its return code.
+     * @access protected
      * @param string $command The command name - not sent to the server
      * @param string $commandstring The actual command to send
      * @param integer|array $expect One or more expected integer success codes
-     * @access protected
      * @return boolean True on success.
      */
     protected function sendCommand($command, $commandstring, $expect)
@@ -846,8 +849,8 @@ class SMTP
      * will send the message to the users terminal if they are logged
      * in and send them an email.
      * Implements rfc 821: SAML <SP> FROM:<reverse-path> <CRLF>
-     * @param string $from The address the message is from
      * @access public
+     * @param string $from The address the message is from
      * @return boolean
      */
     public function sendAndMail($from)
@@ -857,8 +860,8 @@ class SMTP
 
     /**
      * Send an SMTP VRFY command.
-     * @param string $name The name to verify
      * @access public
+     * @param string $name The name to verify
      * @return boolean
      */
     public function verify($name)
@@ -895,8 +898,8 @@ class SMTP
 
     /**
      * Send raw data to the server.
-     * @param string $data The data to send
      * @access public
+     * @param string $data The data to send
      * @return integer|boolean The number of bytes sent to the server or false on error
      */
     public function client_send($data)
@@ -941,6 +944,7 @@ class SMTP
      *  - null returned: handshake was not or we don't know about ext (refer to $this->error)
      *  - false returned: the requested feature exactly not exists
      *  - positive value returned: the requested feature exists
+     * @access public
      * @param string $name Name of SMTP extension or 'HELO'|'EHLO'
      * @return mixed
      */
@@ -1030,7 +1034,9 @@ class SMTP
 
     /**
      * Enable or disable VERP address generation.
+     * @access public
      * @param boolean $enabled
+     * @return void
      */
     public function setVerp($enabled = false)
     {
@@ -1039,6 +1045,7 @@ class SMTP
 
     /**
      * Get VERP address generation mode.
+     * @access public
      * @return boolean
      */
     public function getVerp()
@@ -1048,10 +1055,12 @@ class SMTP
 
     /**
      * Set error messages and codes.
+     * @access public
      * @param string $message The error message
      * @param string $detail Further detail on the error
      * @param string $smtp_code An associated SMTP error code
      * @param string $smtp_code_ex Extended SMTP code
+     * @return  void
      */
     protected function setError($message, $detail = '', $smtp_code = '', $smtp_code_ex = '')
     {
@@ -1065,6 +1074,7 @@ class SMTP
 
     /**
      * Set debug output method.
+     * @access public
      * @param string|callable $method The name of the mechanism to use for debugging output, or a callable to handle it.
      */
     public function setDebugOutput($method = 'echo')
@@ -1074,6 +1084,7 @@ class SMTP
 
     /**
      * Get debug output method.
+     * @access public
      * @return string
      */
     public function getDebugOutput()
@@ -1083,6 +1094,7 @@ class SMTP
 
     /**
      * Set debug output level.
+     * @access public
      * @param integer $level
      */
     public function setDebugLevel($level = 0)
@@ -1092,6 +1104,7 @@ class SMTP
 
     /**
      * Get debug output level.
+     * @access public
      * @return integer
      */
     public function getDebugLevel()
@@ -1101,6 +1114,7 @@ class SMTP
 
     /**
      * Set SMTP timeout.
+     * @access public
      * @param integer $timeout
      */
     public function setTimeout($timeout = 0)
@@ -1110,6 +1124,7 @@ class SMTP
 
     /**
      * Get SMTP timeout.
+     * @access public
      * @return integer
      */
     public function getTimeout()


### PR DESCRIPTION
This `PR` address the inconsistency in the code documentation and also a few code duplication. For example, making all method have a defined format for the `docblock`(`@link`>`@access`, `@param`>`see`>`@use`>`throw`>`@return`>`static`). 