### PR TITLE
Fixing typos in German translation ('Deppenleerzeichen')

### DIFF
--- a/language/phpmailer.lang-de.php
+++ b/language/phpmailer.lang-de.php
@@ -4,22 +4,22 @@
  * @package PHPMailer
  */
 
-$PHPMAILER_LANG['authenticate']         = 'SMTP Fehler: Authentifizierung fehlgeschlagen.';
-$PHPMAILER_LANG['connect_host']         = 'SMTP Fehler: Konnte keine Verbindung zum SMTP-Host herstellen.';
-$PHPMAILER_LANG['data_not_accepted']    = 'SMTP Fehler: Daten werden nicht akzeptiert.';
-$PHPMAILER_LANG['empty_message']        = 'E-Mail Inhalt ist leer.';
+$PHPMAILER_LANG['authenticate']         = 'SMTP-Fehler: Authentifizierung fehlgeschlagen.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-Fehler: Konnte keine Verbindung zum SMTP-Host herstellen.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-Fehler: Daten werden nicht akzeptiert.';
+$PHPMAILER_LANG['empty_message']        = 'E-Mail-Inhalt ist leer.';
 $PHPMAILER_LANG['encoding']             = 'Unbekanntes Encoding-Format: ';
 $PHPMAILER_LANG['execute']              = 'Konnte folgenden Befehl nicht ausführen: ';
 $PHPMAILER_LANG['file_access']          = 'Zugriff auf folgende Datei fehlgeschlagen: ';
-$PHPMAILER_LANG['file_open']            = 'Datei Fehler: konnte folgende Datei nicht öffnen: ';
+$PHPMAILER_LANG['file_open']            = 'Dateifehler: konnte folgende Datei nicht öffnen: ';
 $PHPMAILER_LANG['from_failed']          = 'Die folgende Absenderadresse ist nicht korrekt: ';
-$PHPMAILER_LANG['instantiate']          = 'Mail Funktion konnte nicht initialisiert werden.';
+$PHPMAILER_LANG['instantiate']          = 'Mail-Funktion konnte nicht initialisiert werden.';
 $PHPMAILER_LANG['invalid_address']      = 'E-Mail wird nicht gesendet, die Adresse ist ungültig: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer wird nicht unterstützt.';
-$PHPMAILER_LANG['provide_address']      = 'Bitte geben Sie mindestens eine Empfänger E-Mailadresse an.';
-$PHPMAILER_LANG['recipients_failed']    = 'SMTP Fehler: Die folgenden Empfänger sind nicht korrekt: ';
+$PHPMAILER_LANG['provide_address']      = 'Bitte geben Sie mindestens eine Empfänger-E-Mailadresse an.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-Fehler: Die folgenden Empfänger sind nicht korrekt: ';
 $PHPMAILER_LANG['signing']              = 'Fehler beim Signieren: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'Verbindung zu SMTP Server fehlgeschlagen.';
-$PHPMAILER_LANG['smtp_error']           = 'Fehler vom SMTP Server: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'Verbindung zu SMTP-Server fehlgeschlagen.';
+$PHPMAILER_LANG['smtp_error']           = 'Fehler vom SMTP-Server: ';
 $PHPMAILER_LANG['variable_set']         = 'Kann Variable nicht setzen oder zurücksetzen: ';
 $PHPMAILER_LANG['extension_missing']    = 'Fehlende Erweiterung: ';


### PR DESCRIPTION
Fixed some smaller but aweful errors in German translation related to correct usage of a dash.