### PR TITLE
switch uniqid for random_bytes

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2138,7 +2138,7 @@ class PHPMailer
     {
         $body = '';
         //Create unique IDs and preset boundaries
-        $this->uniqueid = md5(uniqid(time()));
+        $this->uniqueid = md5(random_bytes(16));
         $this->boundary[1] = 'b1_' . $this->uniqueid;
         $this->boundary[2] = 'b2_' . $this->uniqueid;
         $this->boundary[3] = 'b3_' . $this->uniqueid;


### PR DESCRIPTION
As per the PHP docs, using uniqid is really not sensible when you need to generate unique values.

As per the PHP docs, switch to random_bytes() instead.