### PR TITLE
ability to create custom message IDs and boundaries

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2128,6 +2128,14 @@ class PHPMailer
     }
 
     /**
+     * Create unique ID
+     * @return string
+     */
+    protected function generateId() {
+        return md5(uniqid(time()));
+    }
+
+    /**
      * Assemble the message body.
      * Returns an empty string on failure.
      * @access public
@@ -2138,7 +2146,7 @@ class PHPMailer
     {
         $body = '';
         //Create unique IDs and preset boundaries
-        $this->uniqueid = md5(uniqid(time()));
+        $this->uniqueid = $this->generateId();
         $this->boundary[1] = 'b1_' . $this->uniqueid;
         $this->boundary[2] = 'b2_' . $this->uniqueid;
         $this->boundary[3] = 'b3_' . $this->uniqueid;


### PR DESCRIPTION
Due to a problem with Yandex FBL, single possible way to determine sender is a boundary, but there is no way to set it from outside, cuz even i'll do this ( by extending), it will be rewritten by createBody anyway. So I want to propose simple way to customize message boundary and message-id as bonus