### PR TITLE
Use long array syntax as PHP >= 5.0.0 is supported

### DIFF
--- a/class.phpmaileroauthgoogle.php
+++ b/class.phpmaileroauthgoogle.php
@@ -51,10 +51,10 @@ class PHPMailerOAuthGoogle
 
     private function getProvider()
     {
-        return new League\OAuth2\Client\Provider\Google([
+        return new League\OAuth2\Client\Provider\Google(array(
             'clientId' => $this->oauthClientId,
             'clientSecret' => $this->oauthClientSecret
-        ]);
+        ));
     }
 
     private function getGrant()
@@ -66,7 +66,7 @@ class PHPMailerOAuthGoogle
     {
         $provider = $this->getProvider();
         $grant = $this->getGrant();
-        return $provider->getAccessToken($grant, ['refresh_token' => $this->oauthRefreshToken]);
+        return $provider->getAccessToken($grant, array('refresh_token' => $this->oauthRefreshToken));
     }
 
     public function getOauth64()

--- a/extras/htmlfilter.php
+++ b/extras/htmlfilter.php
@@ -772,7 +772,7 @@ function tln_fixstyle($body, $pos, $trans_image_path, $block_external_images)
     tln_defang($contentTemp);
     tln_unspace($contentTemp);
 
-    $match   = Array('/\/\*.*\*\//',
+    $match   = array('/\/\*.*\*\//',
                     '/expression/i',
                     '/behaviou*r/i',
                     '/binding/i',
@@ -780,7 +780,7 @@ function tln_fixstyle($body, $pos, $trans_image_path, $block_external_images)
                     '/javascript/i',
                     '/script/i',
                     '/position/i');
-    $replace = Array('','idiocy', 'idiocy', 'idiocy', 'idiocy', 'idiocy', 'idiocy', '');
+    $replace = array('','idiocy', 'idiocy', 'idiocy', 'idiocy', 'idiocy', 'idiocy', '');
     $contentNew = preg_replace($match, $replace, $contentTemp);
     if ($contentNew !== $contentTemp) {
         $content = $contentNew;

--- a/get_oauth_token.php
+++ b/get_oauth_token.php
@@ -80,24 +80,24 @@ class Google extends AbstractProvider
 
         $params = array_merge(
             parent::getAuthorizationParameters($options),
-            array_filter([
+            array_filter(array(
                 'hd'          => $this->hostedDomain,
                 'access_type' => $this->accessType,
-		'scope'       => $this->scope,
+                'scope'       => $this->scope,
                 // if the user is logged in with more than one account ask which one to use for the login!
                 'authuser'    => '-1'
-            ])
+            ))
         );
         return $params;
     }
 
     protected function getDefaultScopes()
     {
-        return [
+        return array(
             'email',
             'openid',
             'profile',
-        ];
+        );
     }
 
     protected function getScopeSeparator()


### PR DESCRIPTION
https://github.com/PHPMailer/PHPMailer/blob/master/composer.json#L23 says you require PHP >= 5.0.0, but you've some files with short array syntax, which is new in PHP 5.4, so breaks support for PHP < 5.4...

Causes problems for inclusions when people are linting with PHP 5.3