### PR TITLE
Convert use of each() to foreach() for performance

### DIFF
--- a/extras/htmlfilter.php
+++ b/extras/htmlfilter.php
@@ -46,7 +46,7 @@ function tln_tagprint($tagname, $attary, $tagtype)
         $fulltag = '<' . $tagname;
         if (is_array($attary) && sizeof($attary)) {
             $atts = array();
-            while (list($attname, $attvalue) = each($attary)) {
+            foreach($attary as $attname => $attvalue) {
                 array_push($atts, "$attname=$attvalue");
             }
             $fulltag .= ' ' . join(' ', $atts);
@@ -520,7 +520,7 @@ function tln_fixatts(
     $trans_image_path,
     $block_external_images
 ) {
-    while (list($attname, $attvalue) = each($attary)) {
+    foreach($attary as $attname => $attvalue) {
         /**
          * See if this attribute should be removed.
          */


### PR DESCRIPTION
Convert use of each() to foreach() for performance
and also to avoid triggering deprecation alerts in PHP 7.2

This PR is against master, which is 5.2.22 presently. 
I notice this file isn't currently in 6.0 ... but if it "does" get added, then this change should be included there.