### PR TITLE
addAddress : Accept addresses like 'John Doe <john.doe@mail.com>'

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -816,6 +816,11 @@ class PHPMailer
      */
     public function addAddress($address, $name = '')
     {
+	if (strpos($address, '<')) {
+		$addAndName = preg_split('/<|>/', $address);
+		$name = trim($addAndName[0]);
+		$address = trim($addAndName[1]);
+	}
         return $this->addOrEnqueueAnAddress('to', $address, $name);
     }
 


### PR DESCRIPTION
With the class PHPMailer, I could call method addAddress with two ways:
- $mail -> addAddress('john.doe@mail.com', 'John Doe');
- $mail -> addAddress('john.doe@mail.com');

I've updated the addAddress method to accept the following option :
- $mail -> addAddress('John Doe <john.doe@mail.com>');

Which is RFC-2822 compliant.
