### PR TITLE
Date header should be more dynamic

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2024,10 +2024,7 @@ class PHPMailer
     {
         $result = '';
 
-        if ($this->MessageDate == '') {
-            $this->MessageDate = self::rfcDate();
-        }
-        $result .= $this->headerLine('Date', $this->MessageDate);
+        $result .= $this->headerLine('Date', $this->MessageDate == '' ? self::rfcDate() : $this->MessageDate);
 
         // To be created automatically by mail()
         if ($this->SingleTo) {


### PR DESCRIPTION
When a message is sent, unless the MessageDate is explicitly set, the Date header should always be set to the current rfcDate() value.

This is necessary for long-running processes that create a single PHPMailer instance, so all emails sent during the lifetime of the process don't have the same Date header value of the first email sent from the process.

This is important because Gmail in particular, uses the Date header value to show how long ago an email was sent when viewing the email.  (The list view in Gmail, however, uses the Received header value to show when an email was sent.)

These differing times will lead to confusion for users, often resulting in them trying to do several things like updating their timezone in Google's settings, or on their computers, which would result in no resolution.