### PR TITLE
Add support for Sendmail's DeliveryMode option

### DIFF
--- a/language/phpmailer.lang-am.php
+++ b/language/phpmailer.lang-am.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP -ի connect() ֆունկցիան
 $PHPMAILER_LANG['smtp_error']           = 'SMTP սերվերի սխալ: ';
 $PHPMAILER_LANG['variable_set']         = 'Չի հաջողվում ստեղծել կամ վերափոխել փոփոխականը: ';
 $PHPMAILER_LANG['extension_missing']    = 'Հավելվածը բացակայում է: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ar.php
+++ b/language/phpmailer.lang-ar.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() غير ممكن.';
 $PHPMAILER_LANG['smtp_error']           = 'خطأ على مستوى الخادم SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'لا يمكن تعيين أو إعادة تعيين متغير: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-az.php
+++ b/language/phpmailer.lang-az.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP serverinə qoşulma uğursuz old
 $PHPMAILER_LANG['smtp_error']           = 'SMTP serveri xətası: ';
 $PHPMAILER_LANG['variable_set']         = 'Dəyişənin quraşdırılması uğursuz oldu: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-be.php
+++ b/language/phpmailer.lang-be.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Памылка сувязі з SMTP-�
 $PHPMAILER_LANG['smtp_error']           = 'Памылка SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Нельга ўстанавіць або перамяніць значэнне пераменнай: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-bg.php
+++ b/language/phpmailer.lang-bg.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP провален connect().';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP сървърна грешка: ';
 $PHPMAILER_LANG['variable_set']         = 'Не може да се установи или възстанови променлива: ';
 $PHPMAILER_LANG['extension_missing']    = 'Липсва разширение: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ca.php
+++ b/language/phpmailer.lang-ca.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Ha fallat el SMTP Connect().';
 $PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'No s’ha pogut establir o restablir la variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ch.php
+++ b/language/phpmailer.lang-ch.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP 错误： 下面的 收件人失
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-cs.php
+++ b/language/phpmailer.lang-cs.php
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() selhal.';
 $PHPMAILER_LANG['smtp_error']           = 'Chyba SMTP serveru: ';
 $PHPMAILER_LANG['variable_set']         = 'Nelze nastavit nebo změnit proměnnou: ';
 $PHPMAILER_LANG['extension_missing']    = 'Chybí rozšíření: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-da.php
+++ b/language/phpmailer.lang-da.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP fejl: Følgende modtagere er for
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-de.php
+++ b/language/phpmailer.lang-de.php
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Verbindung zum SMTP-Server fehlgeschl
 $PHPMAILER_LANG['smtp_error']           = 'Fehler vom SMTP-Server: ';
 $PHPMAILER_LANG['variable_set']         = 'Kann Variable nicht setzen oder zurücksetzen: ';
 $PHPMAILER_LANG['extension_missing']    = 'Fehlende Erweiterung: ';
+$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Der eingestellte Sendmail DeliveryMode wird nicht unterstützt.';

--- a/language/phpmailer.lang-el.php
+++ b/language/phpmailer.lang-el.php
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Αποτυχία σύνδεσης σ�
 $PHPMAILER_LANG['smtp_error']           = 'Σφάλμα από τον SMTP Server: ';
 $PHPMAILER_LANG['variable_set']         = 'Αδυναμία ορισμού ή αρχικοποίησης μεταβλητής: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-eo.php
+++ b/language/phpmailer.lang-eo.php
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP konektado malsukcesis.';
 $PHPMAILER_LANG['smtp_error']           = 'Eraro de servilo SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Variablo ne pravalorizeblas aŭ ne repravalorizeblas: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-es.php
+++ b/language/phpmailer.lang-es.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falló.';
 $PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'No se pudo configurar la variable: ';
 $PHPMAILER_LANG['extension_missing']    = 'Extensión faltante: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-et.php
+++ b/language/phpmailer.lang-et.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() ebaõnnestus.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP serveri viga: ';
 $PHPMAILER_LANG['variable_set']         = 'Ei õnnestunud määrata või lähtestada muutujat: ';
 $PHPMAILER_LANG['extension_missing']    = 'Nõutud laiendus on puudu: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-fa.php
+++ b/language/phpmailer.lang-fa.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'خطا در اتصال به SMTP.';
 $PHPMAILER_LANG['smtp_error']           = 'خطا در SMTP Server: ';
 $PHPMAILER_LANG['variable_set']         = 'امکان ارسال یا ارسال مجدد متغیر‌ها وجود ندارد: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-fi.php
+++ b/language/phpmailer.lang-fi.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['encoding']             = 'Tuntematon koodaustyyppi: ';
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-fo.php
+++ b/language/phpmailer.lang-fo.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTP Feilur: Fylgjandi móttakarar mi
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-fr.php
+++ b/language/phpmailer.lang-fr.php
@@ -27,3 +27,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Échec de la connexion SMTP.';
 $PHPMAILER_LANG['smtp_error']           = 'Erreur du serveur SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Impossible d\'initialiser ou de réinitialiser une variable : ';
 $PHPMAILER_LANG['extension_missing']    = 'Extension manquante : ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-gl.php
+++ b/language/phpmailer.lang-gl.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro do servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Non puidemos axustar ou reaxustar a variábel: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-he.php
+++ b/language/phpmailer.lang-he.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() failed.';
 $PHPMAILER_LANG['smtp_error']           = 'שגיאת שרת SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'לא ניתן לקבוע או לשנות את המשתנה: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-hr.php
+++ b/language/phpmailer.lang-hr.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Spajanje na SMTP poslužitelj nije us
 $PHPMAILER_LANG['smtp_error']           = 'Greška SMTP poslužitelja: ';
 $PHPMAILER_LANG['variable_set']         = 'Ne mogu postaviti varijablu niti ju vratiti nazad: ';
 $PHPMAILER_LANG['extension_missing']    = 'Nedostaje proširenje: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-hu.php
+++ b/language/phpmailer.lang-hu.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Hiba az SMTP-kapcsolatban.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-szerver hiba: ';
 $PHPMAILER_LANG['variable_set']         = 'A következő változók beállítása nem sikerült: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Érvénytelen Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-id.php
+++ b/language/phpmailer.lang-id.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() gagal.';
 $PHPMAILER_LANG['smtp_error']           = 'Kesalahan peladen SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Tidak berhasil mengatur atau mengatur ulang variable : ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-it.php
+++ b/language/phpmailer.lang-it.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() fallita.';
 $PHPMAILER_LANG['smtp_error']           = 'Errore del server SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Impossibile impostare o resettare la variabile: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ja.php
+++ b/language/phpmailer.lang-ja.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['recipients_failed']    = 'SMTPエラー: 次の受信者アド�
 //$PHPMAILER_LANG['smtp_error']           = 'SMTP server error: ';
 //$PHPMAILER_LANG['variable_set']         = 'Cannot set or reset variable: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ka.php
+++ b/language/phpmailer.lang-ka.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'შეცდომა SMTP სერ�
 $PHPMAILER_LANG['smtp_error']           = 'SMTP სერვერის შეცდომა: ';
 $PHPMAILER_LANG['variable_set']         = 'შეუძლებელია შემდეგი ცვლადის შექმნა ან შეცვლა: ';
 $PHPMAILER_LANG['extension_missing']    = 'ბიბლიოთეკა არ არსებობს: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ko.php
+++ b/language/phpmailer.lang-ko.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 연결을 실패하였습니다.
 $PHPMAILER_LANG['smtp_error']           = 'SMTP 서버 오류: ';
 $PHPMAILER_LANG['variable_set']         = '변수 설정 및 초기화 불가: ';
 $PHPMAILER_LANG['extension_missing']    = '확장자 없음: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-lt.php
+++ b/language/phpmailer.lang-lt.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP susijungimo klaida';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP stoties klaida: ';
 $PHPMAILER_LANG['variable_set']         = 'Nepavyko priskirti reikšmės kintamajam: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-lv.php
+++ b/language/phpmailer.lang-lv.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP savienojuma kļūda';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP servera kļūda: ';
 $PHPMAILER_LANG['variable_set']         = 'Nevar piešķirt mainīgā vērtību: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ms.php
+++ b/language/phpmailer.lang-ms.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() telah gagal.';
 $PHPMAILER_LANG['smtp_error']           = 'Ralat pada pelayan SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Tidak boleh menetapkan atau menetapkan semula pembolehubah: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-nb.php
+++ b/language/phpmailer.lang-nb.php
@@ -23,3 +23,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP connect() feilet.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP server feil: ';
 $PHPMAILER_LANG['variable_set']         = 'Kan ikke skrive eller omskrive variabel: ';
 $PHPMAILER_LANG['extension_missing']    = 'Utvidelse mangler: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-nl.php
+++ b/language/phpmailer.lang-nl.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Verbinding mislukt.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfout: ';
 $PHPMAILER_LANG['variable_set']         = 'Kan de volgende variabele niet instellen of resetten: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-pl.php
+++ b/language/phpmailer.lang-pl.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() zakończone niepowodze
 $PHPMAILER_LANG['smtp_error']           = 'Błąd SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Nie można ustawić lub zmodyfikować zmiennej: ';
 $PHPMAILER_LANG['extension_missing']    = 'Brakujące rozszerzenie: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-pt.php
+++ b/language/phpmailer.lang-pt.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falhou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro de servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou redefinir a variável: ';
 $PHPMAILER_LANG['extension_missing']    = 'Extensão em falta: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-pt_br.php
+++ b/language/phpmailer.lang-pt_br.php
@@ -27,3 +27,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falhou.';
 $PHPMAILER_LANG['smtp_error']           = 'Erro de servidor SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Não foi possível definir ou redefinir a variável: ';
 $PHPMAILER_LANG['extension_missing']    = 'Extensão ausente: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ro.php
+++ b/language/phpmailer.lang-ro.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Conectarea la serverul SMTP a eșuat.
 $PHPMAILER_LANG['smtp_error']           = 'Eroare server SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'Nu se poate seta/reseta variabila. ';
 $PHPMAILER_LANG['extension_missing']    = 'Lipsește extensia: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-ru.php
+++ b/language/phpmailer.lang-ru.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Ошибка соединения с 
 $PHPMAILER_LANG['smtp_error']           = 'Ошибка SMTP-сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Невозможно установить или переустановить переменную: ';
 $PHPMAILER_LANG['extension_missing']    = 'Расширение отсутствует: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-sk.php
+++ b/language/phpmailer.lang-sk.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() zlyhalo.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP chyba serveru: ';
 $PHPMAILER_LANG['variable_set']         = 'Nemožno nastaviť alebo resetovať premennú: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-sl.php
+++ b/language/phpmailer.lang-sl.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Ne morem vzpostaviti povezave s SMTP 
 $PHPMAILER_LANG['smtp_error']           = 'Napaka SMTP strežnika: ';
 $PHPMAILER_LANG['variable_set']         = 'Ne morem nastaviti oz. ponastaviti spremenljivke: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-sr.php
+++ b/language/phpmailer.lang-sr.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Повезивање са SMTP сер
 $PHPMAILER_LANG['smtp_error']           = 'Грешка SMTP сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Није могуће задати променљиву, нити је вратити уназад: ';
 $PHPMAILER_LANG['extension_missing']    = 'Недостаје проширење: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-sv.php
+++ b/language/phpmailer.lang-sv.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() misslyckades.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP server fel: ';
 $PHPMAILER_LANG['variable_set']         = 'Kunde inte definiera eller återställa variabel: ';
 $PHPMAILER_LANG['extension_missing']    = 'Tillägg ej tillgängligt: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-tr.php
+++ b/language/phpmailer.lang-tr.php
@@ -28,3 +28,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP connect() fonksiyonu başarısı
 $PHPMAILER_LANG['smtp_error']           = 'SMTP sunucu hatası: ';
 $PHPMAILER_LANG['variable_set']         = 'Değişken ayarlanamadı ya da sıfırlanamadı: ';
 $PHPMAILER_LANG['extension_missing']    = 'Eklenti bulunamadı: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-uk.php
+++ b/language/phpmailer.lang-uk.php
@@ -25,3 +25,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Помилка з\'єднання і�
 $PHPMAILER_LANG['smtp_error']           = 'Помилка SMTP-сервера: ';
 $PHPMAILER_LANG['variable_set']         = 'Неможливо встановити або перевстановити змінну: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-vi.php
+++ b/language/phpmailer.lang-vi.php
@@ -24,3 +24,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'Lỗi kết nối với SMTP';
 $PHPMAILER_LANG['smtp_error']           = 'Lỗi máy chủ smtp ';
 $PHPMAILER_LANG['variable_set']         = 'Không thể thiết lập hoặc thiết lập lại biến: ';
 //$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-zh.php
+++ b/language/phpmailer.lang-zh.php
@@ -26,3 +26,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP 連線失敗';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP 伺服器錯誤: ';
 $PHPMAILER_LANG['variable_set']         = '無法設定或重設變數: ';
 $PHPMAILER_LANG['extension_missing']    = '遺失模組 Extension: ';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';

--- a/language/phpmailer.lang-zh_cn.php
+++ b/language/phpmailer.lang-zh_cn.php
@@ -26,3 +26,4 @@ $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP服务器连接失败。';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP服务器出错：';
 $PHPMAILER_LANG['variable_set']         = '无法设置或重置变量：';
 $PHPMAILER_LANG['extension_missing']    = '丢失模块 Extension：';
+//$PHPMAILER_LANG['unsupported_sendmail_delivery_mode'] = 'Unsupported Sendmail DeliveryMode.';


### PR DESCRIPTION
We use sendmail to send different kinds of mails. When we send bulk mails, e.g. a newsletter, we do this in the background (-O DeliveryMode=b), because it is faster in general. But when we directly send a single mail and the DNS-Lookup gets no reply, the website is stuck for 30 seconds and then dies with a timeout. So it's important to us to have the posibility to change the DeliveryMode within the code.