### PR TITLE
Add Content-ID for all disposition types

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2737,7 +2737,7 @@ class PHPMailer
                 4 => $type,
                 5 => false, // isStringAttachment
                 6 => $disposition,
-                7 => 0,
+                7 => $name,
             ];
         } catch (Exception $exc) {
             $this->setError($exc->getMessage());
@@ -2828,9 +2828,7 @@ class PHPMailer
                     $mime[] = sprintf('Content-Transfer-Encoding: %s%s', $encoding, static::$LE);
                 }
 
-                if ('inline' == $disposition) {
-                    $mime[] = sprintf('Content-ID: <%s>%s', $cid, static::$LE);
-                }
+                $mime[] = sprintf('Content-ID: <%s>%s', $cid, static::$LE);
 
                 // If a filename contains any of these chars, it should be quoted,
                 // but not otherwise: RFC2183 & RFC2045 5.1


### PR DESCRIPTION
The Content-ID param can be used to reference other attachments on the body of the email rather than just images. One can use the CID to link to a PDF for example with the

`$mailer->AddAttachment('/tmp/test.pdf', 'test');`

And on the email body:

`<a href="cid:test" target="_blank">click me</a>`

Gmail opens up the download dialog box (it does not work for ALL email clients, though)
