### PR TITLE
Show debug log only when tests fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
     fi
 
 script:
-  - ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist --bootstrap ./vendor/autoload.php
+  - ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
   - if [ "$CS_CHECK" = 1 ]; then ./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix; fi
 
 after_script:

--- a/composer.json
+++ b/composer.json
@@ -45,5 +45,10 @@
             "PHPMailer\\PHPMailer\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "PHPMailer\\Test\\": "test/"
+        }
+    },
     "license": "LGPL-2.1"
 }

--- a/test/DebugLogTestListener.php
+++ b/test/DebugLogTestListener.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * PHPMailer - language file tests.
+ *
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2010 - 2017 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test;
+
+class DebugLogTestListener extends \PHPUnit_Framework_BaseTestListener
+{
+    private static $debugLog = '';
+
+    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    {
+        echo self::$debugLog;
+    }
+
+    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    {
+        echo self::$debugLog;
+    }
+
+    public function startTest(\PHPUnit_Framework_Test $test)
+    {
+        self::$debugLog = '';
+    }
+
+    public static function debugLog($str)
+    {
+        self::$debugLog .= $str . PHP_EOL;
+    }
+}

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -70,6 +70,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
         }
         $this->Mail = new PHPMailer();
         $this->Mail->SMTPDebug = 3; //Full debug output
+        $this->Mail->Debugoutput = ['PHPMailer\Test\DebugLogTestListener', 'debugLog'];
         $this->Mail->Priority = 3;
         $this->Mail->Encoding = '8bit';
         $this->Mail->CharSet = 'iso-8859-1';

--- a/travis.phpunit.xml.dist
+++ b/travis.phpunit.xml.dist
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+         bootstrap="vendor/autoload.php"
          verbose="false"
          stopOnError="false"
          stopOnFailure="false"
@@ -8,7 +9,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
-         colors="false"
+         colors="true"
          forceCoversAnnotation="false"
          processIsolation="false">
     <testsuites>
@@ -16,6 +17,9 @@
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
+    <listeners>
+        <listener class="PHPMailer\Test\DebugLogTestListener" />
+    </listeners>
     <groups>
         <exclude>
             <group>languages</group>


### PR DESCRIPTION
As of yet the default debug log fills travis log with ten thousands line, unbearable to read and browse.

This PR shows the entire debug log, but only for failed tests.

I am willing to reorganize the source in `./test` dir, but better take one step at time.