### PR TITLE
Tests improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,5 +54,6 @@ jobs:
     - php: 7.0
     - php: 7.1
       env: CODE_COVERAGE=1
+    - php: 7.2
     - php: hhvm
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install:
 
 install:
   - REMOVE_PACKAGE="friendsofphp/php-cs-fixer"; if [ "$CS_CHECK" = 1 ]; then REMOVE_PACKAGE="phpunit/phpunit"; fi; composer remove --no-update --no-scripts --dev $REMOVE_PACKAGE
+  - composer remove --no-update --no-scripts --dev phpdocumentor/phpdocumentor
   - composer install
   - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - sudo apt-get install -y -qq postfix
 
 install:
-  - if [ "$CS_CHECK" = 1 ]; then composer remove --no-update --no-scripts --dev phpunit/phpunit; fi
+  - REMOVE_PACKAGE="friendsofphp/php-cs-fixer"; if [ "$CS_CHECK" = 1 ]; then REMOVE_PACKAGE="phpunit/phpunit"; fi; composer remove --no-update --no-scripts --dev $REMOVE_PACKAGE
   - composer install
   - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,5 @@
 language: php
 
-matrix:
-  include:
-    - php: 7.1
-      env: CODE_COVERAGE=1
-    - php: 7.0
-    - php: 5.6
-    - php: 5.5
-      env: CS_CHECK=1
-    - php: hhvm
-      dist: trusty
-
 cache:
   directories:
     - $HOME/.composer
@@ -20,6 +9,7 @@ before_install:
   - sudo apt-get install -y -qq postfix
 
 install:
+  - if [ "$CS_CHECK" = 1 ]; then composer remove --no-update --no-scripts --dev phpunit/phpunit; fi
   - composer install
   - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
 
@@ -39,10 +29,30 @@ before_script:
       echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > $(php --ini|grep -m 1 "ini files in:"|cut -d ":" -f 2)/sendmail.ini
     fi
 
-script:
-  - ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
-  - if [ "$CS_CHECK" = 1 ]; then ./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix; fi
+script: ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
 
 after_script:
   - if [ "$CODE_COVERAGE" = 1 ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
   - if [ "$CODE_COVERAGE" = 1 ]; then php ocular.phar code-coverage:upload --format=php-clover ../build/logs/clover.xml; fi
+
+stages:
+  - coding-standard
+  - test
+
+jobs:
+  include:
+    - stage: coding-standard
+      before_install:
+      before_script:
+      script: ./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix
+      after_script:
+      php: 5.5
+      env: CS_CHECK=1
+    - stage: test
+      php: 5.5
+    - php: 5.6
+    - php: 7.0
+    - php: 7.1
+      env: CODE_COVERAGE=1
+    - php: hhvm
+      dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpdocumentor/phpdocumentor": "2.*",
-        "phpunit/phpunit": "4.*",
+        "phpunit/phpunit": "^4.8 || ^5.7",
         "zendframework/zend-serializer": "2.7.*",
         "doctrine/annotations": "1.2.*",
         "zendframework/zend-eventmanager": "3.0.*",

--- a/test/PHPMailerLangTest.php
+++ b/test/PHPMailerLangTest.php
@@ -11,31 +11,27 @@
  * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
-namespace PHPMailer\PHPMailer;
+namespace PHPMailer\Test;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Check language files for missing or excess translations.
  */
-class PHPMailerLangTest extends \PHPUnit_Framework_TestCase
+final class PHPMailerLangTest extends TestCase
 {
     /**
      * Holds a PHPMailer instance.
      *
      * @var PHPMailer
      */
-    public $Mail;
-
-    /**
-     * Default include path.
-     *
-     * @var string
-     */
-    public $INCLUDE_DIR = '../';
+    private $Mail;
 
     /**
      * Run before each test is started.
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->Mail = new PHPMailer();
     }

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -10,47 +10,50 @@
  * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
-namespace PHPMailer\PHPMailer;
+namespace PHPMailer\Test;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * PHPMailer - PHP email transport unit test class.
  */
-class PHPMailerTest extends \PHPUnit_Framework_TestCase
+final class PHPMailerTest extends TestCase
 {
     /**
      * Holds the PHPMailer instance.
      *
      * @var PHPMailer
      */
-    public $Mail;
+    private $Mail;
 
     /**
      * Holds the SMTP mail host.
      *
      * @var string
      */
-    public $Host = '';
+    private $Host = '';
 
     /**
      * Holds the change log.
      *
      * @var string[]
      */
-    public $ChangeLog = [];
+    private $ChangeLog = [];
 
     /**
      * Holds the note log.
      *
      * @var string[]
      */
-    public $NoteLog = [];
+    private $NoteLog = [];
 
     /**
      * Default include path.
      *
      * @var string
      */
-    public $INCLUDE_DIR = '..';
+    private $INCLUDE_DIR = '..';
 
     /**
      * PIDs of any processes we need to kill.
@@ -62,7 +65,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
     /**
      * Run before each test is started.
      */
-    public function setUp()
+    protected function setUp()
     {
         $this->INCLUDE_DIR = dirname(__DIR__); //Default to the dir above the test dir, i.e. the project home dir
         if (file_exists($this->INCLUDE_DIR . '/test/testbootstrap.php')) {
@@ -117,7 +120,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
     /**
      * Run after each test is completed.
      */
-    public function tearDown()
+    protected function tearDown()
     {
         // Clean global variables
         $this->Mail = null;
@@ -133,7 +136,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
     /**
      * Build the body of the message in the appropriate format.
      */
-    public function buildBody()
+    private function buildBody()
     {
         $this->checkChanges();
 
@@ -210,7 +213,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
     /**
      * Check which default settings have been changed for the report.
      */
-    public function checkChanges()
+    private function checkChanges()
     {
         if (3 != $this->Mail->Priority) {
             $this->addChange('Priority', $this->Mail->Priority);
@@ -247,7 +250,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
      * @param string $sName
      * @param string $sNewValue
      */
-    public function addChange($sName, $sNewValue)
+    private function addChange($sName, $sNewValue)
     {
         $this->ChangeLog[] = [$sName, $sNewValue];
     }
@@ -257,7 +260,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
      *
      * @param string $sValue
      */
-    public function addNote($sValue)
+    private function addNote($sValue)
     {
         $this->NoteLog[] = $sValue;
     }
@@ -271,7 +274,7 @@ class PHPMailerTest extends \PHPUnit_Framework_TestCase
      *
      * @return bool
      */
-    public function setAddress($sAddress, $sName = '', $sType = 'to')
+    private function setAddress($sAddress, $sName = '', $sType = 'to')
     {
         switch ($sType) {
             case 'to':

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -39,7 +39,7 @@ final class PHPMailerTest extends TestCase
      *
      * @var string[]
      */
-    private $ChangeLog = array();
+    private $ChangeLog = [];
 
     /**
      * Holds the note log.

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -39,7 +39,7 @@ final class PHPMailerTest extends TestCase
      *
      * @var string[]
      */
-    private $ChangeLog = [];
+    private $ChangeLog = array();
 
     /**
      * Holds the note log.

--- a/travis.phpunit.xml.dist
+++ b/travis.phpunit.xml.dist
@@ -26,6 +26,11 @@
             <group>pop3</group>
         </exclude>
     </groups>
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>


### PR DESCRIPTION
- [x] Tighten test classes
- [x] Move `./test` source to specific namespace
- [x] Travis build stages: coding-standards are checked first, and are mandatory to run tests
- [x] Travis coding-standard build remove phpunit burden to speed up the build
- [x] Test against PHP 7.2
- [x] Add code-coverage whitelisting
- [x] Remove phpunit on coding-standard build
- [x] Remove php-cs-fixer on test builds
- [x] Remove phpdocumentor from Travis builds
- [x] Enable PHPUnit 5