### PR TITLE
Travis: fix cache dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 
 cache:
   directories:
-    - $HOME/.composer
+    - $HOME/.composer/cache
 
 before_install:
   - sudo apt-get update -qq

--- a/travis.phpunit.xml.dist
+++ b/travis.phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
          bootstrap="vendor/autoload.php"
-         verbose="false"
+         verbose="true"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"


### PR DESCRIPTION
On previous PR I specified a cache dir for composer download packages according to common standards `$HOME/.composer`, but [it resulted never working](https://travis-ci.org/PHPMailer/PHPMailer/jobs/275630512#L517) here.

After deep investigation I found out that composer is a bit [fancy](https://github.com/composer/composer/blob/1.5.2/src/Composer/Factory.php#L88-L122) about how to decide cache dir, and the reliable way to cache dependencies is to set cache dir to `$HOME/.composer/cache`.
The cache now [works](https://travis-ci.org/Slamdunk/PHPMailer/jobs/275785044#L517), saving us ~20 seconds per build (and a lot of external expensive calls).

A second change is in place: on Travis be verbose about tests so we can track easily skipped/incomplete/risky tests.