### PR TITLE
Travis-CI no longer supports PHP 5.3, so remove it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
 matrix:
   include:
     - php: hhvm


### PR DESCRIPTION
Before submitting your pull request, be sure your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer fix`

And committing eventual changes.
