### PR TITLE
Make idnSupported() static

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -973,7 +973,7 @@ class PHPMailer
         }
         $params = [$kind, $address, $name];
         // Enqueue addresses with IDN until we know the PHPMailer::$CharSet.
-        if ($this->has8bitChars(substr($address, ++$pos)) and $this->idnSupported()) {
+        if ($this->has8bitChars(substr($address, ++$pos)) and static::idnSupported()) {
             if ('Reply-To' != $kind) {
                 if (!array_key_exists($address, $this->RecipientsQueue)) {
                     $this->RecipientsQueue[$address] = $params;
@@ -1124,7 +1124,7 @@ class PHPMailer
         // Don't validate now addresses with IDN. Will be done in send().
         $pos = strrpos($address, '@');
         if (false === $pos or
-            (!$this->has8bitChars(substr($address, ++$pos)) or !$this->idnSupported()) and
+            (!$this->has8bitChars(substr($address, ++$pos)) or !static::idnSupported()) and
             !static::validateAddress($address)) {
             $error_message = $this->lang('invalid_address') . " (setFrom) $address";
             $this->setError($error_message);
@@ -1249,7 +1249,7 @@ class PHPMailer
      *
      * @return bool `true` if required functions for IDN support are present
      */
-    public function idnSupported()
+    public static function idnSupported()
     {
         return function_exists('idn_to_ascii') and function_exists('mb_convert_encoding');
     }
@@ -1272,7 +1272,7 @@ class PHPMailer
     {
         // Verify we have required functions, CharSet, and at-sign.
         $pos = strrpos($address, '@');
-        if ($this->idnSupported() and
+        if (static::idnSupported() and
             !empty($this->CharSet) and
             false !== $pos
         ) {

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -2192,7 +2192,7 @@ EOT;
         );
 
         $this->Mail->ConfirmReadingTo = 'test@françois.ch';  //Address with IDN
-        if ($this->Mail->idnSupported()) {
+        if (PHPMailer::idnSupported()) {
             $this->assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
             $this->assertEquals(
                 'test@xn--franois-xxa.ch',
@@ -2209,7 +2209,7 @@ EOT;
      */
     public function testConvertEncoding()
     {
-        if (!$this->Mail->idnSupported()) {
+        if (!PHPMailer::idnSupported()) {
             $this->markTestSkipped('intl and/or mbstring extensions are not available');
         }
 
@@ -2260,7 +2260,7 @@ EOT;
      */
     public function testDuplicateIDNRemoved()
     {
-        if (!$this->Mail->idnSupported()) {
+        if (!PHPMailer::idnSupported()) {
             $this->markTestSkipped('intl and/or mbstring extensions are not available');
         }
 


### PR DESCRIPTION
Upgrade guide and changelog say that idnSupported() is now static, but it actually isn't.

Probably this PR should wait v6.1 or other version where breaking changes are OK.