### PR TITLE
update git export ignore with new files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,10 +4,14 @@
 /test export-ignore
 /examples export-ignore
 /.gitattributes export-ignore
+/.github export-ignore
 /.gitignore export-ignore
+/.phan export-ignore
+/.php_cs export-ignore
 /.scrutinizer.yml export-ignore
 /.travis.yml export-ignore
-/travis.phpunit.xml.dist export-ignore
-/SECURITY.md export-ignore
+/UPGRADING.md export-ignore
 /changelog.md export-ignore
-/README.md export-ignore
+/composer.json export-ignore
+/phpdoc.dist.xml export-ignore
+/travis.phpunit.xml.dist export-ignore


### PR DESCRIPTION
the git export (and thus github .zip) contains now only source needed for library to operate.

i was hesitant about documentation, but as changelog and readme were already excluded, excluded other docs as well.

and if you are wondering, then composer.phar does not need composer.json to be exported for composer to work.