### PR TITLE
Add Sender to MIMEHeader

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2273,6 +2273,12 @@ class PHPMailer
 
         $result .= $this->addrAppend('From', [[trim($this->From), $this->FromName]]);
 
+        if ('' == $this->Sender || $this->From == $this->Sender) {
+            // Do not set Sender header
+        } else {
+            $result .= $this->addrAppend('Sender', [[$this->Sender, '']]);
+        }
+
         // sendmail and mail() extract Cc from the header before sending
         if (count($this->cc) > 0) {
             $result .= $this->addrAppend('Cc', $this->cc);


### PR DESCRIPTION
The `Sender` header is not sent. This PR fixes this.

PS:

1. I ran `./vendor/bin/php-cs-fixer`
2. I could not get PHPUnit to run, lots of errors. If somebody can tell me the exact command, I can test my commit. I used: `./vendor/bin/phpunit --bootstrap=test/bootstrap.php test`
