### PR TITLE
Update phpmailer.lang-eo.php

### DIFF
--- a/language/phpmailer.lang-eo.php
+++ b/language/phpmailer.lang-eo.php
@@ -22,4 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Eraro de subskribo: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP konektado malsukcesis.';
 $PHPMAILER_LANG['smtp_error']           = 'Eraro de servilo SMTP : ';
 $PHPMAILER_LANG['variable_set']         = 'Variablo ne pravalorizeblas aŭ ne repravalorizeblas: ';
-//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+$PHPMAILER_LANG['extension_missing']    = 'Mankas etendo: ';


### PR DESCRIPTION
Adding the missing translation.
Due to the flexibility of Esperanto, there is actually many ways of saying "Extension missing". I selected this one, even tho it's not the literal translation (what would rather be more like "Manki etendo" as the "missing" is used as an adjective, not as a verb), because I think this way is much more understandable.