### PR TITLE
composer.json: add dependency on the PHP "filter" extension.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "ext-ctype": "*"
+        "ext-ctype": "*",
+        "ext-filter": "*"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",


### PR DESCRIPTION
Many of the PHP extensions used by PHPMailer are optional, in one of
two senses. Either there is a fallback if the extension is not
present, or the use of the extension is avoidable entirely. For
example, there is a fallback parser if "imap_rfc822_parse_adrlist" is
not available, and OpenSSL is not needed unless encryption is used;
therefore neither are hard dependencies.

The filter extension, on the other hand, is unavoidable. It is used
unconditionally, with no fallbacks, in (for example) the "isValidHost"
function. This commit adds "ext-filter" to composer.json, to document
the dependency and to help out composer users.

Closes: https://github.com/PHPMailer/PHPMailer/issues/1298