### PR TITLE
Add flag for using copiedHeaderFields and config for using extra headers in DKIM signature

### DIFF
--- a/examples/DKIM_sign.phps
+++ b/examples/DKIM_sign.phps
@@ -32,6 +32,10 @@ $mail->DKIM_selector = 'phpmailer';
 $mail->DKIM_passphrase = '';
 //The identity you're signing as - usually your From address
 $mail->DKIM_identity = $mail->From;
+//Suppress listing signed header fields in signature, defaults to true for debugging purpose
+$this->mailer->DKIM_copyHeaderFields = false;
+//Optionally you can add extra headers for signing to meet special requirements
+$this->mailer->DKIM_extraHeaders = ['List-Unsubscribe', 'List-Help'];
 
 //When you send, the DKIM settings will be used to sign the message
 if (!$mail->send()) {

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1911,6 +1911,92 @@ EOT;
     }
 
     /**
+     * DKIM copied header fields tests.
+     *
+     * @group dkim
+     *
+     * @see https://tools.ietf.org/html/rfc6376#section-3.5
+     */
+    public function testDKIMOptionalHeaderFieldsCopy()
+    {
+        $privatekeyfile = 'dkim_private.pem';
+        $pk = openssl_pkey_new(
+            [
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]
+        );
+        openssl_pkey_export_to_file($pk, $privatekeyfile);
+        $this->Mail->DKIM_private = 'dkim_private.pem';
+
+        //Example from https://tools.ietf.org/html/rfc6376#section-3.5
+        $from = 'from@example.com';
+        $to = 'to@example.com';
+        $date = 'date';
+        $subject = 'example';
+
+        $headerLines = "From:$from\r\nTo:$to\r\nDate:$date\r\n";
+        $copyHeaderFields = "\tz=From:$from\r\n\t|To:$to\r\n\t|Date:$date\r\n\t|Subject:=20$subject;\r\n";
+
+        $this->Mail->DKIM_copyHeaderFields = true;
+        $this->assertContains(
+            $copyHeaderFields,
+            $this->Mail->DKIM_Add($headerLines, $subject, ''),
+            'DKIM header with copied header fields incorrect'
+        );
+
+        $this->Mail->DKIM_copyHeaderFields = false;
+        $this->assertNotContains(
+            $copyHeaderFields,
+            $this->Mail->DKIM_Add($headerLines, $subject, ''),
+            'DKIM header without copied header fields incorrect'
+        );
+    }
+
+    /**
+     * DKIM signing extra headers tests.
+     *
+     * @group dkim
+     */
+    public function testDKIMExtraHeaders()
+    {
+        $privatekeyfile = 'dkim_private.pem';
+        $pk = openssl_pkey_new(
+            [
+                'private_key_bits' => 2048,
+                'private_key_type' => OPENSSL_KEYTYPE_RSA,
+            ]
+        );
+        openssl_pkey_export_to_file($pk, $privatekeyfile);
+        $this->Mail->DKIM_private = 'dkim_private.pem';
+
+        //Example from https://tools.ietf.org/html/rfc6376#section-3.5
+        $from = 'from@example.com';
+        $to = 'to@example.com';
+        $date = 'date';
+        $subject = 'example';
+        $anyHeader = 'foo';
+        $unsubscribeUrl = '<https://www.example.com/unsubscribe/?newsletterId=anytoken&amp;actionToken=anyToken' .
+                            '&amp;otherParam=otherValue&amp;anotherParam=anotherVeryVeryVeryLongValue>';
+
+        $this->Mail->addCustomHeader('X-AnyHeader', $anyHeader);
+        $this->Mail->addCustomHeader('Baz', 'bar');
+        $this->Mail->addCustomHeader('List-Unsubscribe', $unsubscribeUrl);
+
+        $this->Mail->DKIM_extraHeaders = ['Baz', 'List-Unsubscribe'];
+
+        $headerLines = "From:$from\r\nTo:$to\r\nDate:$date\r\n";
+        $headerLines .= "X-AnyHeader:$anyHeader\r\nBaz:bar\r\n";
+        $headerLines .= 'List-Unsubscribe:' . $this->Mail->encodeHeader($unsubscribeUrl) . "\r\n";
+
+        $headerFields = 'h=From:To:Date:Subject:Baz:List-Unsubscribe';
+
+        $result = $this->Mail->DKIM_Add($headerLines, $subject, '');
+
+        $this->assertContains($headerFields, $result, 'DKIM header with extra headers incorrect');
+    }
+
+    /**
      * DKIM Signing tests.
      *
      * @requires extension openssl

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1951,6 +1951,8 @@ EOT;
             $this->Mail->DKIM_Add($headerLines, $subject, ''),
             'DKIM header without copied header fields incorrect'
         );
+
+        unlink($privatekeyfile);
     }
 
     /**
@@ -1977,7 +1979,7 @@ EOT;
         $subject = 'example';
         $anyHeader = 'foo';
         $unsubscribeUrl = '<https://www.example.com/unsubscribe/?newsletterId=anytoken&amp;actionToken=anyToken' .
-                            '&amp;otherParam=otherValue&amp;anotherParam=anotherVeryVeryVeryLongValue>';
+                            '&otherParam=otherValue&anotherParam=anotherVeryVeryVeryLongValue>';
 
         $this->Mail->addCustomHeader('X-AnyHeader', $anyHeader);
         $this->Mail->addCustomHeader('Baz', 'bar');
@@ -1994,6 +1996,8 @@ EOT;
         $result = $this->Mail->DKIM_Add($headerLines, $subject, '');
 
         $this->assertContains($headerFields, $result, 'DKIM header with extra headers incorrect');
+
+        unlink($privatekeyfile);
     }
 
     /**


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc6376#section-3.5:
"Copied header fields (dkim-quoted-printable, but see description;
OPTIONAL, default is null). ..."
"Copied header field values are for diagnostic use."

Disabling this information can save network traffic.
For backward compatibility its enabled by default.

In addition you can add custom extra headers to the DKIM signature, for instance `List-Unsubscribe` for newsletter, which is recommend by [CSA](https://certified-senders.org/)
