### PR TITLE
Fix warning under PHP 7.3.x+: filter_var(): explicit use of FILTER_FL…

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3628,7 +3628,7 @@ class PHPMailer
             //Is it a valid IPv4 address?
             return (bool) filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4);
         }
-        if (filter_var('http://' . $host, FILTER_VALIDATE_URL, FILTER_FLAG_HOST_REQUIRED)) {
+        if (filter_var('http://' . $host, FILTER_VALIDATE_URL)) {
             //Is it a syntactically valid hostname?
             return true;
         }


### PR DESCRIPTION
…AG_SCHEME_REQUIRED and FILTER_FLAG_HOST_REQUIRED is deprecated.

FILTER_VALIDATE_URL already checks the host, thus no need to explicitly pass FILTER_FLAG_HOST_REQUIRED (hence the warning).

This fixes #1548
