### PR TITLE
Fix missing Arabic translations

### DIFF
--- a/language/phpmailer.lang-ar.php
+++ b/language/phpmailer.lang-ar.php
@@ -24,4 +24,4 @@ $PHPMAILER_LANG['signing']              = 'خطأ في التوقيع: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() غير ممكن.';
 $PHPMAILER_LANG['smtp_error']           = 'خطأ على مستوى الخادم SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'لا يمكن تعيين أو إعادة تعيين متغير: ';
-//$PHPMAILER_LANG['extension_missing']    = 'Extension missing: ';
+$PHPMAILER_LANG['extension_missing']    = 'الأضافة غير موجودة: ';

--- a/language/phpmailer.lang-ar.php
+++ b/language/phpmailer.lang-ar.php
@@ -24,4 +24,4 @@ $PHPMAILER_LANG['signing']              = 'خطأ في التوقيع: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() غير ممكن.';
 $PHPMAILER_LANG['smtp_error']           = 'خطأ على مستوى الخادم SMTP: ';
 $PHPMAILER_LANG['variable_set']         = 'لا يمكن تعيين أو إعادة تعيين متغير: ';
-$PHPMAILER_LANG['extension_missing']    = 'الأضافة غير موجودة: ';
+$PHPMAILER_LANG['extension_missing']    = 'الإضافة غير موجودة: ';


### PR DESCRIPTION
You probably want to squash before merging. `extension_missing` was missing.