### PR TITLE
6.0 ical

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -49,6 +49,7 @@ This is a major update that breaks backwards compatibility.
 * Trap low-level errors in SMTP, reports via debug output
 * More reliable folding of message headers
 * Inject your own SMTP implementation via `setSMTPInstance()` instead of having to subclass and override `getSMTPInstance()`.
+* Ical support now works with attachments.
 
 ## Version 5.2.24 (July 26th 2017)
 * **SECURITY** Fix XSS vulnerability in one of the code examples, [CVE-2017-11503](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2017-11503). The `code_generator.phps` example did not filter user input prior to output. This file is distributed with a `.phps` extension, so it it not normally executable unless it is explicitly renamed, so it is safe by default. There was also an undisclosed potential XSS vulnerability in the default exception handler (unused by default). Patches for both issues kindly provided by Patrick Monnerat of the Fedora Project.

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3781,6 +3781,7 @@ class PHPMailer
             'png'   => 'image/png',
             'tiff'  => 'image/tiff',
             'tif'   => 'image/tiff',
+            'svg'   => 'image/svg+xml',
             'eml'   => 'message/rfc822',
             'css'   => 'text/css',
             'html'  => 'text/html',
@@ -3803,7 +3804,7 @@ class PHPMailer
             'qt'    => 'video/quicktime',
             'rv'    => 'video/vnd.rn-realvideo',
             'avi'   => 'video/x-msvideo',
-            'movie' => 'video/x-sgi-movie'
+            'movie' => 'video/x-sgi-movie',
         ];
         if (array_key_exists(strtolower($ext), $mimes)) {
             return $mimes[strtolower($ext)];

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2235,11 +2235,23 @@ class PHPMailer
             case 'inline_attach':
             case 'alt_attach':
             case 'alt_inline_attach':
+                if (!empty($this->Ical)) {
+                    $result .= $this->headerLine(
+                        'Content-Class',
+                        'urn:content-classes:calendarmessage'
+                    );
+                }
                 $result .= $this->headerLine('Content-Type', 'multipart/mixed;');
                 $result .= $this->textLine("\tboundary=\"" . $this->boundary[1] . '"');
                 break;
             case 'alt':
             case 'alt_inline':
+                if (!empty($this->Ical)) {
+                    $result .= $this->headerLine(
+                        'Content-Class',
+                        'urn:content-classes:calendarmessage'
+                    );
+                }
                 $result .= $this->headerLine('Content-Type', 'multipart/alternative;');
                 $result .= $this->textLine("\tboundary=\"" . $this->boundary[1] . '"');
                 break;
@@ -2388,7 +2400,17 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[1], '', 'text/calendar; method=REQUEST', '');
+                    $body .= $this->getBoundary(
+                        $this->boundary[2],
+                        '',
+                        'text/calendar; method=REQUEST',
+                        '',
+                        //@link https://blogs.msdn.microsoft.com/webdav_101/2008/02/26/building-vcalendar-content-without-an-microsoft-api-is-not-supported-by-ms/
+                        $this->headerLine(
+                            'Content-Class',
+                            'urn:content-classes:calendarmessage'
+                        )
+                    );
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                     $body .= static::$LE;
                 }
@@ -2423,7 +2445,17 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[2], '', 'text/calendar; method=REQUEST', '');
+                    $body .= $this->getBoundary(
+                        $this->boundary[2],
+                        '',
+                        'text/calendar; method=REQUEST',
+                        '',
+                        //@link https://blogs.msdn.microsoft.com/webdav_101/2008/02/26/building-vcalendar-content-without-an-microsoft-api-is-not-supported-by-ms/
+                        $this->headerLine(
+                            'Content-Class',
+                            'urn:content-classes:calendarmessage'
+                        )
+                    );
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                 }
                 $body .= $this->endBoundary($this->boundary[2]);
@@ -2525,10 +2557,11 @@ class PHPMailer
      * @param string $charSet
      * @param string $contentType
      * @param string $encoding
+     * @param string $extraheaders Any additional headers for this MIME part
      *
      * @return string
      */
-    protected function getBoundary($boundary, $charSet, $contentType, $encoding)
+    protected function getBoundary($boundary, $charSet, $contentType, $encoding, $extraheaders = '')
     {
         $result = '';
         if ('' == $charSet) {
@@ -2546,6 +2579,9 @@ class PHPMailer
         // RFC1341 part 5 says 7bit is assumed if not specified
         if ('7bit' != $encoding) {
             $result .= $this->headerLine('Content-Transfer-Encoding', $encoding);
+        }
+        if (!empty($extraheaders)) {
+            $result .= trim($extraheaders) . static::$LE;
         }
         $result .= static::$LE;
 


### PR DESCRIPTION
Before submitting your pull request, check whether your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix `

And committing eventual changes. It's important that this command uses the specific version of php-cs-fixer configured for PHPMailer, so run `composer install` within the PHPMailer folder to use the exact version it needs.
if (!lca;.isEmpty($this->Ical)) {
                    $body .= $this->getBoundary($this->boundary[1], '', 'text/calendar; method=REQUEST', '');
                    $body .= $this->getBoundary(
                        $this->boundary[2],
                        '',
                        'text/calendar; method=REQUEST',
                        '',
                
                        $this->headerLine(
                            'Content-Class',
                            'urn:content-classes:calendarmessage'
                        )
                    );
                    $body .= $this->encodeString($this->Ical, $this->Encoding);
                    $body .= static::$LE;
                }