### PR TITLE
Add support for one single attachment

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2932,7 +2932,7 @@ class PHPMailer
                 // but not otherwise: RFC2183 & RFC2045 5.1
                 // Fixes a warning in IETF's msglint MIME checker
                 // Allow for bypassing the Content-Disposition header totally
-                if (!(empty($disposition)) && ($disposition != "attach_one")) {
+                if (!(empty($disposition)) && ($disposition != 'attach_one')) {
                     $encoded_name = $this->encodeHeader($this->secureHeader($name));
                     if (preg_match('/[ \(\)<>@,;:\\"\/\[\]\?=]/', $encoded_name)) {
                         $mime[] = sprintf(

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3310,6 +3310,7 @@ class PHPMailer
             5 => true, // isStringAttachment
             6 => $disposition,
             7 => 0,
+            8 => '', // description
         ];
     }
 
@@ -3360,6 +3361,7 @@ class PHPMailer
             5 => false, // isStringAttachment
             6 => $disposition,
             7 => $cid,
+            8 => '', // description
         ];
 
         return true;
@@ -3405,6 +3407,7 @@ class PHPMailer
             5 => true, // isStringAttachment
             6 => $disposition,
             7 => $cid,
+            8 => '', // description
         ];
 
         return true;


### PR DESCRIPTION
French administration for handling electronic invoices over email
has a specific format. They require the use of a single attachment
without any additional text for the various fields and headers.

The following should be used in order to be compatible with their
specific enveloppe of email and attachment:
   $mail->AllowEmptyName = true;
   $mail->addAttachment($file, '', 'BASE64', 'Application/EDI-consent', 'attach_one', 'nature/norme');
