### PR TITLE
fixed catching detail enhanced error code

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -925,7 +925,7 @@ class SMTP
         $this->last_reply = $this->get_lines();
         // Fetch SMTP code and possible error code explanation
         $matches = [];
-        if (preg_match('/^([0-9]{3})[ -](?:([0-9]\\.[0-9]\\.[0-9]) )?/', $this->last_reply, $matches)) {
+        if (preg_match('/^([0-9]{3})[ -](?:([0-9]\\.[0-9]\\.[0-9]{1,2}) )?/', $this->last_reply, $matches)) {
             $code = $matches[1];
             $code_ex = (count($matches) > 2 ? $matches[2] : null);
             // Cut off error code from each response line


### PR DESCRIPTION
https://tools.ietf.org/html/rfc7505 


```
220 smtpd.xxx.xxx ESMTP Postfix (Debian/GNU)
helo localhost
250 smtpd.xxx.xxx
mail from:noreply@xx.com
250 2.1.0 Ok
rcpt to:zz@yahooo.com
556 5.1.10 <zz@yahooo.com>: Recipient address rejected: Domain yahooo.com does not accept mail (nullMX)
quit
221 2.0.0 Bye
Connection closed by foreign host.
```

error from SMTP 556 5.1.10
```

X.1.10 | Recipient address has null MX | 556 | This status code is returned when the associated address is marked as invalid using a null MX. | [RFC7505] (Standards Track); [RFC7504] (Standards Track) | J. Levine, M. Delany, J. Klensin | IESG
```
https://github.com/PHPMailer/PHPMailer/blob/258931af903b10842d1a066b2bb1658cf10ddc62/src/SMTP.php#L928

the regex fails to catch it.

this patch to catch the **detail** code that count > 1 digit 

