### PR TITLE
DKIM replace boundary tab with whitespace

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4304,7 +4304,8 @@ class PHPMailer
         }
         // Normalize line endings to CRLF
         $body = static::normalizeBreaks($body, "\r\n");
-
+        // Remove TABS from boundary
+        $body=preg_replace('/\t+boundary/', ' boundary', $body);
         //Reduce multiple trailing line breaks to a single one
         return rtrim($body, "\r\n") . "\r\n";
     }


### PR DESCRIPTION
The boundary for DKIM is not correct, at the moment it´s a tab it should be a whitespace.
This fixes #1352 and fixes #1655 .

