### PR TITLE
Update composer license to `LGPL-2.1-only`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,5 +51,5 @@
             "PHPMailer\\Test\\": "test/"
         }
     },
-    "license": "LGPL-2.1"
+    "license": "LGPL-2.1-only"
 }


### PR DESCRIPTION
As per SPDX License List, previously used `LGPL-2.1` is deprecated [[1]].

I'm not 100% sure, but assumed you indeed are under `LGPL-2.1-only` and not `LGPL-2.1-or-later`.

[1]: https://spdx.org/licenses/LGPL-2.1.html
