### PR TITLE
Create phpmailer.lang-af.php

### DIFF
--- a/language/phpmailer.lang-af.php
+++ b/language/phpmailer.lang-af.php
@@ -22,4 +22,4 @@ $PHPMAILER_LANG['signing']              = 'Ondertekening Fout: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP-verbinding () misluk.';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-bediener fout: ';
 $PHPMAILER_LANG['variable_set']         = 'Kan nie veranderlike instel of herstel nie: ';
-//$PHPMAILER_LANG['extension_missing']    = 'Uitbreiding ontbreek: ';
+$PHPMAILER_LANG['extension_missing']    = 'Uitbreiding ontbreek: ';

--- a/language/phpmailer.lang-af.php
+++ b/language/phpmailer.lang-af.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Afrikaans PHPMailer language file: refer to English translation for definitive list
+ * @package PHPMailer
+ */
+
+$PHPMAILER_LANG['authenticate']         = 'SMTP-fout: kon nie geverifieer word nie.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-fout: kon nie aan SMTP-verbind nie.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-fout: data nie aanvaar nie.';
+$PHPMAILER_LANG['empty_message']        = 'Boodskapliggaam leeg.';
+$PHPMAILER_LANG['encoding']             = 'Onbekende kodering: ';
+$PHPMAILER_LANG['execute']              = 'Kon nie uitvoer nie: ';
+$PHPMAILER_LANG['file_access']          = 'Kon nie lêer oopmaak nie: ';
+$PHPMAILER_LANG['file_open']            = 'Lêerfout: Kon nie lêer oopmaak nie: ';
+$PHPMAILER_LANG['from_failed']          = 'Die volgende Van adres misluk: ';
+$PHPMAILER_LANG['instantiate']          = 'Kon nie posfunksie instansieer nie.';
+$PHPMAILER_LANG['invalid_address']      = 'Ongeldige adres: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' mailer word nie ondersteun nie.';
+$PHPMAILER_LANG['provide_address']      = 'U moet ten minste een ontvanger e-pos adres verskaf.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-fout: Die volgende ontvangers het misluk: ';
+$PHPMAILER_LANG['signing']              = 'Ondertekening Fout: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP-verbinding () misluk.';
+$PHPMAILER_LANG['smtp_error']           = 'SMTP-bediener fout: ';
+$PHPMAILER_LANG['variable_set']         = 'Kan nie veranderlike instel of herstel nie: ';
+//$PHPMAILER_LANG['extension_missing']    = 'Uitbreiding ontbreek: ';


### PR DESCRIPTION
Afrikaans PHPMailer language file this can be easily verified using google translate except 'connect_host' => 'SMTP-fout: kon nie aan SMTP-gasheer koppel nie.', which is better said like 'SMTP-fout: kon nie aan SMTP-verbind nie.'

Before submitting your pull request, check whether your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix `

And committing eventual changes. It's important that this command uses the specific version of php-cs-fixer configured for PHPMailer, so run `composer install` within the PHPMailer folder to use the exact version it needs.
