### PR TITLE
Strict check XMailer with empty string

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -527,9 +527,9 @@ class PHPMailer
 
     /**
      * What to put in the X-Mailer header.
-     * Options: An empty string for PHPMailer default, whitespace for none, or a string to use.
+     * Options: An empty string for PHPMailer default, whitespace/null for none, or a string to use.
      *
-     * @var string
+     * @var string|null
      */
     public $XMailer = '';
 
@@ -2380,7 +2380,7 @@ class PHPMailer
         if (null !== $this->Priority) {
             $result .= $this->headerLine('X-Priority', $this->Priority);
         }
-        if ('' == $this->XMailer) {
+        if ('' === $this->XMailer) {
             $result .= $this->headerLine(
                 'X-Mailer',
                 'PHPMailer ' . self::VERSION . ' (https://github.com/PHPMailer/PHPMailer)'


### PR DESCRIPTION
Motivation:
https://github.com/PHPMailer/PHPMailer/issues/184
to disable X-Mailer header it is necessary to set `XMailer` to a whitespace.
```php
$mailer = new PHPMailer();
$mailer->XMailer = ' ';
```

Without breaking a backward compatibility too much, strict check with an empty string allows to use `null` in a similar manner to whitespace:

```php
$mailer = new PHPMailer();
$mailer->XMailer = null;
```

`trim(null)` return `''`, so code inside this condition won't get executed:

https://github.com/PHPMailer/PHPMailer/blob/511413a6eaeb167fa88282d437766d34510548b8/src/PHPMailer.php#L2390-L2392