### PR TITLE
addrFormat: Ensure RFC 2822 compliance for addresses without name.

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2133,7 +2133,7 @@ class PHPMailer
     public function addrFormat($addr)
     {
         if (empty($addr[1])) { // No name provided
-            return $this->secureHeader($addr[0]);
+            return '<' . $this->secureHeader($addr[0]) . '>';
         }
 
         return $this->encodeHeader($this->secureHeader($addr[1]), 'phrase') . ' <' . $this->secureHeader(


### PR DESCRIPTION
Per https://tools.ietf.org/html/rfc2822#section-3.4, even a naked
address without display name needs to be enclosed in angle brackets.
At least spamassassin may not like naked addresses, e.g. if the rule
TO_NO_BRKTS_NORDNS_HTML is triggered.