### PR TITLE
PHP 7.4 Fix: Do not run get_magic_quotes_runtime anymore

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2711,7 +2711,7 @@ class PHPMailer
             if (!self::isPermittedPath($path) or !file_exists($path)) {
                 throw new phpmailerException($this->lang('file_open') . $path, self::STOP_CONTINUE);
             }
-            $magic_quotes = get_magic_quotes_runtime();
+            $magic_quotes = PHP_VERSION_ID < 70400 && get_magic_quotes_runtime();
             if ($magic_quotes) {
                 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
                     set_magic_quotes_runtime(false);


### PR DESCRIPTION
PHP 7.4 will start to throw deprecation notices when magic quote functions are use. A simple version check before calling them will fix this. 

I'd be grateful if you could review it. The PR tries to make the changes as minimally as possible.

Thaak you. 