### PR TITLE
Try to help #1824

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require": {
         "php": ">=5.5.0",
         "ext-ctype": "*",
-        "ext-filter": "*"
+        "ext-filter": "*",
+        "psr/simple-cache": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.2",

--- a/examples/benchmark_mime_cache.phps
+++ b/examples/benchmark_mime_cache.phps
@@ -18,7 +18,6 @@ require '../vendor/autoload.php';
 // $ curl https://sample-videos.com/img/Sample-jpg-image-200kb.jpg > /tmp/200kb.jpg
 // $ curl https://sample-videos.com/img/Sample-jpg-image-100kb.jpg > /tmp/100kb.jpg
 // $ curl https://sample-videos.com/img/Sample-jpg-image-50kb.jpg > /tmp/50kb.jpg
-//
 $image_files = array(
     '1.8kb' => 'phpmailer_mini.png',
     '5.7kb' => 'images/phpmailer.png',
@@ -102,7 +101,7 @@ echo "Sending $receiver_count mails with only one PHPMailer instance: \n";
             $mail->addReplyTo('replyto@example.com', 'First Last');
 
             foreach ($receiver_list as $receiver) {
-                       $mail->clearAddresses();
+                $mail->clearAddresses();
                 $mail->addAddress($receiver);
                 $mail->Subject = 'Hi '.$receiver.'!';
                 $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
@@ -127,6 +126,46 @@ echo "Sending $receiver_count mails with only one PHPMailer instance: \n";
     }
 }
 
+class MyCacheHelper implements Psr\SimpleCache\CacheInterface {
+    protected $cacheStore = [];
+    public function get($key, $default = null) {
+        if (array_key_exists($key, $this->cacheStore)) {
+            return $this->cacheStore[$key];
+        }
+
+        return $default;
+    }
+
+    public function set($key, $value, $ttl = null) {
+        $this->cacheStore[$key] = $value;
+    }
+
+    public function delete($key) {
+        usset($this->cacheStore[$key]);
+    }
+
+    public function clear() {
+        usset($this->cacheStore);
+        $this->cacheStore = [];
+    }
+
+    public function has($key) {
+        return array_key_exists($key, $this->cacheStore);
+    }
+
+    public function getMultiple($keys, $default = null) {
+
+    }
+
+    public function setMultiple($values, $ttl = null) {
+
+    }
+
+    public function deleteMultiple($keys) {
+
+    }
+}
+
 echo "Sending $receiver_count mails with creating a new PHPMailer instance and MIMECache: \n";
 {
     foreach ($image_files as $filesize => $image_file) {
@@ -135,7 +174,7 @@ echo "Sending $receiver_count mails with creating a new PHPMailer instance and M
         for ($i=1; $i<=$test_count_per_run ; ++$i) {
             //echo "\t\tRun $i: ";
             $start = microtime(true);
-            $cacheLookupTable = [];
+            $cacheLookupTable = new MyCacheHelper;
             foreach ($receiver_list as $receiver) {
                 $mail = new PHPMailer;
                 $mail->isSMTP();
@@ -182,7 +221,7 @@ echo "Sending $receiver_count mails with only one PHPMailer instance and MIMECac
         for ($i=1; $i<=$test_count_per_run ; ++$i) {
             //echo "\t\tRun $i: ";
             $start = microtime(true);
-            $cacheLookupTable = [];
+            $cacheLookupTable = new MyCacheHelper;
 
             $mail = new PHPMailer;
             $mail->isSMTP();
@@ -196,7 +235,7 @@ echo "Sending $receiver_count mails with only one PHPMailer instance and MIMECac
             $mail->addReplyTo('replyto@example.com', 'First Last');
 
             foreach ($receiver_list as $receiver) {
-                       $mail->clearAddresses();
+                $mail->clearAddresses();
                 $mail->addAddress($receiver);
                 $mail->Subject = 'Hi '.$receiver.'!';
                 $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);

--- a/examples/benchmark_mime_cache.phps
+++ b/examples/benchmark_mime_cache.phps
@@ -1,0 +1,234 @@
+<?php
+/**
+ * This example shows sending mail per receiver and reduce MIME encode.
+ */
+
+//Import the PHPMailer class into the global namespace
+use PHPMailer\PHPMailer\PHPMailer;
+
+//SMTP needs accurate times, and the PHP time zone MUST be set
+//This should be done in your php.ini, but this is how to do it if you don't have access to that
+date_default_timezone_set('Etc/UTC');
+
+require '../vendor/autoload.php';
+
+//Sample Images from https://sample-videos.com/download-sample-jpg-image.php
+// $ curl https://sample-videos.com/img/Sample-jpg-image-1mb.jpg > /tmp/1mb.jpg
+// $ curl https://sample-videos.com/img/Sample-jpg-image-500kb.jpg > /tmp/500kb.jpg
+// $ curl https://sample-videos.com/img/Sample-jpg-image-200kb.jpg > /tmp/200kb.jpg
+// $ curl https://sample-videos.com/img/Sample-jpg-image-100kb.jpg > /tmp/100kb.jpg
+// $ curl https://sample-videos.com/img/Sample-jpg-image-50kb.jpg > /tmp/50kb.jpg
+//
+$image_files = array(
+    '1.8kb' => 'phpmailer_mini.png',
+    '5.7kb' => 'images/phpmailer.png',
+    '50kb' => '/tmp/50kb.jpg',
+    '100kb' => '/tmp/100kb.jpg',
+    '200kb' => '/tmp/200kb.jpg',
+    '500kb' => '/tmp/500kb.jpg',
+);
+
+$receiver_count = 200;
+
+$receiver_list = [];
+for ($i=0 ; $i<$receiver_count ; ++$i)
+    $receiver_list[] = 'whoto'.$i.'@example.com';
+
+echo "Genrate $receiver_count receivers: " . count($receiver_list) . "\n";
+
+$results = [];
+$test_count_per_run = 10;
+
+echo "Sending $receiver_count mails with creating a new PHPMailer instance:\n";
+{
+    foreach ($image_files as $filesize => $image_file) {
+        echo "\tWith $filesize attachment, path = $image_file\n";
+        $total_time = 0;
+        for ($i=1; $i<=$test_count_per_run ; ++$i) {
+            $start = microtime(true);
+            foreach ($receiver_list as $receiver) {
+                $mail = new PHPMailer;
+                $mail->isSMTP();
+                $mail->SMTPDebug = 0;
+                $mail->Host = 'mail.example.com';
+                $mail->Port = 25;
+                $mail->SMTPAuth = true;
+                $mail->Username = 'yourname@example.com';
+                $mail->Password = 'yourpassword';
+                $mail->setFrom('from@example.com', 'First Last');
+                $mail->addReplyTo('replyto@example.com', 'First Last');
+                $mail->addAddress($receiver);
+                $mail->Subject = 'Hi '.$receiver.'!';
+                $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+                $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    
+                //Attach an image file
+                $mail->addAttachment($image_file);
+    
+                //Build the mail content
+                $mail->preSend(); 
+                unset($mail);
+            }
+            $cost = microtime(true) - $start;
+            $total_time += $cost;
+        }
+        $avg_time = $total_time / floatval($test_count_per_run);
+        echo sprintf("\t\ttest $test_count_per_run runs, avg. time: %.5f seconds\n", $avg_time );
+    
+        if (!isset($results[$filesize]))
+            $results[$filesize] = [];
+        $results[$filesize]['method1'] = $avg_time;
+    }
+}
+
+echo "Sending $receiver_count mails with only one PHPMailer instance: \n";
+{
+    foreach ($image_files as $filesize => $image_file) {
+        echo "\tWith $filesize attachment, path = $image_file\n";
+        $total_time = 0;
+        for ($i=1; $i<=$test_count_per_run ; ++$i) {
+            //echo "\t\tRun $i: ";
+            $start = microtime(true);
+
+            $mail = new PHPMailer;
+            $mail->isSMTP();
+            $mail->SMTPDebug = 0;
+            $mail->Host = 'mail.example.com';
+            $mail->Port = 25;
+            $mail->SMTPAuth = true;
+            $mail->Username = 'yourname@example.com';
+            $mail->Password = 'yourpassword';
+            $mail->setFrom('from@example.com', 'First Last');
+            $mail->addReplyTo('replyto@example.com', 'First Last');
+
+            foreach ($receiver_list as $receiver) {
+                       $mail->clearAddresses();
+                $mail->addAddress($receiver);
+                $mail->Subject = 'Hi '.$receiver.'!';
+                $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+                $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    
+                //Attach an image file
+                $mail->addAttachment($image_file);
+    
+                //Build the mail content
+                $mail->preSend(); 
+            }
+            $cost = microtime(true) - $start;
+            //echo "$cost sec\n";
+            $total_time += $cost;
+        }
+        $avg_time = $total_time / floatval($test_count_per_run);
+        echo sprintf("\t\ttest $test_count_per_run runs, avg. time: %.5f seconds\n", $avg_time );
+    
+        if (!isset($results[$filesize]))
+            $results[$filesize] = [];
+        $results[$filesize]['method2'] = $avg_time;
+    }
+}
+
+echo "Sending $receiver_count mails with creating a new PHPMailer instance and MIMECache: \n";
+{
+    foreach ($image_files as $filesize => $image_file) {
+        echo "\tWith $filesize attachment, path = $image_file\n";
+        $total_time = 0;
+        for ($i=1; $i<=$test_count_per_run ; ++$i) {
+            //echo "\t\tRun $i: ";
+            $start = microtime(true);
+            $cacheLookupTable = [];
+            foreach ($receiver_list as $receiver) {
+                $mail = new PHPMailer;
+                $mail->isSMTP();
+                $mail->SMTPDebug = 0;
+                $mail->Host = 'mail.example.com';
+                $mail->Port = 25;
+                $mail->SMTPAuth = true;
+                $mail->Username = 'yourname@example.com';
+                $mail->Password = 'yourpassword';
+                $mail->setFrom('from@example.com', 'First Last');
+                $mail->addReplyTo('replyto@example.com', 'First Last');
+                $mail->addAddress($receiver);
+                $mail->Subject = 'Hi '.$receiver.'!';
+                $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+                $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    
+                //Attach an image file
+                $mail->addAttachment($image_file);
+
+                $mail->MIMECache = &$cacheLookupTable;
+    
+                //Build the mail content
+                $mail->preSend(); 
+                unset($mail);
+            }
+            $cost = microtime(true) - $start;
+            //echo "$cost sec\n";
+            $total_time += $cost;
+        }
+        $avg_time = $total_time / floatval($test_count_per_run);
+        echo sprintf("\t\ttest $test_count_per_run runs, avg. time: %.5f seconds\n", $avg_time );
+    
+        if (!isset($results[$filesize]))
+            $results[$filesize] = [];
+        $results[$filesize]['method3'] = $avg_time;
+    }
+
+}
+echo "Sending $receiver_count mails with only one PHPMailer instance and MIMECache: \n";
+{
+    foreach ($image_files as $filesize => $image_file) {
+        echo "\tWith $filesize attachment, path = $image_file\n";
+        $total_time = 0;
+        for ($i=1; $i<=$test_count_per_run ; ++$i) {
+            //echo "\t\tRun $i: ";
+            $start = microtime(true);
+            $cacheLookupTable = [];
+
+            $mail = new PHPMailer;
+            $mail->isSMTP();
+            $mail->SMTPDebug = 0;
+            $mail->Host = 'mail.example.com';
+            $mail->Port = 25;
+            $mail->SMTPAuth = true;
+            $mail->Username = 'yourname@example.com';
+            $mail->Password = 'yourpassword';
+            $mail->setFrom('from@example.com', 'First Last');
+            $mail->addReplyTo('replyto@example.com', 'First Last');
+
+            foreach ($receiver_list as $receiver) {
+                       $mail->clearAddresses();
+                $mail->addAddress($receiver);
+                $mail->Subject = 'Hi '.$receiver.'!';
+                $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+                $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    
+                //Attach an image file
+                $mail->addAttachment($image_file);
+
+                $mail->MIMECache = &$cacheLookupTable;
+    
+                //Build the mail content
+                $mail->preSend(); 
+            }
+            $cost = microtime(true) - $start;
+            //echo "$cost sec\n";
+            $total_time += $cost;
+        }
+        $avg_time = $total_time / floatval($test_count_per_run);
+        echo sprintf("\t\ttest $test_count_per_run runs, avg. time: %.5f seconds\n", $avg_time );
+    
+        if (!isset($results[$filesize]))
+            $results[$filesize] = [];
+        $results[$filesize]['method4'] = $avg_time;
+    }
+}
+//
+// Print results
+echo "\n";
+echo "Size\tMethod1\tMethod2\tMethod3\tMethod4\n";
+foreach($results as $filesize => $test_method_result) {
+    echo "$filesize";
+    foreach($test_method_result as $value)
+        echo sprintf("\t%3.4f", $value);
+    echo "\n";
+}

--- a/examples/smtp_mime_cache.phps
+++ b/examples/smtp_mime_cache.phps
@@ -1,0 +1,232 @@
+<?php
+/**
+ * This example shows sending mail per receiver and reduce MIME encode.
+ */
+
+//Import the PHPMailer class into the global namespace
+use PHPMailer\PHPMailer\PHPMailer;
+
+//SMTP needs accurate times, and the PHP time zone MUST be set
+//This should be done in your php.ini, but this is how to do it if you don't have access to that
+date_default_timezone_set('Etc/UTC');
+
+require '../vendor/autoload.php';
+
+
+$receiver_count = 1000;
+
+$receiver_list = [];
+for ($i=0 ; $i<$receiver_count ; ++$i)
+    $receiver_list[] = 'whoto'.$i.'@example.com';
+
+echo "Genrate $receiver_count receivers: " . count($receiver_list) . "\n";
+
+echo "Sending $receiver_count mails with creating a new PHPMailer instance: ";
+
+$start = microtime(true);
+foreach ($receiver_list as $receiver) {
+
+    //Create a new PHPMailer instance
+    $mail = new PHPMailer;
+    //Tell PHPMailer to use SMTP
+    $mail->isSMTP();
+    //Enable SMTP debugging
+    // 0 = off (for production use)
+    // 1 = client messages
+    // 2 = client and server messages
+    $mail->SMTPDebug = 0;
+    //Set the hostname of the mail server
+    $mail->Host = 'mail.example.com';
+    //Set the SMTP port number - likely to be 25, 465 or 587
+    $mail->Port = 25;
+    //Whether to use SMTP authentication
+    $mail->SMTPAuth = true;
+    //Username to use for SMTP authentication
+    $mail->Username = 'yourname@example.com';
+    //Password to use for SMTP authentication
+    $mail->Password = 'yourpassword';
+    //Set who the message is to be sent from
+    $mail->setFrom('from@example.com', 'First Last');
+    //Set an alternative reply-to address
+    $mail->addReplyTo('replyto@example.com', 'First Last');
+    //Set who the message is to be sent to
+    $mail->addAddress($receiver);
+    //Set the subject line
+    $mail->Subject = 'Hi '.$receiver.'!';
+    //Read an HTML message body from an external file, convert referenced images to embedded,
+    //convert HTML into a basic plain-text alternative body
+    $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+    //Replace the plain text body with one created manually
+    $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    //Attach an image file
+    $mail->addAttachment('images/phpmailer_mini.png');
+
+    //Build the mail content
+    $mail->preSend(); 
+    unset($mail);
+}
+$cost = microtime(true) - $start;
+
+echo $cost . " sec\n";
+
+echo "Sending $receiver_count mails with only one PHPMailer instance: ";
+
+$start = microtime(true);
+{
+    //Create a new PHPMailer instance
+    $mail = new PHPMailer;
+    //Tell PHPMailer to use SMTP
+    $mail->isSMTP();
+    //Enable SMTP debugging
+    // 0 = off (for production use)
+    // 1 = client messages
+    // 2 = client and server messages
+    $mail->SMTPDebug = 0;
+    //Set the hostname of the mail server
+    $mail->Host = 'mail.example.com';
+    //Set the SMTP port number - likely to be 25, 465 or 587
+    $mail->Port = 25;
+    //Whether to use SMTP authentication
+    $mail->SMTPAuth = true;
+    //Username to use for SMTP authentication
+    $mail->Username = 'yourname@example.com';
+    //Password to use for SMTP authentication
+    $mail->Password = 'yourpassword';
+    //Set who the message is to be sent from
+    $mail->setFrom('from@example.com', 'First Last');
+    //Set an alternative reply-to address
+    $mail->addReplyTo('replyto@example.com', 'First Last');
+
+    //Attach an image file
+    $mail->addAttachment('images/phpmailer_mini.png');
+
+    foreach ($receiver_list as $receiver) {
+        //Reset addresses
+        $mail->clearAddresses();
+        //Set who the message is to be sent to
+        $mail->addAddress($receiver);
+        //Set the subject line
+        $mail->Subject = 'Hi '.$receiver.'!';
+        //Read an HTML message body from an external file, convert referenced images to embedded,
+        //convert HTML into a basic plain-text alternative body
+        $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+        //Replace the plain text body with one created manually
+        $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+ 
+        //Build the mail content
+        $mail->preSend(); 
+    }
+}
+$cost = microtime(true) - $start;
+
+echo $cost . " sec\n";
+//
+// ---
+//
+echo "Sending $receiver_count mails with creating a new PHPMailer instance and MIMECache: ";
+
+$start = microtime(true);
+$cacheLookupTable = [];
+foreach ($receiver_list as $receiver) {
+    //Create a new PHPMailer instance
+    $mail = new PHPMailer;
+    //Tell PHPMailer to use SMTP
+    $mail->isSMTP();
+    //Enable SMTP debugging
+    // 0 = off (for production use)
+    // 1 = client messages
+    // 2 = client and server messages
+    $mail->SMTPDebug = 0;
+    //Set the hostname of the mail server
+    $mail->Host = 'mail.example.com';
+    //Set the SMTP port number - likely to be 25, 465 or 587
+    $mail->Port = 25;
+    //Whether to use SMTP authentication
+    $mail->SMTPAuth = true;
+    //Username to use for SMTP authentication
+    $mail->Username = 'yourname@example.com';
+    //Password to use for SMTP authentication
+    $mail->Password = 'yourpassword';
+    //Set who the message is to be sent from
+    $mail->setFrom('from@example.com', 'First Last');
+    //Set an alternative reply-to address
+    $mail->addReplyTo('replyto@example.com', 'First Last');
+    //Set who the message is to be sent to
+    $mail->addAddress($receiver);
+    //Set the subject line
+    $mail->Subject = 'Hi '.$receiver.'!';
+    //Read an HTML message body from an external file, convert referenced images to embedded,
+    //convert HTML into a basic plain-text alternative body
+    $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+    //Replace the plain text body with one created manually
+    $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+    //Attach an image file
+    $mail->addAttachment('images/phpmailer_mini.png');
+
+    //Set Reduce MIME Encode Cache Store
+    $mail->MIMECache = &$cacheLookupTable;
+
+    //Build the mail content
+    $mail->preSend(); 
+    unset($mail);
+}
+$cost = microtime(true) - $start;
+
+echo $cost . " sec\n";
+//
+// ---
+//
+echo "Sending $receiver_count mails with only one PHPMailer instance and MIMECache: ";
+
+$start = microtime(true);
+$cacheLookupTable = [];
+{
+    //Create a new PHPMailer instance
+    $mail = new PHPMailer;
+    //Tell PHPMailer to use SMTP
+    $mail->isSMTP();
+    //Enable SMTP debugging
+    // 0 = off (for production use)
+    // 1 = client messages
+    // 2 = client and server messages
+    $mail->SMTPDebug = 0;
+    //Set the hostname of the mail server
+    $mail->Host = 'mail.example.com';
+    //Set the SMTP port number - likely to be 25, 465 or 587
+    $mail->Port = 25;
+    //Whether to use SMTP authentication
+    $mail->SMTPAuth = true;
+    //Username to use for SMTP authentication
+    $mail->Username = 'yourname@example.com';
+    //Password to use for SMTP authentication
+    $mail->Password = 'yourpassword';
+    //Set who the message is to be sent from
+    $mail->setFrom('from@example.com', 'First Last');
+    //Set an alternative reply-to address
+    $mail->addReplyTo('replyto@example.com', 'First Last');
+    //Attach an image file
+    $mail->addAttachment('images/phpmailer_mini.png');
+
+    //Set Reduce MIME Encode Cache Store
+    $mail->MIMECache = &$cacheLookupTable;
+
+    foreach ($receiver_list as $receiver) {
+        //Reset addresses
+        $mail->clearAddresses();
+        //Set who the message is to be sent to
+        $mail->addAddress($receiver);
+        //Set the subject line
+        $mail->Subject = 'Hi '.$receiver.'!';
+        //Read an HTML message body from an external file, convert referenced images to embedded,
+        //convert HTML into a basic plain-text alternative body
+        $mail->msgHTML(str_replace( '<h1>This is a test of PHPMailer.</h1>', '<h1>Hi '.$receiver.'</h1>', file_get_contents('contents.html')), __DIR__);
+        //Replace the plain text body with one created manually
+        $mail->AltBody = 'This is a plain-text message body for '.$receiver;
+ 
+        //Build the mail content
+        $mail->preSend(); 
+    }
+}
+$cost = microtime(true) - $start;
+
+echo $cost . " sec\n";

--- a/examples/smtp_mime_cache.phps
+++ b/examples/smtp_mime_cache.phps
@@ -123,10 +123,54 @@ echo $cost . " sec\n";
 //
 // ---
 //
+
+class MyCacheHelper implements Psr\SimpleCache\CacheInterface {
+    protected $cacheStore = [];
+    public function get($key, $default = null) {
+        if (array_key_exists($key, $this->cacheStore)) {
+            return $this->cacheStore[$key];
+        }
+
+        return $default;
+    }
+
+    public function set($key, $value, $ttl = null) {
+        $this->cacheStore[$key] = $value;
+    }
+
+    public function delete($key) {
+        usset($this->cacheStore[$key]);
+    }
+
+    public function clear() {
+        usset($this->cacheStore);
+        $this->cacheStore = [];
+    }
+
+    public function has($key) {
+        return array_key_exists($key, $this->cacheStore);
+    }
+
+    public function getMultiple($keys, $default = null) {
+
+    }
+
+    public function setMultiple($values, $ttl = null) {
+
+    }
+
+    public function deleteMultiple($keys) {
+
+    }
+}
+
+
+
 echo "Sending $receiver_count mails with creating a new PHPMailer instance and MIMECache: ";
 
 $start = microtime(true);
-$cacheLookupTable = [];
+//$cacheLookupTable = [];
+$cacheLookupTable = new MyCacheHelper;
 foreach ($receiver_list as $receiver) {
     //Create a new PHPMailer instance
     $mail = new PHPMailer;
@@ -179,7 +223,8 @@ echo $cost . " sec\n";
 echo "Sending $receiver_count mails with only one PHPMailer instance and MIMECache: ";
 
 $start = microtime(true);
-$cacheLookupTable = [];
+//$cacheLookupTable = [];
+$cacheLookupTable = new MyCacheHelper;
 {
     //Create a new PHPMailer instance
     $mail = new PHPMailer;


### PR DESCRIPTION
This solution could be running at Read-Only file system because using PHP array type to keep the MIME encoding result in memory.

```
//
// $this->ReduceMIMEEncodeCacheStore = [];
//
if (is_array($this->ReduceMIMEEncodeCacheStore)) {
	$cache_key = "$path\t$encoding";
	if (isset($this->ReduceMIMEEncodeCacheStore[$cache_key])) {
		$file_buffer = $this->ReduceMIMEEncodeCacheStore[$cache_key];
		$this->edebug('encodeFile: use cache ['.$path.']['.$encoding.']');
	} else {
		$file_buffer = file_get_contents($path);
		if (false === $file_buffer) {
			throw new Exception($this->lang('file_open') . $path, self::STOP_CONTINUE);
		}
		$file_buffer = $this->encodeString($file_buffer, $encoding);
		$this->ReduceMIMEEncodeCacheStore[$cache_key] = $file_buffer;
		$this->edebug('encodeFile: set cache ['.$path.']['.$encoding.']');
	}
} 
```

Performance improvement:

```
$ php -v
PHP 7.1.23 (cli) (built: Feb 22 2019 22:19:32) ( NTS )
Copyright (c) 1997-2018 The PHP Group
Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
$ git clone https://github.com/changyy/PHPMailer.git
$ cd PHPMailer
$ php ~/bin/composer.phar install --no-dev
$ cd examples
$ php examples/smtp_reduce_mime_encoding.phps 
$ php smtp_reduce_mime_encoding.phps 
Genrate 1000 receivers: 1000
Sending 1000 mails with creating a new PHPMailer instance: 0.41333603858948 sec
Sending 1000 mails with only one PHPMailer instance: 1.745913028717 sec
Sending 1000 mails with creating a new PHPMailer instance and ReduceMIMEEncodeCacheStore: 0.32201600074768 sec
Sending 1000 mails with only one PHPMailer instance and ReduceMIMEEncodeCacheStore: 1.6159191131592 sec
```

I think using an array key-value cache to reduce MIME encoding would nice to let CPU usage down.