### PR TITLE
Cancel ICS file corrupted on Office 365 #1780

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -22,10 +22,7 @@ return PhpCsFixer\Config::create()
         'phpdoc_summary' => false,
         'semicolon_after_instruction' => true,
         'simplified_null_return' => true,
-        'native_function_invocation' => false,
-        'yoda_style' => false,
-        'no_break_comment' => false,
-        'native_constant_invocation' => false,
+        'native_function_invocation' => false
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/.php_cs
+++ b/.php_cs
@@ -22,7 +22,10 @@ return PhpCsFixer\Config::create()
         'phpdoc_summary' => false,
         'semicolon_after_instruction' => true,
         'simplified_null_return' => true,
-        'native_function_invocation' => false
+        'native_function_invocation' => false,
+        'yoda_style' => false,
+        'no_break_comment' => false,
+        'native_constant_invocation' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -162,7 +162,7 @@ class PHPMailer
      *
      * @var string[]
      */
-    private static $IcalMethod = [
+    protected static $IcalMethods = [
         self::ICAL_METHOD_REQUEST,
         self::ICAL_METHOD_PUBLISH,
         self::ICAL_METHOD_REPLY,
@@ -170,7 +170,7 @@ class PHPMailer
         self::ICAL_METHOD_CANCEL,
         self::ICAL_METHOD_REFRESH,
         self::ICAL_METHOD_COUNTER,
-        self::ICAL_METHOD_DECLINECOUNTER
+        self::ICAL_METHOD_DECLINECOUNTER,
     ];
 
     /**
@@ -2617,13 +2617,13 @@ class PHPMailer
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
                     $method = static::ICAL_METHOD_REQUEST;
-                    foreach (static::$IcalMethod as $imethod) {
-                        if (stripos($this->Ical, 'METHOD:'.$imethod) !== false) {
+                    foreach (static::$IcalMethods as $imethod) {
+                        if (stripos($this->Ical, 'METHOD:' . $imethod) !== false) {
                             $method = $imethod;
                             break;
                         }
                     }
-                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$method, '');
+                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method=' . $method, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                     $body .= static::$LE;
                 }
@@ -2660,13 +2660,13 @@ class PHPMailer
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
                     $method = static::ICAL_METHOD_REQUEST;
-                    foreach (static::$IcalMethod as $imethod) {
-                        if (stripos($this->Ical, 'METHOD:'.$imethod) !== false) {
+                    foreach (static::$IcalMethods as $imethod) {
+                        if (stripos($this->Ical, 'METHOD:' . $imethod) !== false) {
                             $method = $imethod;
                             break;
                         }
                     }
-                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$method, '');
+                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method=' . $method, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                 }
                 $body .= $this->endBoundary($this->boundary[2]);

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -49,14 +49,14 @@ class PHPMailer
     const ENCRYPTION_STARTTLS = 'tls';
     const ENCRYPTION_SMTPS = 'ssl';
 
-    const ICAL_METHOD_REQUEST = "REQUEST";
-    const ICAL_METHOD_PUBLISH = "PUBLISH";
-    const ICAL_METHOD_REPLY = "REPLY";
-    const ICAL_METHOD_ADD = "ADD";
-    const ICAL_METHOD_CANCEL = "CANCEL";
-    const ICAL_METHOD_REFRESH = "REFRESH";
-    const ICAL_METHOD_COUNTER = "COUNTER";
-    const ICAL_METHOD_DECLINECOUNTER = "DECLINECOUNTER";
+    const ICAL_METHOD_REQUEST = 'REQUEST';
+    const ICAL_METHOD_PUBLISH = 'PUBLISH';
+    const ICAL_METHOD_REPLY = 'REPLY';
+    const ICAL_METHOD_ADD = 'ADD';
+    const ICAL_METHOD_CANCEL = 'CANCEL';
+    const ICAL_METHOD_REFRESH = 'REFRESH';
+    const ICAL_METHOD_COUNTER = 'COUNTER';
+    const ICAL_METHOD_DECLINECOUNTER = 'DECLINECOUNTER';
 
     /**
      * Email priority.
@@ -158,11 +158,20 @@ class PHPMailer
     public $Ical = '';
 
     /**
-     * Value of "method" in Contenttype header "text/calendar"
+     * Value-array of "method" in Contenttype header "text/calendar"
      *
-     * @var string
+     * @var string[]
      */
-    public $IcalMethod = self::ICAL_METHOD_REQUEST;
+    private static $IcalMethod = [
+        self::ICAL_METHOD_REQUEST,
+        self::ICAL_METHOD_PUBLISH,
+        self::ICAL_METHOD_REPLY,
+        self::ICAL_METHOD_ADD,
+        self::ICAL_METHOD_CANCEL,
+        self::ICAL_METHOD_REFRESH,
+        self::ICAL_METHOD_COUNTER,
+        self::ICAL_METHOD_DECLINECOUNTER
+    ];
 
     /**
      * The complete compiled MIME message body.
@@ -2607,7 +2616,14 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$this->IcalMethod, '');
+                    $method = static::ICAL_METHOD_REQUEST;
+                    foreach (static::$IcalMethod as $imethod) {
+                        if (stripos($this->Ical, 'METHOD:'.$imethod) !== false) {
+                            $method = $imethod;
+                            break;
+                        }
+                    }
+                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$method, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                     $body .= static::$LE;
                 }
@@ -2643,7 +2659,14 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$this->IcalMethod, '');
+                    $method = static::ICAL_METHOD_REQUEST;
+                    foreach (static::$IcalMethod as $imethod) {
+                        if (stripos($this->Ical, 'METHOD:'.$imethod) !== false) {
+                            $method = $imethod;
+                            break;
+                        }
+                    }
+                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$method, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                 }
                 $body .= $this->endBoundary($this->boundary[2]);

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -49,6 +49,15 @@ class PHPMailer
     const ENCRYPTION_STARTTLS = 'tls';
     const ENCRYPTION_SMTPS = 'ssl';
 
+    const ICAL_METHOD_REQUEST = "REQUEST";
+    const ICAL_METHOD_PUBLISH = "PUBLISH";
+    const ICAL_METHOD_REPLY = "REPLY";
+    const ICAL_METHOD_ADD = "ADD";
+    const ICAL_METHOD_CANCEL = "CANCEL";
+    const ICAL_METHOD_REFRESH = "REFRESH";
+    const ICAL_METHOD_COUNTER = "COUNTER";
+    const ICAL_METHOD_DECLINECOUNTER = "DECLINECOUNTER";
+
     /**
      * Email priority.
      * Options: null (default), 1 = High, 3 = Normal, 5 = low.
@@ -147,6 +156,13 @@ class PHPMailer
      * @var string
      */
     public $Ical = '';
+
+    /**
+     * Value of "method" in Contenttype header "text/calendar"
+     *
+     * @var string
+     */
+    public $IcalMethod = self::ICAL_METHOD_REQUEST;
 
     /**
      * The complete compiled MIME message body.
@@ -2591,7 +2607,7 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method=REQUEST', '');
+                    $body .= $this->getBoundary($this->boundary[1], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$this->IcalMethod, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                     $body .= static::$LE;
                 }
@@ -2627,7 +2643,7 @@ class PHPMailer
                 $body .= $this->encodeString($this->Body, $bodyEncoding);
                 $body .= static::$LE;
                 if (!empty($this->Ical)) {
-                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method=REQUEST', '');
+                    $body .= $this->getBoundary($this->boundary[2], '', static::CONTENT_TYPE_TEXT_CALENDAR . '; method='.$this->IcalMethod, '');
                     $body .= $this->encodeString($this->Ical, $this->Encoding);
                 }
                 $body .= $this->endBoundary($this->boundary[2]);

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -2684,7 +2684,7 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = "BEGIN:VCALENDAR"
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
             . "\r\nVERSION:2.0"
             . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
             . "\r\nMETHOD:CANCEL"
@@ -2726,7 +2726,7 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = "BEGIN:VCALENDAR"
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
             . "\r\nVERSION:2.0"
             . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
             . "\r\nMETHOD:INVALID"
@@ -2768,7 +2768,7 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = "BEGIN:VCALENDAR"
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
             . "\r\nVERSION:2.0"
             . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
             . "\r\nCALSCALE:GREGORIAN"

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -2675,6 +2675,131 @@ EOT;
         $this->assertNull($subject);
         $this->assertInstanceOf(OAuth::class, $PHPMailer->getOAuth());
     }
+
+    /**
+     * Test ICal method
+     */
+    public function testICalMethod()
+    {
+        $this->Mail->Subject .= ': ICal method';
+        $this->Mail->Body = '<h3>ICal method test.</h3>';
+        $this->Mail->AltBody = 'ICal method test.';
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
+            . '\r\nVERSION:2.0'
+            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
+            . '\r\nMETHOD:CANCEL'
+            . '\r\nCALSCALE:GREGORIAN'
+            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
+            . '\r\nBEGIN:VEVENT'
+            . '\r\nUID:201909250755-42825@test'
+            . '\r\nDTSTART;20190930T080000Z'
+            . '\r\nSEQUENCE:2'
+            . '\r\nTRANSP:OPAQUE'
+            . '\r\nSTATUS:CONFIRMED'
+            . '\r\nDTEND:20190930T084500Z'
+            . '\r\nLOCATION:[London] London Eye'
+            . '\r\nSUMMARY:Test ICal method'
+            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
+            . '\r\n TRUE:MAILTO:attendee-test@example.com'
+            . '\r\nCLASS:PUBLIC'
+            . '\r\nDESCRIPTION:Some plain text'
+            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
+            . '\r\nDTSTAMP:20190925T075546Z'
+            . '\r\nCREATED:20190925T075709Z'
+            . '\r\nLAST-MODIFIED:20190925T075546Z'
+            . '\r\nEND:VEVENT'
+            . '\r\nEND:VCALENDAR';
+        $this->buildBody();
+        $this->Mail->preSend();
+        $this->assertRegExp(
+            '/Content-Type: text\/calendar; method=CANCEL; charset=utf-8/',
+            $this->Mail->getSentMIMEMessage(),
+            'Wrong ICal method in Content-Type header'
+        );
+    }
+
+    /**
+     * Test ICal missing method to use default (REQUEST)
+     */
+    public function testICalInvalidMethod()
+    {
+        $this->Mail->Subject .= ': ICal method';
+        $this->Mail->Body = '<h3>ICal method test.</h3>';
+        $this->Mail->AltBody = 'ICal method test.';
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
+            . '\r\nVERSION:2.0'
+            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
+            . '\r\nMETHOD:INVALID'
+            . '\r\nCALSCALE:GREGORIAN'
+            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
+            . '\r\nBEGIN:VEVENT'
+            . '\r\nUID:201909250755-42825@test'
+            . '\r\nDTSTART;20190930T080000Z'
+            . '\r\nSEQUENCE:2'
+            . '\r\nTRANSP:OPAQUE'
+            . '\r\nSTATUS:CONFIRMED'
+            . '\r\nDTEND:20190930T084500Z'
+            . '\r\nLOCATION:[London] London Eye'
+            . '\r\nSUMMARY:Test ICal method'
+            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
+            . '\r\n TRUE:MAILTO:attendee-test@example.com'
+            . '\r\nCLASS:PUBLIC'
+            . '\r\nDESCRIPTION:Some plain text'
+            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
+            . '\r\nDTSTAMP:20190925T075546Z'
+            . '\r\nCREATED:20190925T075709Z'
+            . '\r\nLAST-MODIFIED:20190925T075546Z'
+            . '\r\nEND:VEVENT'
+            . '\r\nEND:VCALENDAR';
+        $this->buildBody();
+        $this->Mail->preSend();
+        $this->assertRegExp(
+            '/Content-Type: text\/calendar; method=REQUEST; charset=utf-8/',
+            $this->Mail->getSentMIMEMessage(),
+            'Wrong ICal method in Content-Type header'
+        );
+    }
+
+    /**
+     * Test ICal invalid method to use default (REQUEST)
+     */
+    public function testICalDefaultMethod()
+    {
+        $this->Mail->Subject .= ': ICal method';
+        $this->Mail->Body = '<h3>ICal method test.</h3>';
+        $this->Mail->AltBody = 'ICal method test.';
+        $this->Mail->Ical = 'BEGIN:VCALENDAR'
+            . '\r\nVERSION:2.0'
+            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
+            . '\r\nCALSCALE:GREGORIAN'
+            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
+            . '\r\nBEGIN:VEVENT'
+            . '\r\nUID:201909250755-42825@test'
+            . '\r\nDTSTART;20190930T080000Z'
+            . '\r\nSEQUENCE:2'
+            . '\r\nTRANSP:OPAQUE'
+            . '\r\nSTATUS:CONFIRMED'
+            . '\r\nDTEND:20190930T084500Z'
+            . '\r\nLOCATION:[London] London Eye'
+            . '\r\nSUMMARY:Test ICal method'
+            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
+            . '\r\n TRUE:MAILTO:attendee-test@example.com'
+            . '\r\nCLASS:PUBLIC'
+            . '\r\nDESCRIPTION:Some plain text'
+            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
+            . '\r\nDTSTAMP:20190925T075546Z'
+            . '\r\nCREATED:20190925T075709Z'
+            . '\r\nLAST-MODIFIED:20190925T075546Z'
+            . '\r\nEND:VEVENT'
+            . '\r\nEND:VCALENDAR';
+        $this->buildBody();
+        $this->Mail->preSend();
+        $this->assertRegExp(
+            '/Content-Type: text\/calendar; method=REQUEST; charset=utf-8/',
+            $this->Mail->getSentMIMEMessage(),
+            'Wrong ICal method in Content-Type header'
+        );
+    }
 }
 /*
  * This is a sample form for setting appropriate test values through a browser

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -2684,35 +2684,35 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = 'BEGIN:VCALENDAR'
-            . '\r\nVERSION:2.0'
-            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
-            . '\r\nMETHOD:CANCEL'
-            . '\r\nCALSCALE:GREGORIAN'
-            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
-            . '\r\nBEGIN:VEVENT'
-            . '\r\nUID:201909250755-42825@test'
-            . '\r\nDTSTART;20190930T080000Z'
-            . '\r\nSEQUENCE:2'
-            . '\r\nTRANSP:OPAQUE'
-            . '\r\nSTATUS:CONFIRMED'
-            . '\r\nDTEND:20190930T084500Z'
-            . '\r\nLOCATION:[London] London Eye'
-            . '\r\nSUMMARY:Test ICal method'
-            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
-            . '\r\n TRUE:MAILTO:attendee-test@example.com'
-            . '\r\nCLASS:PUBLIC'
-            . '\r\nDESCRIPTION:Some plain text'
-            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
-            . '\r\nDTSTAMP:20190925T075546Z'
-            . '\r\nCREATED:20190925T075709Z'
-            . '\r\nLAST-MODIFIED:20190925T075546Z'
-            . '\r\nEND:VEVENT'
-            . '\r\nEND:VCALENDAR';
+        $this->Mail->Ical = "BEGIN:VCALENDAR"
+            . "\r\nVERSION:2.0"
+            . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
+            . "\r\nMETHOD:CANCEL"
+            . "\r\nCALSCALE:GREGORIAN"
+            . "\r\nX-MICROSOFT-CALSCALE:GREGORIAN"
+            . "\r\nBEGIN:VEVENT"
+            . "\r\nUID:201909250755-42825@test"
+            . "\r\nDTSTART;20190930T080000Z"
+            . "\r\nSEQUENCE:2"
+            . "\r\nTRANSP:OPAQUE"
+            . "\r\nSTATUS:CONFIRMED"
+            . "\r\nDTEND:20190930T084500Z"
+            . "\r\nLOCATION:[London] London Eye"
+            . "\r\nSUMMARY:Test ICal method"
+            . "\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP="
+            . "\r\n TRUE:MAILTO:attendee-test@example.com"
+            . "\r\nCLASS:PUBLIC"
+            . "\r\nDESCRIPTION:Some plain text"
+            . "\r\nORGANIZER;CN=\"Example, Test\":MAILTO:test@example.com"
+            . "\r\nDTSTAMP:20190925T075546Z"
+            . "\r\nCREATED:20190925T075709Z"
+            . "\r\nLAST-MODIFIED:20190925T075546Z"
+            . "\r\nEND:VEVENT"
+            . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
         $this->assertRegExp(
-            '/Content-Type: text\/calendar; method=CANCEL; charset=utf-8/',
+            '/Content-Type: text\/calendar; method=CANCEL;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'
         );
@@ -2726,35 +2726,35 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = 'BEGIN:VCALENDAR'
-            . '\r\nVERSION:2.0'
-            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
-            . '\r\nMETHOD:INVALID'
-            . '\r\nCALSCALE:GREGORIAN'
-            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
-            . '\r\nBEGIN:VEVENT'
-            . '\r\nUID:201909250755-42825@test'
-            . '\r\nDTSTART;20190930T080000Z'
-            . '\r\nSEQUENCE:2'
-            . '\r\nTRANSP:OPAQUE'
-            . '\r\nSTATUS:CONFIRMED'
-            . '\r\nDTEND:20190930T084500Z'
-            . '\r\nLOCATION:[London] London Eye'
-            . '\r\nSUMMARY:Test ICal method'
-            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
-            . '\r\n TRUE:MAILTO:attendee-test@example.com'
-            . '\r\nCLASS:PUBLIC'
-            . '\r\nDESCRIPTION:Some plain text'
-            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
-            . '\r\nDTSTAMP:20190925T075546Z'
-            . '\r\nCREATED:20190925T075709Z'
-            . '\r\nLAST-MODIFIED:20190925T075546Z'
-            . '\r\nEND:VEVENT'
-            . '\r\nEND:VCALENDAR';
+        $this->Mail->Ical = "BEGIN:VCALENDAR"
+            . "\r\nVERSION:2.0"
+            . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
+            . "\r\nMETHOD:INVALID"
+            . "\r\nCALSCALE:GREGORIAN"
+            . "\r\nX-MICROSOFT-CALSCALE:GREGORIAN"
+            . "\r\nBEGIN:VEVENT"
+            . "\r\nUID:201909250755-42825@test"
+            . "\r\nDTSTART;20190930T080000Z"
+            . "\r\nSEQUENCE:2"
+            . "\r\nTRANSP:OPAQUE"
+            . "\r\nSTATUS:CONFIRMED"
+            . "\r\nDTEND:20190930T084500Z"
+            . "\r\nLOCATION:[London] London Eye"
+            . "\r\nSUMMARY:Test ICal method"
+            . "\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP="
+            . "\r\n TRUE:MAILTO:attendee-test@example.com"
+            . "\r\nCLASS:PUBLIC"
+            . "\r\nDESCRIPTION:Some plain text"
+            . "\r\nORGANIZER;CN=\"Example, Test\":MAILTO:test@example.com"
+            . "\r\nDTSTAMP:20190925T075546Z"
+            . "\r\nCREATED:20190925T075709Z"
+            . "\r\nLAST-MODIFIED:20190925T075546Z"
+            . "\r\nEND:VEVENT"
+            . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
         $this->assertRegExp(
-            '/Content-Type: text\/calendar; method=REQUEST; charset=utf-8/',
+            '/Content-Type: text\/calendar; method=REQUEST;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'
         );
@@ -2768,34 +2768,34 @@ EOT;
         $this->Mail->Subject .= ': ICal method';
         $this->Mail->Body = '<h3>ICal method test.</h3>';
         $this->Mail->AltBody = 'ICal method test.';
-        $this->Mail->Ical = 'BEGIN:VCALENDAR'
-            . '\r\nVERSION:2.0'
-            . '\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN'
-            . '\r\nCALSCALE:GREGORIAN'
-            . '\r\nX-MICROSOFT-CALSCALE:GREGORIAN'
-            . '\r\nBEGIN:VEVENT'
-            . '\r\nUID:201909250755-42825@test'
-            . '\r\nDTSTART;20190930T080000Z'
-            . '\r\nSEQUENCE:2'
-            . '\r\nTRANSP:OPAQUE'
-            . '\r\nSTATUS:CONFIRMED'
-            . '\r\nDTEND:20190930T084500Z'
-            . '\r\nLOCATION:[London] London Eye'
-            . '\r\nSUMMARY:Test ICal method'
-            . '\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP='
-            . '\r\n TRUE:MAILTO:attendee-test@example.com'
-            . '\r\nCLASS:PUBLIC'
-            . '\r\nDESCRIPTION:Some plain text'
-            . '\r\nORGANIZER;CN="Example, Test":MAILTO:test@example.com'
-            . '\r\nDTSTAMP:20190925T075546Z'
-            . '\r\nCREATED:20190925T075709Z'
-            . '\r\nLAST-MODIFIED:20190925T075546Z'
-            . '\r\nEND:VEVENT'
-            . '\r\nEND:VCALENDAR';
+        $this->Mail->Ical = "BEGIN:VCALENDAR"
+            . "\r\nVERSION:2.0"
+            . "\r\nPRODID:-//PHPMailer//PHPMailer Calendar Plugin 1.0//EN"
+            . "\r\nCALSCALE:GREGORIAN"
+            . "\r\nX-MICROSOFT-CALSCALE:GREGORIAN"
+            . "\r\nBEGIN:VEVENT"
+            . "\r\nUID:201909250755-42825@test"
+            . "\r\nDTSTART;20190930T080000Z"
+            . "\r\nSEQUENCE:2"
+            . "\r\nTRANSP:OPAQUE"
+            . "\r\nSTATUS:CONFIRMED"
+            . "\r\nDTEND:20190930T084500Z"
+            . "\r\nLOCATION:[London] London Eye"
+            . "\r\nSUMMARY:Test ICal method"
+            . "\r\nATTENDEE;CN=Attendee, Test;ROLE=OPT-PARTICIPANT;PARTSTAT=NEEDS-ACTION;RSVP="
+            . "\r\n TRUE:MAILTO:attendee-test@example.com"
+            . "\r\nCLASS:PUBLIC"
+            . "\r\nDESCRIPTION:Some plain text"
+            . "\r\nORGANIZER;CN=\"Example, Test\":MAILTO:test@example.com"
+            . "\r\nDTSTAMP:20190925T075546Z"
+            . "\r\nCREATED:20190925T075709Z"
+            . "\r\nLAST-MODIFIED:20190925T075546Z"
+            . "\r\nEND:VEVENT"
+            . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
         $this->assertRegExp(
-            '/Content-Type: text\/calendar; method=REQUEST; charset=utf-8/',
+            '/Content-Type: text\/calendar; method=REQUEST;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'
         );


### PR DESCRIPTION
Since Office 365 with Outlook for web respects the Contenttype-header attribute für ICalendar-Method there is a need to set the property  suitable to your ICal-Method. ```$this->Encoding``` can be used to change the method value (Default = REQUEST).

In order to prevent literal errors the propery can be set by contants matching to the RFC.

    ```const ICAL_METHOD_REQUEST = "REQUEST";
    const ICAL_METHOD_PUBLISH = "PUBLISH";
    const ICAL_METHOD_REPLY = "REPLY";
    const ICAL_METHOD_ADD = "ADD";
    const ICAL_METHOD_CANCEL = "CANCEL";
    const ICAL_METHOD_REFRESH = "REFRESH";
    const ICAL_METHOD_COUNTER = "COUNTER";
    const ICAL_METHOD_DECLINECOUNTER = "DECLINECOUNTER";```