### PR TITLE
[Fixes #1847] Building docs with GitHub Actions

### DIFF
--- a/.github/actions/build-docs/Dockerfile
+++ b/.github/actions/build-docs/Dockerfile
@@ -1,0 +1,15 @@
+FROM phpdoc/phpdoc
+
+LABEL "repository"="https://github.com/PHPMailer/PHPMailer"
+
+LABEL "com.github.actions.name"="Build Docs"
+LABEL "com.github.actions.description"="Build Docs with phpDocumentor"
+LABEL "com.github.actions.icon"="file-text"
+LABEL "com.github.actions.color"="blue"
+
+# don't show errors
+RUN echo "display_errors = Off" > $PHP_INI_DIR/conf.d/errors.ini
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/build-docs/entrypoint.sh
+++ b/.github/actions/build-docs/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -eu
+
+/opt/phpdoc/bin/phpdoc

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,34 @@
+name: Docs
+on: push
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Build Docs
+        uses: ./.github/actions/build-docs
+      - name: Upload file artifacts
+        uses: actions/upload-artifact@v1
+        with:
+          name: docs
+          path: docs/
+
+  publish:
+    name: Publish Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download file artifacts
+        uses: actions/download-artifact@v1
+        with:
+          name: docs
+      - name: Publish Docs to gh-pages
+        uses: maxheld83/ghpages@v0.2.1
+        env:
+          BUILD_DIR: docs/
+        secrets:
+          - GH_PAT

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -30,5 +30,4 @@ jobs:
         uses: maxheld83/ghpages@v0.2.1
         env:
           BUILD_DIR: docs/
-        secrets:
-          - GH_PAT
+          GH_PAT: ${{ secrets.GH_PAT }}


### PR DESCRIPTION
Building docs with GitHub Actions.
Requires setting [Personal Access Token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) with `repo` permissions as `GH_PAT` secret of this repository