### PR TITLE
wrong location of is_callable()'s closing parenthesis

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -878,7 +878,7 @@ class PHPMailer
             return;
         }
         //Avoid clash with built-in function names
-        if (is_callable($this->Debugoutput && !in_array($this->Debugoutput, ['error_log', 'html', 'echo']))) {
+        if (is_callable($this->Debugoutput) && !in_array($this->Debugoutput, ['error_log', 'html', 'echo'])) {
             call_user_func($this->Debugoutput, $str, $this->SMTPDebug);
 
             return;


### PR DESCRIPTION
wrong location of `is_callable($this->Debugoutput)`'s closing parenthesis makes `call_user_func($this->Debugoutput, ...)` is not called