### PR TITLE
FIX int type

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -372,7 +372,7 @@ class SMTP
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function
         if (strpos(PHP_OS, 'WIN') !== 0) {
-            $max = (int)(ini_get('max_execution_time'));
+            $max = (int) (ini_get('max_execution_time'));
             // Don't bother if unlimited
             if (0 !== $max && $timeout > $max) {
                 @set_time_limit($timeout);

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -372,7 +372,7 @@ class SMTP
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function
         if (strpos(PHP_OS, 'WIN') !== 0) {
-            $max = (int) (ini_get('max_execution_time'));
+            $max = (int) ini_get('max_execution_time');
             // Don't bother if unlimited
             if (0 !== $max && $timeout > $max) {
                 @set_time_limit($timeout);

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -372,7 +372,7 @@ class SMTP
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function
         if (strpos(PHP_OS, 'WIN') !== 0) {
-            $max = intval(ini_get('max_execution_time'));
+            $max = (int)(ini_get('max_execution_time'));
             // Don't bother if unlimited
             if (0 !== $max && $timeout > $max) {
                 @set_time_limit($timeout);

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -372,7 +372,7 @@ class SMTP
         // SMTP server can take longer to respond, give longer timeout for first read
         // Windows does not have support for this timeout function
         if (strpos(PHP_OS, 'WIN') !== 0) {
-            $max = ini_get('max_execution_time');
+            $max = intval(ini_get('max_execution_time'));
             // Don't bother if unlimited
             if (0 !== $max && $timeout > $max) {
                 @set_time_limit($timeout);


### PR DESCRIPTION
Hello!

This part `0 !== $max`
of expression `if (0 !== $max && $timeout > $max) {`
will always be true

Because ini_get returns string in `$max = ini_get('max_execution_time');`

Please merge my fix to correct use of strict comparison operator.