### PR TITLE
Add fallback to INTL_IDNA_VARIANT_2003 if needed

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1389,7 +1389,13 @@ class PHPMailer
                 $domain = mb_convert_encoding($domain, 'UTF-8', $this->CharSet);
                 //Ignore IDE complaints about this line - method signature changed in PHP 5.4
                 $errorcode = 0;
-                $punycode = idn_to_ascii($domain, $errorcode, INTL_IDNA_VARIANT_UTS46);
+                if (defined('INTL_IDNA_VARIANT_UTS46')) {
+                    $punycode = idn_to_ascii($domain, $errorcode, INTL_IDNA_VARIANT_UTS46);
+                } elseif (defined('INTL_IDNA_VARIANT_2003')) {
+                    $punycode = idn_to_ascii($domain, $errorcode, INTL_IDNA_VARIANT_2003);
+                } else {
+                    $punycode = idn_to_ascii($domain, $errorcode);
+                }
                 if (false !== $punycode) {
                     return substr($address, 0, $pos) . $punycode;
                 }


### PR DESCRIPTION
INTL_IDNA_VARIANT_UTS46 exists from ICU 4.6, which has been released in
March 2011. However, some recent installations might have older ICU
versions (even with PHP 7+). In this situation `INTL_IDNA_VARIANT_UTS46`
will not exist and PHP will transform the constant into a string,
resulting in the following error:

    Warning: idn_to_ascii() expects parameter 3 to be integer, string
    given in /some/path/to/a/file.php on line XX

This commit allows to fallback to INTL_IDNA_VARIANT_2003 if it's needed
and possible. This variable is deprecated from PHP 7.2 and will be
removed in PHP 8, so we take care to test its existence as well.

References:

- https://github.com/FreshRSS/FreshRSS/pull/2680
- https://github.com/PrestaShop/PrestaShop/pull/11995
- https://wiki.php.net/rfc/deprecate-and-remove-intl_idna_variant_2003