### PR TITLE
fix DKIM issue in 6.1.2 - update PHPMailer.php

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1554,7 +1554,7 @@ class PHPMailer
                     $this->MIMEBody
                 );
                 $this->MIMEHeader = rtrim($this->MIMEHeader, "\r\n ") . static::$LE .
-                    static::normalizeBreaks($header_dkim) . static::$LE;
+                    static::normalizeBreaks($header_dkim);
             }
 
             return true;
@@ -4476,9 +4476,11 @@ class PHPMailer
         //@see https://tools.ietf.org/html/rfc5322#section-2.2
         //That means this may break if you do something daft like put vertical tabs in your headers.
         //Unfold header lines
-        $signHeader = preg_replace('/\r\n[ \t]+/', ' ', $signHeader);
+        $signHeader = str_replace(["\r\n","\r"], ["\n","\n"], $signHeader);
+        $signHeader = preg_replace('/\n[ \t]+/', ' ', $signHeader);
+        
         //Break headers out into an array
-        $lines = explode("\r\n", $signHeader);
+        $lines = explode("\n", $signHeader);
         foreach ($lines as $key => $line) {
             //If the header is missing a :, skip it as it's invalid
             //This is likely to happen because the explode() above will also split


### PR DESCRIPTION
DKIM signature does not work when static::$LE=="\n"
It appends when $this->Mailer!='smtp' AND PHP_OS!="WIN".

Here are the messages I got, using PHPMailer/DKIMValidator:

```
Computed body hash does not match signature body hash
DKIM signature did not verify
```

It works fine after the fix, using "mail" (verified with PHPMailer/DKIMValidator and some online DKIM services)
