### PR TITLE
Remove deprecated message for PHP 7.4+

### DIFF
--- a/class.phpmailer.php
+++ b/class.phpmailer.php
@@ -2711,7 +2711,10 @@ class PHPMailer
             if (!self::isPermittedPath($path) or !file_exists($path)) {
                 throw new phpmailerException($this->lang('file_open') . $path, self::STOP_CONTINUE);
             }
-            $magic_quotes = get_magic_quotes_runtime();
+            $magic_quotes = false;
+            if( version_compare(PHP_VERSION, '7.4.0', '<') ) {
+                $magic_quotes = get_magic_quotes_runtime();
+            }
             if ($magic_quotes) {
                 if (version_compare(PHP_VERSION, '5.3.0', '<')) {
                     set_magic_quotes_runtime(false);


### PR DESCRIPTION
PHPMailer used in Joomla! 3 can't be updated to 6.x until Joomla! 4.0 is released because of minimum PHP version differences between Joomla! and PHPMailer. Could you please kindly accept this PR and release another version of PHPMailer 5.x that would not create a deprecated warning in PHP 7.4? This PR fixes the warning. Thanks :)

Before submitting your pull request, check whether your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix `

And committing eventual changes. It's important that this command uses the specific version of php-cs-fixer configured for PHPMailer, so run `composer install` within the PHPMailer folder to use the exact version it needs.
