### PR TITLE
remove x-mailer from dkim sign headers

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4596,7 +4596,6 @@ class PHPMailer
             'message-id',
             'content-type',
             'mime-version',
-            'x-mailer',
         ];
         if (stripos($headers_line, 'Subject') === false) {
             $headers_line .= 'Subject: ' . $subject . static::$LE;


### PR DESCRIPTION
remove x-mailer from dkim sign headers because some exit smtp (proxy between corporate network and public network) remove al headers X-* to protect internal network information from public

