### PR TITLE
Removing parameter type so that code works with PHP strict_types decl…

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4814,7 +4814,7 @@ class PHPMailer
     /**
      * Set an OAuth instance.
      */
-    public function setOAuth(OAuth $oauth)
+    public function setOAuth($oauth)
     {
         $this->oauth = $oauth;
     }


### PR DESCRIPTION
…aration and Gmail XOAUTH2

I was updated in #2048 about the [wiki page](https://github.com/PHPMailer/PHPMailer/wiki/Gmail-XOAUTH2-Using-Google-API-Client) to use google_api_php_client and I found that due to the parameter type php 7 strict types throws exceptions that it expected OAuth and found GmailXOAuth2 class object.

I need this fixed so that other devlopers using composer install can install phpmailer and use the smtp module of drupal cms directly without this modification or code break.

Thanks,
Sadashiv.
