### PR TITLE
Provide a content id to string attachments

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3487,7 +3487,7 @@ class PHPMailer
                 4 => $type,
                 5 => true, // isStringAttachment
                 6 => $disposition,
-                7 => 0,
+                7 => $filename,
             ];
         } catch (Exception $exc) {
             $this->setError($exc->getMessage());


### PR DESCRIPTION
Since it's possible to create a string attachment with an 'inline'
$disposition we cannot blindly set what will become the attachment CID
to 0 otherwise we'll not be able to retrieve it using the 'cid:...' URL.

As with addAttachment(), set the future CID to the filename.

Signed-off-by: Emmanuel Deloget <logout@free.fr>
