### PR TITLE
Write server banner to SMTP::$last_reply

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -340,8 +340,8 @@ class SMTP
         $this->edebug('Connection: opened', self::DEBUG_CONNECTION);
 
         // Get any announcement
-        $announce = $this->get_lines();
-        $this->edebug('SERVER -> CLIENT: ' . $announce, self::DEBUG_SERVER);
+        $this->last_reply = $this->get_lines();
+        $this->edebug('SERVER -> CLIENT: ' . $this->last_reply, self::DEBUG_SERVER);
 
         return true;
     }


### PR DESCRIPTION
It doesn't seem to me like there's any real reason why the SMTP banner is not written to the `$last_reply` property. I have a small project where I'd like to get the server's banner.

My current (lazy and bad, but functional) fix is extending the class as such:

```php
class SMTP extends PHPMailer\PHPMailer\SMTP {
  protected function get_lines() {
    $data = parent::get_lines();
    $this->last_reply = $data;
    return $data;
  }
}
```

I'd rather not have to copy out the entire `connect()` method just to assign a variable. This change would make sense, if not for anything else, for consistency.