### PR TITLE
Remove old links from SMTP test server suggestions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -7,10 +7,9 @@ This folder contains a collection of examples of using [PHPMailer](https://githu
 
 When working on email sending code you'll find yourself worrying about what might happen if all these test emails got sent to your mailing list. The solution is to use a fake mail server, one that acts just like the real thing, but just doesn't actually send anything out. Some offer web interfaces, feedback, logging, the ability to return specific error codes, all things that are useful for testing error handling, authentication etc. Here's a selection of mail testing tools you might like to try:
 
-*   [FakeSMTP](https://github.com/Nilhcem/FakeSMTP), a Java desktop app with the ability to show an SMTP log and save messages to a folder.
-*   [FakeEmail](https://github.com/isotoma/FakeEmail), a Python-based fake mail server with a web interface.
+*   [FakeEmail](https://github.com/tomwardill/FakeEmail), a Python-based fake mail server with a web interface.
 *   [smtp-sink](http://www.postfix.org/smtp-sink.1.html), part of the Postfix mail server, so you may have this installed already. This is used in the Travis-CI configuration to run PHPMailer's unit tests.
-*   [smtp4dev](http://smtp4dev.codeplex.com), a dummy SMTP server for Windows.
+*   [smtp4dev](https://github.com/rnwood/smtp4dev), a dummy SMTP server for Windows and Linux.
 *   [fakesendmail.sh](https://github.com/PHPMailer/PHPMailer/blob/master/test/fakesendmail.sh), part of PHPMailer's test setup, this is a shell script that emulates sendmail for testing 'mail' or 'sendmail' methods in PHPMailer.
 *   [msglint](http://tools.ietf.org/tools/msglint/), not a mail server, the IETF's MIME structure analyser checks the formatting of your messages.
 


### PR DESCRIPTION
FakeSMTP's repo is read-only and hasn't been updated since 2016, so I removed it. The link to FakeEmail's repo was pointing at a fork that also hasn't been updated since 2016, so i changed the link to one that has more activity. Also smtp4dev has been moved to Github and works on Linux, so I updated its entry to reflect that.
