### PR TITLE
Add AVIF file extension to mime list

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4221,6 +4221,7 @@ class PHPMailer
             'tiff' => 'image/tiff',
             'tif' => 'image/tiff',
             'webp' => 'image/webp',
+            'avif' => 'image/avif',
             'heif' => 'image/heif',
             'heifs' => 'image/heif-sequence',
             'heic' => 'image/heic',


### PR DESCRIPTION
I'm not sure if the current mime list comes from anther software/project, but I'd like to propose to add AVIF image support to the mimes list. Chrome and Firefox support them in the latest versions, and I support their adoption rates will go up soon. We already have the relatively new heic extension, so I think adding avif makes sense too. 

Thank you.