### PR TITLE
Reset SMTP session after error with keepalive

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1610,6 +1610,9 @@ class PHPMailer
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
             }
         } catch (Exception $exc) {
+            if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true) {
+              $this->smtp->reset();
+            }
             $this->setError($exc->getMessage());
             $this->edebug($exc->getMessage());
             if ($this->exceptions) {


### PR DESCRIPTION
Fixes: https://github.com/PHPMailer/PHPMailer/issues/2137

I couldn't figure out a way to trigger the issue with the current testing mechanism in the project.