### PR TITLE
Also use validateAddress in addOrEnqueueAnAddress

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1069,7 +1069,7 @@ class PHPMailer
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         $pos = strrpos($address, '@');
         // Allow custom validators to stop an email from being invalid just because
-        // a missing @ (See PR <placeholder>)
+        // a missing @ (See PR 2147)
         if (!static::validateAddress($address) && $pos === false) {
             $error_message = sprintf(
                 '%s (%s): %s',

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1068,8 +1068,9 @@ class PHPMailer
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         $pos = strrpos($address, '@');
-        if (false === $pos) {
-            // At-sign is missing.
+        // Allow custom validators to stop an email from being invalid just because
+        // a missing @ (See PR <placeholder>)
+        if (!static::validateAddress($address) && $pos === false) {
             $error_message = sprintf(
                 '%s (%s): %s',
                 $this->lang('invalid_address'),
@@ -1085,8 +1086,9 @@ class PHPMailer
             return false;
         }
         $params = [$kind, $address, $name];
+        // Only run if a @ second part of the E-Mail is present
         // Enqueue addresses with IDN until we know the PHPMailer::$CharSet.
-        if (static::idnSupported() && $this->has8bitChars(substr($address, ++$pos))) {
+        if (static::idnSupported() && $pos !== false && $this->has8bitChars(substr($address, ++$pos))) {
             if ('Reply-To' !== $kind) {
                 if (!array_key_exists($address, $this->RecipientsQueue)) {
                     $this->RecipientsQueue[$address] = $params;


### PR DESCRIPTION
Prior to this commit E-Mails are if they contain an `@` sign in
`PHPMailer\addOrEnqueueAnAddress` before reaching the configurable
`validateAddress` in `PHPMailer\addAnAddress`. In 99.9999% of the
cases this will be perfectly fine. But however, it is possible to send
mail only to a user on the local system by their username. This is
especially neat for local development where you just have a sendmail
delivering mails to local user. Depending on your sendmail backend, it
would require additional configuration to create aliases with a domain
(e.g. something with `@something.tld`).

And if you provide a custom validator for that, I don't see any reason
to not use the configurable filter in that scenario.