### PR TITLE
Add MailHog in the code example as a tool for testing email sending

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,7 @@ When working on email sending code you'll find yourself worrying about what migh
 *   [fakesendmail.sh](https://github.com/PHPMailer/PHPMailer/blob/master/test/fakesendmail.sh), part of PHPMailer's test setup, this is a shell script that emulates sendmail for testing 'mail' or 'sendmail' methods in PHPMailer.
 *   [HELO](https://usehelo.com), a very nice (commercial) mail server desktop app from BeyondCode.
 *   [msglint](http://tools.ietf.org/tools/msglint/), not a mail server, the IETF's MIME structure analyser checks the formatting of your messages.
+*   [MailHog](https://github.com/les-enovateurs/mailhog-examples), a Go-based email testing tool for developer with a web interface. You can use it with Docker and GitHub Actions to test mail.
 
 Most of these examples use the `example.com` and `example.net` domains. These domains are reserved by IANA for illustrative purposes, as documented in [RFC 2606](http://tools.ietf.org/html/rfc2606). Don't use made-up domains like 'mydomain.com' or 'somedomain.com' in examples as someone, somewhere, probably owns them!
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ When working on email sending code you'll find yourself worrying about what migh
 *   [fakesendmail.sh](https://github.com/PHPMailer/PHPMailer/blob/master/test/fakesendmail.sh), part of PHPMailer's test setup, this is a shell script that emulates sendmail for testing 'mail' or 'sendmail' methods in PHPMailer.
 *   [HELO](https://usehelo.com), a very nice (commercial) mail server desktop app from BeyondCode.
 *   [msglint](http://tools.ietf.org/tools/msglint/), not a mail server, the IETF's MIME structure analyser checks the formatting of your messages.
-*   [MailHog](https://github.com/les-enovateurs/mailhog-examples), a Go-based email testing tool for developer with a web interface. You can use it with Docker and GitHub Actions to test mail.
+*   [MailHog](https://github.com/les-enovateurs/mailhog-examples), a Go-based email testing tool for developers with a web interface. You can use it with Docker and GitHub Actions to test your mails. The repository also contains a small part of PHPMailer's setup.
 
 Most of these examples use the `example.com` and `example.net` domains. These domains are reserved by IANA for illustrative purposes, as documented in [RFC 2606](http://tools.ietf.org/html/rfc2606). Don't use made-up domains like 'mydomain.com' or 'somedomain.com' in examples as someone, somewhere, probably owns them!
 


### PR DESCRIPTION
Hi!
MailHog is a tool that can be installed with Docker or GitHub Action to test email sending. I propose to add it in the README of the example folder.
The repository that I suggest shows how to use PHPMailer and to configure it, in order to work with MailHog easily.
Thanks for your review.
