### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Alternatively, if you're not using Composer, copy the contents of the PHPMailer 
 <?php
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\SMTP;
 
 require 'path/to/PHPMailer/src/Exception.php';
 require 'path/to/PHPMailer/src/PHPMailer.php';


### PR DESCRIPTION
Loading the class files manually needs the SMTP class as well: "use PHPMailer\PHPMailer\SMTP;"

Before submitting your pull request, check whether your code adheres to PHPMailer
coding standards by running the following command:

`./vendor/bin/php-cs-fixer --diff --dry-run --verbose fix `

And committing eventual changes. It's important that this command uses the specific version of php-cs-fixer configured for PHPMailer, so run `composer install` within the PHPMailer folder to use the exact version it needs.
