### PR TITLE
Travis: simplify and improve setup and run tests on php 5.5

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -9,6 +9,7 @@ tools:
     external_code_coverage:
         enabled: true
         timeout: 300
+        runs: 2
         filter:
             excluded_paths:
                 - 'docs/*'
@@ -19,13 +20,6 @@ tools:
 
     php_code_coverage:
         enabled:              false
-        filter:
-            excluded_paths:
-                - 'docs/*'
-                - 'examples/*'
-                - 'extras/*'
-                - 'test/*'
-                - 'vendor/*'
 
     php_code_sniffer:
         enabled:              true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 dist: xenial
 os: linux
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 php:
   - 5.6
   - 7.0
@@ -10,9 +15,32 @@ php:
   - 7.4
   - nightly
 
-cache:
-  directories:
-    - $HOME/.composer/cache
+stages:
+  - coding-standard
+  - test
+
+jobs:
+  allow_failures:
+    - php: nightly
+  include:
+    ## SNIFF STAGE ##
+    - stage: coding-standard
+      php: 7.4
+      before_install:
+      before_script:
+      script: ./vendor/bin/phpcs -s
+      after_script:
+      env: CS_CHECK=1
+
+    ## TEST STAGE ##
+    - stage: test
+    - php: 7.0
+    - php: 7.1
+    - php: 7.2
+    - php: 7.3
+    - php: 7.4
+      env: CODE_COVERAGE=1
+    - php: nightly
 
 before_install:
   - sudo apt-get update -qq
@@ -33,32 +61,9 @@ before_script:
   - sudo cp test/fakesendmail.sh /usr/sbin/sendmail
   - echo 'sendmail_path = "/usr/sbin/sendmail -t -i "' > $(php --ini|grep -m 1 "ini files in:"|cut -d ":" -f 2)/sendmail.ini
 
-script: ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
+script:
+  - ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
 
 after_script:
   - if [ "$CODE_COVERAGE" = 1 ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
   - if [ "$CODE_COVERAGE" = 1 ]; then php ocular.phar code-coverage:upload --format=php-clover ../build/logs/clover.xml; fi
-
-stages:
-  - coding-standard
-  - test
-
-jobs:
-  allow_failures:
-    - php: nightly
-  include:
-    - stage: coding-standard
-      before_install:
-      before_script:
-      script: ./vendor/bin/phpcs -s
-      after_script:
-      php: 7.4
-      env: CS_CHECK=1
-    - stage: test
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
-      env: CODE_COVERAGE=1
-    - php: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-  - 7.4
   - nightly
 
 stages:
@@ -32,14 +31,10 @@ jobs:
       after_script:
 
     ## TEST STAGE ##
+    # Extra builds on top of those defined via the "php:" key.
     - stage: test
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
-    - php: 7.3
-    - php: 7.4
+      php: 7.4
       env: CODE_COVERAGE=1
-    - php: nightly
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,8 +46,8 @@ before_install:
   - sudo apt-get install -y -qq postfix
 
 install:
-  - composer install --no-interaction
   - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
+  - composer install --no-interaction
 
 before_script:
   - sudo service postfix stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
       before_script:
       script: ./vendor/bin/phpcs -s
       after_script:
-      env: CS_CHECK=1
 
     ## TEST STAGE ##
     - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+# PHP 5.5 and 7.4 (lowest/highest supported) are run in a separate stage with code coverage. See jobs.
 php:
   - 5.6
   - 7.0
@@ -17,6 +18,7 @@ php:
 stages:
   - coding-standard
   - test
+  - coverage
 
 jobs:
   allow_failures:
@@ -30,11 +32,10 @@ jobs:
       script: ./vendor/bin/phpcs -s
       after_script:
 
-    ## TEST STAGE ##
-    # Extra builds on top of those defined via the "php:" key.
-    - stage: test
+    ## COVERAGE STAGE ##
+    # Extra builds generating code coverage on top of the standard test runs defined via the "php:" key.
+    - stage: coverage
       php: 7.4
-      env: CODE_COVERAGE=1
     - php: 5.5
       dist: trusty
 
@@ -43,7 +44,7 @@ before_install:
   - sudo apt-get install -y -qq postfix
 
 install:
-  - if [ "$CODE_COVERAGE" != 1 ]; then phpenv config-rm xdebug.ini || true; fi
+  - if [[ "${TRAVIS_BUILD_STAGE_NAME^}" != "Coverage" ]]; then phpenv config-rm xdebug.ini || true; fi
   - composer install --no-interaction
 
 before_script:
@@ -61,5 +62,5 @@ script:
   - ./vendor/bin/phpunit --configuration ./travis.phpunit.xml.dist
 
 after_script:
-  - if [ "$CODE_COVERAGE" = 1 ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-  - if [ "$CODE_COVERAGE" = 1 ]; then php ocular.phar code-coverage:upload --format=php-clover ../build/logs/clover.xml; fi
+  - if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [[ "${TRAVIS_BUILD_STAGE_NAME^}" == "Coverage" ]]; then php ocular.phar code-coverage:upload --format=php-clover ../build/logs/clover.xml; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ jobs:
     - stage: test
       php: 7.4
       env: CODE_COVERAGE=1
+    - php: 5.5
+      dist: trusty
 
 before_install:
   - sudo apt-get update -qq

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -2450,11 +2450,12 @@ EOT;
     /**
      * Check whether setting a bad custom header throws exceptions.
      *
+     * @expectedException PHPMailer\PHPMailer\Exception
+     *
      * @throws Exception
      */
     public function testHeaderException()
     {
-        $this->expectException(Exception::class);
         $mail = new PHPMailer(true);
         $mail->addCustomHeader('SomeHeader', "Some\n Value");
     }


### PR DESCRIPTION
As the changes are extensive, it will be easiest to review the changes by looking at the individual commits.

---

### Travis: reorder the config

No functional changes.

### Travis: remove redundant env variable

The "CS check" is being run in its own stage with its own script, so there is no need for this environment variable anymore.

### Travis: disable Xdebug before running Composer

Composer can be slower when Xdebug is enabled, so when Xdebug isn't needed, let's disable it _before_ running Composer.

### Travis: remove duplicate build definitions

The default stage is the `test` stage and all builds defined in the `php` key, possibly combined with an `env` key, will automatically be build in the `test` stage.

No need to define them twice.

The only builds to declare explicitly in `jobs` are those which need custom `env`, `dist`, `script`s etc.

So:
* Remove those builds which don't need anything "custom" from the `jobs` key.
* Remove the one build which _does_ need something "custom" from the `php` key.

### Travis: re-enable testing against PHP 5.5

PHP 5.5 is not available on the default `xenial` distro, but by explicitly telling Travis to use the `trusty` distro, we can still run the tests against PHP 5.5.

### Travis: run code coverage in a separate stage

Code coverage builds are "expensive" builds and if any of the tests would be failing, we are wasting time and resources by running them.

So, let's move the coverage build(s) to a separate stage, which will only run once the `test` stage has passed.

As this is now a separate stage, we don't need to set an environment variable to toggle code coverage on/off anymore. We can base conditions on the Travis stage name.

Let's also run code coverage for PHP 5.5, so both high and low PHP code coverage output can be combined for the most realistic results, taking PHP version specific conditions into account.

To make this work, we do need to tell Scrutinizer to expect reports from two separate code coverage runs.

And if I'm editing that file anyway, let's remove the redundant `filter` setting for a Scrutinizer native code coverage run which is turned off anyway.

### Tests: fix test failing on PHP 5.5

... due to the use of a PHPUnit method which is not available on PHPUnit 4.x.

These kind of things will be addressed better in a future PR, but this will get the build passing for now.
