### PR TITLE
Change Debugoutput to accept 'error_log' and other debug functions passed by string

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -827,7 +827,7 @@ class PHPMailer
             $this->exceptions = (bool) $exceptions;
         }
         //Pick an appropriate debug output format automatically
-        $this->Debugoutput = (strpos(PHP_SAPI, 'cli') !== false ? 'echo' : 'html');
+        $this->Debugoutput = (strpos(PHP_SAPI, 'cli') !== false ? 'echo' : $this->Debugoutput);
     }
 
     /**


### PR DESCRIPTION
Previous code exclude 'error_log' config for debug option.