### PR TITLE
Always use CRLF if php version is 8.0 or newer

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1462,7 +1462,7 @@ class PHPMailer
     {
         if (
             'smtp' === $this->Mailer
-            || ('mail' === $this->Mailer && stripos(PHP_OS, 'WIN') === 0)
+            || ('mail' === $this->Mailer && (PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0))
         ) {
             //SMTP mandates RFC-compliant line endings
             //and it's also used with mail() on Windows


### PR DESCRIPTION
Since https://git.php.net/?p=php-src.git;a=commit;h=6983ae751cd301886c966b84367fc7aaa1273b2d
which solved the bug https://bugs.php.net/bug.php?id=47983, the headers
have to always be CRLF separated.
Without this fix, a space is prepended to the header names.