### PR TITLE
Preference to NTLM before LOGIN type.

### DIFF
--- a/class.smtp.php
+++ b/class.smtp.php
@@ -418,7 +418,7 @@ class SMTP
             );
 
             if (empty($authtype)) {
-                foreach (array('CRAM-MD5', 'LOGIN', 'PLAIN', 'NTLM', 'XOAUTH2') as $method) {
+                foreach (array('CRAM-MD5','NTLM','LOGIN', 'PLAIN', 'XOAUTH2') as $method) {
                     if (in_array($method, $this->server_caps['AUTH'])) {
                         $authtype = $method;
                         break;


### PR DESCRIPTION
NTLM should be chosen over LOGIN type of authentication.