### PR TITLE
Make the tests PHPUnit cross version compatible + test on PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ composer.lock
 .phpcs.xml
 phpcs.xml
 .phpcs-cache
+/.rnd
+test/PHPMailerTest.php*nonexistent_file.txt

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ phpcs.xml
 .phpcs-cache
 /.rnd
 test/PHPMailerTest.php*nonexistent_file.txt
+phpunit.xml

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ phpcs.xml
 /.rnd
 test/PHPMailerTest.php*nonexistent_file.txt
 phpunit.xml
+/.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "doctrine/annotations": "^1.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "phpunit/phpunit": "^4.8 || ^5.7",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.5.6"
+        "squizlabs/php_codesniffer": "^3.5.6",
+        "yoast/phpunit-polyfills": "^0.2.0"
     },
     "suggest": {
         "ext-mbstring": "Needed to send email in multibyte encoding charset",

--- a/test/DebugLogTestListener.php
+++ b/test/DebugLogTestListener.php
@@ -7,28 +7,35 @@
  *
  * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
  * @author    Andy Prevost
+ * @author    Juliette Reinders Folmer
  * @copyright 2010 - 2020 Marcus Bointon
  * @copyright 2004 - 2009 Andy Prevost
+ * @copyright 2020 Juliette Reinders Folmer
  * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
  */
 
 namespace PHPMailer\Test;
 
-class DebugLogTestListener extends \PHPUnit_Framework_BaseTestListener
+use PHPUnit\Framework\TestListener;
+use Yoast\PHPUnitPolyfills\TestListeners\TestListenerDefaultImplementation;
+
+class DebugLogTestListener implements TestListener
 {
+    use TestListenerDefaultImplementation;
+
     private static $debugLog = '';
 
-    public function addError(\PHPUnit_Framework_Test $test, \Exception $e, $time)
+    public function add_error($test, $e, $time)
     {
         echo self::$debugLog;
     }
 
-    public function addFailure(\PHPUnit_Framework_Test $test, \PHPUnit_Framework_AssertionFailedError $e, $time)
+    public function add_failure($test, $e, $time)
     {
         echo self::$debugLog;
     }
 
-    public function startTest(\PHPUnit_Framework_Test $test)
+    public function start_test($test)
     {
         self::$debugLog = '';
     }

--- a/test/PHPMailerLangTest.php
+++ b/test/PHPMailerLangTest.php
@@ -15,7 +15,7 @@
 namespace PHPMailer\Test;
 
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Check language files for missing or excess translations.
@@ -32,7 +32,7 @@ final class PHPMailerLangTest extends TestCase
     /**
      * Run before each test is started.
      */
-    protected function setUp()
+    protected function set_up()
     {
         $this->Mail = new PHPMailer();
     }

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1694,8 +1694,10 @@ EOT;
     /**
      * Tests this denial of service attack.
      *
-     * @see https://sourceforge.net/p/phpmailer/bugs/383/
      * According to the ticket, this should get stuck in a loop, though I can't make it happen.
+     * @see https://sourceforge.net/p/phpmailer/bugs/383/
+     *
+     * @doesNotPerformAssertions
      */
     public function testDenialOfServiceAttack2()
     {

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -320,6 +320,10 @@ final class PHPMailerTest extends TestCase
      */
     public function testAuthCRAMMD5()
     {
+        $this->markTestIncomplete(
+            'Test needs a connection to a server supporting the CRAMMD5 auth mechanism.'
+        );
+
         $this->Mail->Host = 'hostname';
         $this->Mail->Port = 587;
         $this->Mail->SMTPAuth = true;

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -18,7 +18,7 @@ use PHPMailer\PHPMailer\OAuth;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\POP3;
 use PHPMailer\PHPMailer\SMTP;
-use PHPUnit\Framework\TestCase;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * PHPMailer - PHP email transport unit test class.
@@ -70,7 +70,7 @@ final class PHPMailerTest extends TestCase
     /**
      * Run before each test is started.
      */
-    protected function setUp()
+    protected function set_up()
     {
         $this->INCLUDE_DIR = dirname(__DIR__); //Default to the dir above the test dir, i.e. the project home dir
         if (file_exists($this->INCLUDE_DIR . '/test/testbootstrap.php')) {
@@ -134,7 +134,7 @@ final class PHPMailerTest extends TestCase
     /**
      * Run after each test is completed.
      */
-    protected function tearDown()
+    protected function tear_down()
     {
         // Clean global variables
         $this->Mail = null;

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1969,22 +1969,22 @@ EOT;
 
     /**
      * Expect exceptions on bad encoding
-     *
-     * @expectedException PHPMailer\PHPMailer\Exception
      */
     public function testAddAttachmentEncodingException()
     {
+        $this->expectException(Exception::class);
+
         $mail = new PHPMailer(true);
         $mail->addAttachment(__FILE__, 'test.txt', 'invalidencoding');
     }
 
     /**
      * Expect exceptions on sending after deleting a previously successfully attached file
-     *
-     * @expectedException PHPMailer\PHPMailer\Exception
      */
     public function testDeletedAttachmentException()
     {
+        $this->expectException(Exception::class);
+
         $filename = __FILE__ . md5(microtime()) . 'test.txt';
         touch($filename);
         $this->Mail = new PHPMailer(true);
@@ -2008,33 +2008,33 @@ EOT;
 
     /**
      * Expect exceptions on bad encoding
-     *
-     * @expectedException PHPMailer\PHPMailer\Exception
      */
     public function testStringAttachmentEncodingException()
     {
+        $this->expectException(Exception::class);
+
         $mail = new PHPMailer(true);
         $mail->addStringAttachment('hello', 'test.txt', 'invalidencoding');
     }
 
     /**
      * Expect exceptions on bad encoding
-     *
-     * @expectedException PHPMailer\PHPMailer\Exception
      */
     public function testEmbeddedImageEncodingException()
     {
+        $this->expectException(Exception::class);
+
         $mail = new PHPMailer(true);
         $mail->addEmbeddedImage(__FILE__, 'cid', 'test.png', 'invalidencoding');
     }
 
     /**
      * Expect exceptions on bad encoding
-     *
-     * @expectedException PHPMailer\PHPMailer\Exception
      */
     public function testStringEmbeddedImageEncodingException()
     {
+        $this->expectException(Exception::class);
+
         $mail = new PHPMailer(true);
         $mail->addStringEmbeddedImage('hello', 'cid', 'test.png', 'invalidencoding');
     }
@@ -2453,12 +2453,12 @@ EOT;
     /**
      * Check whether setting a bad custom header throws exceptions.
      *
-     * @expectedException PHPMailer\PHPMailer\Exception
-     *
      * @throws Exception
      */
     public function testHeaderException()
     {
+        $this->expectException(Exception::class);
+
         $mail = new PHPMailer(true);
         $mail->addCustomHeader('SomeHeader', "Some\n Value");
     }

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -979,7 +979,7 @@ EOT;
         $this->buildBody();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
         $msg = $this->Mail->getSentMIMEMessage();
-        self::assertNotContains("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
     }
 
     /**
@@ -1064,7 +1064,7 @@ EOT;
             realpath($this->INCLUDE_DIR . '/examples')
         );
         $this->buildBody();
-        self::assertContains($check, $this->Mail->Body, 'ISO message body does not contain expected text');
+        self::assertStringContainsString($check, $this->Mail->Body, 'ISO message body does not contain expected text');
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
     }
 
@@ -1095,7 +1095,7 @@ EOT;
         $this->buildBody();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
         $msg = $this->Mail->getSentMIMEMessage();
-        self::assertNotContains("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
     }
 
     /**
@@ -1152,7 +1152,7 @@ EOT;
         $this->buildBody();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
         $msg = $this->Mail->getSentMIMEMessage();
-        self::assertNotContains("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
     }
 
     /**
@@ -1187,26 +1187,29 @@ EOT;
 
         //Test that local paths without a basedir are ignored
         $this->Mail->msgHTML('<img src="/etc/hostname">test');
-        self::assertContains('src="/etc/hostname"', $this->Mail->Body);
+        self::assertStringContainsString('src="/etc/hostname"', $this->Mail->Body);
         //Test that local paths with a basedir are not ignored
         $this->Mail->msgHTML('<img src="composer.json">test', realpath($this->INCLUDE_DIR));
-        self::assertNotContains('src="composer.json"', $this->Mail->Body);
+        self::assertStringNotContainsString('src="composer.json"', $this->Mail->Body);
         //Test that local paths with parent traversal are ignored
         $this->Mail->msgHTML('<img src="../composer.json">test', realpath($this->INCLUDE_DIR));
-        self::assertNotContains('src="composer.json"', $this->Mail->Body);
+        self::assertStringNotContainsString('src="composer.json"', $this->Mail->Body);
         //Test that existing embedded URLs are ignored
         $this->Mail->msgHTML('<img src="cid:5d41402abc4b2a76b9719d911017c592">test');
-        self::assertContains('src="cid:5d41402abc4b2a76b9719d911017c592"', $this->Mail->Body);
+        self::assertStringContainsString('src="cid:5d41402abc4b2a76b9719d911017c592"', $this->Mail->Body);
         //Test that absolute URLs are ignored
         $this->Mail->msgHTML('<img src="https://github.com/PHPMailer/PHPMailer/blob/master/composer.json">test');
-        self::assertContains(
+        self::assertStringContainsString(
             'src="https://github.com/PHPMailer/PHPMailer/blob/master/composer.json"',
             $this->Mail->Body
         );
         //Test that absolute URLs with anonymous/relative protocol are ignored
         //Note that such URLs will not work in email anyway because they have no protocol to be relative to
         $this->Mail->msgHTML('<img src="//github.com/PHPMailer/PHPMailer/blob/master/composer.json">test');
-        self::assertContains('src="//github.com/PHPMailer/PHPMailer/blob/master/composer.json"', $this->Mail->Body);
+        self::assertStringContainsString(
+            'src="//github.com/PHPMailer/PHPMailer/blob/master/composer.json"',
+            $this->Mail->Body
+        );
     }
 
     /**
@@ -1272,32 +1275,32 @@ EOT;
         $this->buildBody();
         $this->Mail->preSend();
         $message = $this->Mail->getSentMIMEMessage();
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Type: image/png; name="phpmailer_mini.png\";.jpg"',
             $message,
             'Name containing double quote should be escaped in Content-Type'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Disposition: attachment; filename="phpmailer_mini.png\";.jpg"',
             $message,
             'Filename containing double quote should be escaped in Content-Disposition'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Type: image/png; name=phpmailer.png',
             $message,
             'Name without special chars should not be quoted in Content-Type'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Disposition: attachment; filename=phpmailer.png',
             $message,
             'Filename without special chars should not be quoted in Content-Disposition'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Type: image/png; name="PHPMailer card logo.png"',
             $message,
             'Name with spaces should be quoted in Content-Type'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Disposition: attachment; filename="PHPMailer card logo.png"',
             $message,
             'Filename with spaces should be quoted in Content-Disposition'
@@ -1406,7 +1409,7 @@ EOT;
   </body>
 </html>');
         $this->Mail->preSend();
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-ID: <bb229a48bee31f5d54ca12dc9bd960c6@phpmailer.0>',
             $this->Mail->getSentMIMEMessage(),
             'Embedded image header encoding incorrect.'
@@ -1577,7 +1580,7 @@ EOT;
         $this->Mail->isMail();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
         $msg = $this->Mail->getSentMIMEMessage();
-        self::assertNotContains("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
     }
 
     /**
@@ -1620,7 +1623,7 @@ EOT;
             PHPMailer::hasLineLongerThanMax($message),
             'Long line not corrected (Max: ' . (PHPMailer::MAX_LINE_LENGTH + strlen(PHPMailer::getLE())) . ' chars)'
         );
-        self::assertContains(
+        self::assertStringContainsString(
             'Content-Transfer-Encoding: quoted-printable',
             $message,
             'Long line did not cause transfer encoding switch.'
@@ -1645,7 +1648,7 @@ EOT;
         $this->Mail->preSend();
         $message = $this->Mail->getSentMIMEMessage();
         self::assertFalse(PHPMailer::hasLineLongerThanMax($message), 'Long line not corrected.');
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             'Content-Transfer-Encoding: quoted-printable',
             $message,
             'Short line caused transfer encoding switch.'
@@ -1866,7 +1869,7 @@ EOT;
         $this->buildBody();
         $this->Mail->preSend();
         $b = $this->Mail->getSentMIMEMessage();
-        self::assertContains('To: "Tim \"The Book\" O\'Reilly" <foo@example.com>', $b);
+        self::assertStringContainsString('To: "Tim \"The Book\" O\'Reilly" <foo@example.com>', $b);
 
         $this->Mail->Subject .= ': Address escaping invalid';
         $this->Mail->clearAddresses();
@@ -1915,7 +1918,7 @@ EOT;
         $this->Mail->preSend();
         $b = $this->Mail->getSentMIMEMessage();
         self::assertTrue($this->Mail->addBCC('a@example.com'), 'BCC addressing failed');
-        self::assertContains('To: Foo <foo@example.com>', $b);
+        self::assertStringContainsString('To: Foo <foo@example.com>', $b);
         self::assertTrue($this->Mail->send(), 'send failed');
     }
 
@@ -2097,7 +2100,7 @@ EOT;
         self::assertTrue($this->Mail->send(), 'S/MIME signing failed');
 
         $msg = $this->Mail->getSentMIMEMessage();
-        self::assertNotContains("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
         unlink($certfile);
         unlink($keyfile);
     }
@@ -2265,14 +2268,14 @@ EOT;
         $copyHeaderFields = " z=From:$from\r\n |To:$to\r\n |Date:$date\r\n |Subject:$subject;\r\n";
 
         $this->Mail->DKIM_copyHeaderFields = true;
-        self::assertContains(
+        self::assertStringContainsString(
             $copyHeaderFields,
             $this->Mail->DKIM_Add($headerLines, $subject, ''),
             'DKIM header with copied header fields incorrect'
         );
 
         $this->Mail->DKIM_copyHeaderFields = false;
-        self::assertNotContains(
+        self::assertStringNotContainsString(
             $copyHeaderFields,
             $this->Mail->DKIM_Add($headerLines, $subject, ''),
             'DKIM header without copied header fields incorrect'
@@ -2321,7 +2324,7 @@ EOT;
 
         $result = $this->Mail->DKIM_Add($headerLines, $subject, '');
 
-        self::assertContains($headerFields, $result, 'DKIM header with extra headers incorrect');
+        self::assertStringContainsString($headerFields, $result, 'DKIM header with extra headers incorrect');
 
         unlink($privatekeyfile);
     }

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1019,25 +1019,25 @@ EOT;
         $property = $reflection->getProperty('message_type');
         $property->setAccessible(true);
         $property->setValue($PHPMailer, 'inline');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'attach');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'inline_attach');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'alt');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'alt_inline');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'alt_attach');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
 
         $property->setValue($PHPMailer, 'alt_inline_attach');
-        self::assertInternalType('string', $PHPMailer->createBody());
+        self::assertIsString($PHPMailer->createBody());
     }
 
     /**

--- a/test/PHPMailerTest.php
+++ b/test/PHPMailerTest.php
@@ -1897,7 +1897,7 @@ EOT;
         $this->Mail->AltBody = 'MIME structure test.';
         $this->buildBody();
         $this->Mail->preSend();
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             "/Content-Transfer-Encoding: 8bit\r\n\r\n" .
             'This is a multi-part message in MIME format./',
             $this->Mail->getSentMIMEMessage(),
@@ -1964,7 +1964,10 @@ EOT;
         $this->Mail->ErrorInfo = '';
         $this->Mail->encodeString('hello', 'asdfghjkl');
         self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
-        self::assertRegExp('/' . base64_encode('hello') . '/', $this->Mail->encodeString('hello'));
+        self::assertMatchesRegularExpression(
+            '/' . base64_encode('hello') . '/',
+            $this->Mail->encodeString('hello')
+        );
     }
 
     /**
@@ -2447,7 +2450,7 @@ EOT;
         $this->buildBody();
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
-        self::assertRegExp('/^<.*@.*>$/', $lastid, 'Invalid default Message ID');
+        self::assertMatchesRegularExpression('/^<.*@.*>$/', $lastid, 'Invalid default Message ID');
     }
 
     /**
@@ -2899,7 +2902,7 @@ EOT;
             . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             '/Content-Type: text\/calendar; method=CANCEL;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'
@@ -2941,7 +2944,7 @@ EOT;
             . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             '/Content-Type: text\/calendar; method=REQUEST;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'
@@ -2982,7 +2985,7 @@ EOT;
             . "\r\nEND:VCALENDAR";
         $this->buildBody();
         $this->Mail->preSend();
-        self::assertRegExp(
+        self::assertMatchesRegularExpression(
             '/Content-Type: text\/calendar; method=REQUEST;/',
             $this->Mail->getSentMIMEMessage(),
             'Wrong ICal method in Content-Type header'

--- a/travis.phpunit.xml.dist
+++ b/travis.phpunit.xml.dist
@@ -1,19 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
+         backupGlobals="true"
          bootstrap="vendor/autoload.php"
          verbose="true"
-         stopOnError="false"
-         stopOnFailure="false"
-         stopOnIncomplete="false"
-         stopOnSkipped="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          colors="true"
          forceCoversAnnotation="false"
-         processIsolation="false">
+    >
     <testsuites>
-        <testsuite name="PHPMailer Tests">
+        <testsuite name="PHPMailerTests">
             <directory>./test/</directory>
         </testsuite>
     </testsuites>
@@ -27,13 +23,13 @@
         </exclude>
     </groups>
     <filter>
-        <whitelist>
+        <whitelist addUncoveredFilesFromWhitelist="true">
             <directory suffix=".php">./src</directory>
         </whitelist>
     </filter>
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml" logIncompleteSkipped="false"/>
+        <log type="junit" target="build/logs/junit.xml"/>
     </logging>
 </phpunit>


### PR DESCRIPTION
**TL;DR**: Make the tests compatible with PHPUnit 4 to 9 by using the [PHPUnit Polyfills](https://packagist.org/packages/yoast/phpunit-polyfills), which allows for the tests to run (and pass) on PHP 8.

## Commit Details

### .gitignore: ignore files created during a test run

### Tests: make config cross-version compatible

PHPUnit config file:

* Add `backupGlobals="true"`.
    The default value for this setting changed in PHPUnit 6 from `true` to `false`. By explicitly setting it to `true`, the existing behaviour is maintained.
* Remove the `logIncompleteSkipped` directive which is no longer supported.
* Remove a number of directives which use the default values and for which the defaults have not changed across PHPUnit versions.
* Remove the space in the testsuite name to make it more easily usable on the command line.
* Make sure that all src files are taken into consideration when calculating code coverage.
* Add XSD schema reference.
    Note: the config as-is will now validate for PHPUnit 4.4-9.2. For PHPUnit 9.3, the code coverage terminology has changed, though the "old" configuration is still supported.
    If needs be (PHPUnit 10), the config can be updated on the fly by using `--migrate-configuration`.

Other:
* Ignore a locally overloaded PHPUnit config file using the standard `phpunit.xml` file name.

_**Question: why does the config file not use the standard `phpunit.xml.dist` file name ?**_ That would allow for running the tests without command line arguments.
That file can still be overloaded locally by a `phpunit.xml` file.

### Composer: add dependency on the PHPUnit Polyfills package

* Adds a dev dependency to the `yoast/phpunit-polyfills` package.
* As that package already requires and manages the installable versions for PHPUnit, remove this as an explicit requirement from `require-dev` in favour of letting the PHPUnit Polyfills package manage the versions.
    This will update the supported PHPUnit versions from `^4.8 || ^5.7` to `^4.8.36 || ^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0`.
    Note: the supported versions for PHPUnit 4.x and 5.x are very specific and restrictive as it specifically targets the versions in which the "forward compatible" alias files for the namespaced classes are available.

This new package adds the following features:
* Polyfills for various PHPUnit cross-version changes.
* Basic test case and test listener.

Refs:
* https://github.com/Yoast/PHPUnit-Polyfills/

Includes adding the PHPUnit cache file, which is automatically created in PHPUnit 8 and 9, to the `.gitignore` file.

### Tests: switch over to use the Yoast\PHPUnitPolyfills\TestCases\TestCase

This switches the parent class of the test classes over `TestCase` from the PHPUnit native TestCase to the `Yoast\PHPUnitPolyfills\TestCases\TestCase`.

The Yoast `TestCase`:
* Provides cross-version compatibility using snake case fixture method names instead of the PHPUnit native camelCase names.

This switch over includes:
* Renaming the `setUp()` and `tearDown()` methods to, respectively, `set_up()` and `tear_down()` in various test classes for PHPUnit cross-version compatibility.

### Tests: switch over to use the Yoast Polyfill TestListenerDefaultImplementation

This switches `DebugLogTestListener` class over to using the PHPUnit 9 default implementation pattern in combination with using the `TestListenerDefaultImplementation` from the PHPUnit Polyfill library for the cross-version compatibility layer for the TestListener.

The Yoast `TestListenerDefaultImplementation`:
* Provides cross-version compatibility using snake case method names instead of the PHPUnit native camelCase names.

This switch over includes:
* Renaming the template methods used in the `DebugLogTestListener` to use their snake_case variant and removes the type declarations.

### Tests: switch out `assertInternalType()`

... in favour of the more specific assertion(s) as introduced in PHPUnit 7.5.0.

The new assertions are automatically polyfilled via the PHPUnit Polyfill repo as this test class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` test case.

### Tests: switch out `assert[Not]Contains()` with string haystacks

... in favour of the string specific `assertString[Not]ContainsString() assertion(s) as introduced in PHPUnit 7.5.0.

The new assertions are automatically polyfilled via the PHPUnit Polyfill repo as this test class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` test case.

### Tests: switch out `@expectException` annotations

... in favour of method calls to the `TestCase::expectException()` method as introduced in PHPUnit 5.2.0.

The new method and its variants are automatically polyfilled via the PHPUnit Polyfill repo as this test class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` test case.

### Tests: switch out `assertRegExp()`

... in favour of the renamed `Assert::assertMatchesRegularExpression() as introduced in PHPUnit 9.1.0.

The new assertion is automatically polyfilled via the PHPUnit Polyfill repo as this test class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` test case.

### Tests: mark a test as incomplete

As per the comment in the docblock:
> Needs a connection to a server that supports this auth mechanism, so commented out by default.

As the test cannot currently be executed succesfully, we may as well skip it with a meaningful message.

### Tests: mark a test as not performing assertions

... to prevent it from being marked as risky.

