### PR TITLE
Use fully-qualified constant names for PHP versions

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1462,7 +1462,7 @@ class PHPMailer
     {
         if (
             'smtp' === $this->Mailer
-            || ('mail' === $this->Mailer && (PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0))
+            || ('mail' === $this->Mailer && (\PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0))
         ) {
             //SMTP mandates RFC-compliant line endings
             //and it's also used with mail() on Windows
@@ -1474,8 +1474,8 @@ class PHPMailer
         //Check for buggy PHP versions that add a header with an incorrect line break
         if (
             'mail' === $this->Mailer
-            && ((PHP_VERSION_ID >= 70000 && PHP_VERSION_ID < 70017)
-                || (PHP_VERSION_ID >= 70100 && PHP_VERSION_ID < 70103))
+            && ((\PHP_VERSION_ID >= 70000 && \PHP_VERSION_ID < 70017)
+                || (\PHP_VERSION_ID >= 70100 && \PHP_VERSION_ID < 70103))
             && ini_get('mail.add_x_header') === '1'
             && stripos(PHP_OS, 'WIN') === 0
         ) {
@@ -4526,13 +4526,13 @@ class PHPMailer
             $privKey = openssl_pkey_get_private($privKeyStr);
         }
         if (openssl_sign($signHeader, $signature, $privKey, 'sha256WithRSAEncryption')) {
-            if (PHP_MAJOR_VERSION < 8) {
+            if (\PHP_MAJOR_VERSION < 8) {
                 openssl_pkey_free($privKey);
             }
 
             return base64_encode($signature);
         }
-        if (PHP_MAJOR_VERSION < 8) {
+        if (\PHP_MAJOR_VERSION < 8) {
             openssl_pkey_free($privKey);
         }
 


### PR DESCRIPTION
This is a micro performance improvement. When PHP opcode generates opcodes, it can remove PHP version-specific `if` blocks if it sees `PHP_MAJOR_VERSION` or `PHP_VERSION_ID`. However, if the code belongs to a namespace, it cannot make that optimization because the code under namespace can declare the same constants.
This PR updates such PHP constants to be fully-qualified (with back-slash), which enables PHP to make the improvement.

To compare, this is the VLD opcode without fully-qualified constant names:

```php
namespace X;

if (\PHP_VERSION_ID < 80000) {
    echo "hi";
}
```

-->

```
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   5     0  E >   FETCH_CONSTANT                                   ~0      'X%5CPHP_MAJOR_VERSION'
         1        IS_SMALLER_OR_EQUAL                              ~1      ~0, 8
         2      > JMPZ                                                     ~1, ->4
   6     3    >   ECHO                                                     'hi'
   7     4    > > RETURN                                                   1
```

The same snippet, with the fully-qualified constants, PHP can simply eliminate and optimize the `if` block:

```
line     #* E I O op                           fetch          ext  return  operands
-------------------------------------------------------------------------------------
   5     0  E > > JMPZ                                                     <true>, ->2
   6     1    >   ECHO                                                     'hi'
   7     2    > > RETURN                                                   1
```