### PR TITLE
Travis: add build against PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 8.0
   - nightly
 
 stages:


### PR DESCRIPTION
PHP 8.0 has been branched off two months ago, so `nightly` is now PHP 8.1 and in the mean time PHP 8.0 was released last week.

As of today, there is a PHP 8.0 image available on Travis.

This PR adds a new build against PHP 8.0 to the matrix and, as PHP 8.0 has been released, that build is not allowed to fail.