### PR TITLE
Allow to specify content ID in addStringAttachment

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3485,6 +3485,8 @@ class PHPMailer
      * @param string $encoding    File encoding (see $Encoding)
      * @param string $type        File extension (MIME) type
      * @param string $disposition Disposition to use
+     * @param string $cid         Content ID of the attachment; Use this to reference
+     *                            the content when using an embedded image in HTML
      *
      * @throws Exception
      *
@@ -3495,7 +3497,8 @@ class PHPMailer
         $filename,
         $encoding = self::ENCODING_BASE64,
         $type = '',
-        $disposition = 'attachment'
+        $disposition = 'attachment',
+        $cid = 0
     ) {
         try {
             // If a MIME type is not specified, try to work it out from the file name
@@ -3516,7 +3519,7 @@ class PHPMailer
                 4 => $type,
                 5 => true, // isStringAttachment
                 6 => $disposition,
-                7 => 0,
+                7 => $cid,
             ];
         } catch (Exception $exc) {
             $this->setError($exc->getMessage());


### PR DESCRIPTION
I propose to add a 6th optional parameter to specify the content ID in function PHPMailer::addStringAttachment.

In current version content ID it is not set, disallowing to add an attachement of an image into the HTML body via addStringAttachment.

In my personal use case I'm allowing to select a mailer among several ones. Adding right now PHPMailer. Base64 encoding seems to be the most common and low level attachment way. 

Pushing things forth and back, I don't see a valid reason why a base64 encoded attachment could not be used with a content ID reference.