### PR TITLE
Add detection support for Haraka transaction ID

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -186,6 +186,7 @@ class SMTP
         'Amazon_SES' => '/[\d]{3} Ok (.*)/',
         'SendGrid' => '/[\d]{3} Ok: queued as (.*)/',
         'CampaignMonitor' => '/[\d]{3} 2.0.0 OK:([a-zA-Z\d]{48})/',
+        'Haraka' => '/[\d]{3} Message Queued \((.*)\)/',
     ];
 
     /**


### PR DESCRIPTION
A typical SMTP transaction ID for Haraka looks like this:

```
250 Message Queued (14490C56-76FB-4932-A59B-A8299DB2B693.1)
```

This regex will detect and extract this transaction ID
