### PR TITLE
Fixed Inclusion of Functionality from Untrusted Control Sphere in PHP…

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1334,10 +1334,11 @@ class PHPMailer
      */
     public static function validateAddress($address, $patternselect = null)
     {
+        $defaultValidation=['pcre','pcre8','html5','php']; //Default validation options
         if (null === $patternselect) {
             $patternselect = static::$validator;
         }
-        if (is_callable($patternselect)) {
+        if (is_callable($patternselect) &&  !array_search($patternselect,$defaultValidation)) {
             return call_user_func($patternselect, $address);
         }
         //Reject line breaks in addresses; it's valid RFC5322, but not RFC5321


### PR DESCRIPTION
…Mailer/PHPMailer

Before submitting your pull request, check whether your code adheres to PHPMailer coding standards (which is mostly [PSR-12](https://www.php-fig.org/psr/psr-12/)) by running [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer):

    ./vendor/bin/phpcs

Any problems reported can probably be fixed automatically by using its partner tool, PHP code beautifier:

    ./vendor/bin/phpcbf
