### PR TITLE
GH Actions: start testing against PHP 8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,7 +34,16 @@ jobs:
       matrix:
         php: ['5.5', '5.6', '7.0.', '7.1', '7.2', '7.3', '7.4', '8.0']
         dependency-version: [prefer-stable]
+        experimental: [false]
+        include:
+          # Experimental builds. These are allowed to fail.
+          - php: '8.1'
+            dependency-version: 'prefer-stable'
+            experimental: true
+
     name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+
+    continue-on-error: ${{ matrix.experimental }}
 
     steps:
       - name: Check out code
@@ -48,8 +57,13 @@ jobs:
           ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8
           extensions: xdebug, imap, mbstring, intl, ctype, filter, hash
 
-      - name: Install PHP packages
+      - name: Install PHP packages - normal
+        if: ${{ matrix.php != '8.1' }}
         run: composer install --no-interaction
+
+      - name: Install PHP packages - ignore-platform-reqs
+        if: ${{ matrix.php == '8.1' }}
+        run: composer install --no-interaction --ignore-platform-reqs
 
       - name: Install postfix
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           coverage: xdebug
-          ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8
+          ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8, error_reporting=E_ALL, display_errors=On
           extensions: xdebug, imap, mbstring, intl, ctype, filter, hash
 
       - name: Install PHP packages - normal


### PR DESCRIPTION
The first alpha of PHP 8.1 has been released, so now seems like a good time to start running the tests against PHP 8.1.

For now, I've configured it to allow builds against PHP 8.1 to fail, while PHP 8.1 is still unstable.

Also: PHPUnit doesn't officially support PHP 8.1 yet, so to install PHPUnit 9.x on PHP 8.1, we need to use `--ignore-platform-reqs`, as otherwise PHPUnit 4.8 would be installed (last PHPUnit version without strict PHP version constraints).

---

**Edit**: I've added a second commit to this PR.

### GH Actions: set error reporting to E_ALL

Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.