### PR TITLE
Composer: use a version of PHPCS compatible with PHP 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "doctrine/annotations": "^1.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.5.6",
+        "squizlabs/php_codesniffer": "^3.6.0",
         "yoast/phpunit-polyfills": "^0.2.0"
     },
     "suggest": {


### PR DESCRIPTION
While working on #2363 I noticed that the code sniffer run was using PHP 8.0, but Composer still allowed for a PHP_CodeSniffer version to be installed which is not fully compatible with PHP 8.0.

Note: there are still two known incompatibilities with PHP 8.0 in PHPCS 3.6.0, but everything else has been fixed.

Ref: https://github.com/squizlabs/php_codesniffer/releases
