### PR TITLE
PHP 8.1: ensure consistent exception messages

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -35,6 +35,6 @@ class Exception extends \Exception
      */
     public function errorMessage()
     {
-        return '<strong>' . htmlspecialchars($this->getMessage()) . "</strong><br />\n";
+        return '<strong>' . htmlspecialchars($this->getMessage(), ENT_COMPAT | ENT_HTML401) . "</strong><br />\n";
     }
 }


### PR DESCRIPTION
 From the PHP 8.1 changelog:
> `htmlspecialchars()`, `htmlentities()`, `htmlspecialchars_decode()`,
>` html_entity_decode()` and `get_html_translation_table()` now use
> `ENT_QUOTES | ENT_SUBSTITUTE` rather than `ENT_COMPAT` by default. This means
> that `'` is escaped to `&#039;` while previously it was left alone.
> Additionally, malformed UTF-8 will be replaced by a Unicode substitution
> character, instead of resulting in an empty string.

Ref: https://github.com/php/php-src/blob/28a1a6be0873a109cb02ba32784bf046b87a02e4/UPGRADING#L149-L154

If effect this means that the output of the above mentioned functions may be different depending on the PHP version and the passed text string, unless the `$flags` parameter is explicitly passed.

This patch proposes to add the old default to the one affected function call in PHPMailer, though most other flag combination choices would be just as valid, as long as a `$flags` parameter is passed.

I'd be happy to adjust the PR if another value for `$flags` would be preferred.

Ref: https://www.php.net/manual/en/function.htmlspecialchars.php