### PR TITLE
Composer: update version constraints for PHPUnit Polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.5.6",
-        "yoast/phpunit-polyfills": "^0.2.0"
+        "yoast/phpunit-polyfills": "^1.0.0"
     },
     "suggest": {
         "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",


### PR DESCRIPTION
PHPUnit Polyfills 1.0.0 has been released.

Ref: https://github.com/Yoast/PHPUnit-Polyfills/releases/tag/1.0.0