### PR TITLE
PHP 8.1: fix deprecation warning in PHPMailer::addCustomHeader()

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4079,7 +4079,7 @@ class PHPMailer
             list($name, $value) = explode(':', $name, 2);
         }
         $name = trim($name);
-        $value = trim($value);
+        $value = (null === $value) ? '' : trim($value);
         //Ensure name is not empty, and that neither name nor value contain line breaks
         if (empty($name) || strpbrk($name . $value, "\r\n") !== false) {
             if ($this->exceptions) {


### PR DESCRIPTION
On PHP 8.1, passing `null` to `trim()` generates a `trim(): Passing null to parameter #1 ($string) of type string is deprecated` notice.

As the `$value` is optional and may not even get set via the `name:value` parsing, the code as was, was causing this notice to be thrown.

This fix is covered by the existing unit tests and was exposed when running the tests on PHP 8.1 with `error_reporting` set to `E_ALL`.