### PR TITLE
GH Actions: don't run the docs workflow on forks

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ jobs:
   build_and_publish:
     name: Build and publish Docs
     runs-on: ubuntu-latest
+    if: github.repository == 'PHPMailer/PHPMailer'
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1


### PR DESCRIPTION
The `docs` workflow to deploy the GH Pages website is run on pushes to `master`, but that includes pushes to `master` in forks, which obviously can't deploy to the GH Pages site.

This means that in forks (and there are nearly 9000 of them), this workflow will always fail, while in reality, it shouldn't be run in the first place.

So, I'd like to propose making this small change, which _should_ prevent the `docs` workflow from being run on forks.

Before submitting your pull request, check whether your code adheres to PHPMailer coding standards (which is mostly [PSR-12](https://www.php-fig.org/psr/psr-12/)) by running [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer):

    ./vendor/bin/phpcs

Any problems reported can probably be fixed automatically by using its partner tool, PHP code beautifier:

    ./vendor/bin/phpcbf
