### PR TITLE
.gitattributes: sync with reality

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,12 +5,11 @@
 /.gitignore export-ignore
 /.phan export-ignore
 /.scrutinizer.yml export-ignore
-/.travis.yml export-ignore
 /changelog.md export-ignore
 /docs export-ignore
 /examples export-ignore
 /phpcs.xml.dist export-ignore
 /phpdoc.dist.xml export-ignore
+/phpunit.xml.dist export-ignore
 /test export-ignore
-/travis.phpunit.xml.dist export-ignore
 /UPGRADING.md export-ignore


### PR DESCRIPTION
The `.gitattributes` file was no longer in line with the files in the repo. Fixed now.