### PR TITLE
PHPMailerLangTest: rename and minor tweaks

### DIFF
--- a/test/Language/TranslationCompletenessTest.php
+++ b/test/Language/TranslationCompletenessTest.php
@@ -20,7 +20,7 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 /**
  * Check language files for missing or excess translations.
  */
-final class PHPMailerLangTest extends TestCase
+final class TranslationCompletenessTest extends TestCase
 {
     /**
      * Holds a PHPMailer instance.

--- a/test/Language/TranslationCompletenessTest.php
+++ b/test/Language/TranslationCompletenessTest.php
@@ -19,6 +19,10 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Check language files for missing or excess translations.
+ *
+ * @group languages
+ *
+ * @coversNothing
  */
 final class TranslationCompletenessTest extends TestCase
 {
@@ -40,8 +44,6 @@ final class TranslationCompletenessTest extends TestCase
     /**
      * Test language files for missing and excess translations.
      * All languages are compared with English, which is built-in.
-     *
-     * @group languages
      */
     public function testTranslations()
     {
@@ -52,16 +54,17 @@ final class TranslationCompletenessTest extends TestCase
             if ($fileInfo->isDot()) {
                 continue;
             }
+
             $matches = [];
-            //Only look at language files, ignore anything else in there
+            // Only look at language files, ignore anything else in there.
             if (preg_match('/^phpmailer\.lang-([a-z_]{2,})\.php$/', $fileInfo->getFilename(), $matches)) {
-                $lang = $matches[1]; //Extract language code
-                $PHPMAILER_LANG = []; //Language strings get put in here
+                $lang = $matches[1]; // Extract language code.
+                $PHPMAILER_LANG = []; // Language strings get put in here.
                 $lines = file($fileInfo->getPathname());
                 foreach ($lines as $line) {
-                    //Translation file lines look like this:
-                    //$PHPMAILER_LANG['authenticate'] = 'SMTP-Fehler: Authentifizierung fehlgeschlagen.';
-                    //These files are parsed as text and not PHP so as to avoid the possibility of code injection
+                    // Translation file lines look like this:
+                    // `$PHPMAILER_LANG['authenticate'] = 'SMTP-Fehler: Authentifizierung fehlgeschlagen.';`
+                    // These files are parsed as text and not PHP so as to avoid the possibility of code injection.
                     $matches = [];
                     if (
                         preg_match(
@@ -70,13 +73,14 @@ final class TranslationCompletenessTest extends TestCase
                             $matches
                         )
                     ) {
-                        //Overwrite language-specific strings so we'll never have missing translation keys.
+                        // Overwrite language-specific strings so we'll never have missing translation keys.
                         $PHPMAILER_LANG[$matches[1]] = (string)$matches[3];
                     }
                 }
             }
 
-            include $fileInfo->getPathname(); //Get language strings
+            include $fileInfo->getPathname(); // Get language strings.
+
             $missing = array_diff(array_keys($definedStrings), array_keys($PHPMAILER_LANG));
             $extra = array_diff(array_keys($PHPMAILER_LANG), array_keys($definedStrings));
             if (!empty($missing)) {
@@ -86,7 +90,8 @@ final class TranslationCompletenessTest extends TestCase
                 $err .= "\nExtra translations in $lang: " . implode(', ', $extra);
             }
         }
-        //If we have no extra and no missing translations, $err will be empty
+
+        // If we have no extra and no missing translations, $err will be empty.
         self::assertEmpty($err, $err);
     }
 }


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376 

## Commit details

### PHPMailerLangTest: rename test class to TranslationCompletenessTest

As the test class has been moved to a separate directory, we may as well make the class name more descriptive of what the test class actually does.

### TranslationCompletenessTest: various test tweaks

Minor test tweaks:
* Move `@group` tag up to class level.
* Add a `@coversNothing` tag as this test is more a maintainer utility/package test than a test to cover functionality in code.
* Tidy up inline comments.

