### PR TITLE
Tests: move tests for PHPMailer::validateAddress with custom validator to separate file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -64,62 +64,6 @@ final class PHPMailerTest extends TestCase
     }
 
     /**
-     * Test injecting a custom validator.
-     */
-    public function testCustomValidator()
-    {
-        //Inject a one-off custom validator
-        self::assertTrue(
-            PHPMailer::validateAddress(
-                'user@example.com',
-                static function ($address) {
-                    return strpos($address, '@') !== false;
-                }
-            ),
-            'Custom validator false negative'
-        );
-        self::assertFalse(
-            PHPMailer::validateAddress(
-                'userexample.com',
-                static function ($address) {
-                    return strpos($address, '@') !== false;
-                }
-            ),
-            'Custom validator false positive'
-        );
-        //Set the default validator to an injected function
-        PHPMailer::$validator = static function ($address) {
-            return 'user@example.com' === $address;
-        };
-        self::assertTrue(
-            $this->Mail->addAddress('user@example.com'),
-            'Custom default validator false negative'
-        );
-        self::assertFalse(
-        //Need to pick a failing value which would pass all other validators
-        //to be sure we're using our custom one
-            $this->Mail->addAddress('bananas@example.com'),
-            'Custom default validator false positive'
-        );
-        //Set validator back to default
-        PHPMailer::$validator = 'php';
-        self::assertFalse(
-        //This is a valid address that FILTER_VALIDATE_EMAIL thinks is invalid
-            $this->Mail->addAddress('first.last@example.123'),
-            'PHP validator not behaving as expected'
-        );
-
-        //Test denying function name callables as validators
-        //See SECURITY.md and CVE-2021-3603
-        //If a `php` function defined in validators.php successfully overrides this built-in validator name,
-        //this would return false – and we don't want to allow that
-        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'php'));
-        //Check that a non-existent validator name falls back to a built-in validator
-        //and does not call a global function with that name
-        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'phpx'));
-    }
-
-    /**
      * Word-wrap an ASCII message.
      */
     public function testWordWrap()

--- a/test/PHPMailer/ValidateAddressCustomValidatorTest.php
+++ b/test/PHPMailer/ValidateAddressCustomValidatorTest.php
@@ -25,58 +25,91 @@ final class ValidateAddressCustomValidatorTest extends TestCase
 {
 
     /**
-     * Test injecting a custom validator.
+     * Test injecting a one-off custom validator.
      */
-    public function testCustomValidator()
+    public function testOneOffCustomValidator()
     {
-        //Inject a one-off custom validator
+        $callback = static function ($address) {
+            return strpos($address, '@') !== false;
+        };
+
         self::assertTrue(
-            PHPMailer::validateAddress(
-                'user@example.com',
-                static function ($address) {
-                    return strpos($address, '@') !== false;
-                }
-            ),
+            PHPMailer::validateAddress('user@example.com', $callback),
             'Custom validator false negative'
         );
         self::assertFalse(
-            PHPMailer::validateAddress(
-                'userexample.com',
-                static function ($address) {
-                    return strpos($address, '@') !== false;
-                }
-            ),
+            PHPMailer::validateAddress('userexample.com', $callback),
             'Custom validator false positive'
         );
-        //Set the default validator to an injected function
+    }
+
+    /**
+     * Test setting the default validator to an injected function.
+     */
+    public function testSetDefaultValidatorToCustom()
+    {
+        // Set the default validator to an injected function.
         PHPMailer::$validator = static function ($address) {
             return 'user@example.com' === $address;
         };
+
         self::assertTrue(
             $this->Mail->addAddress('user@example.com'),
             'Custom default validator false negative'
         );
+
+        // Need to pick a failing value which would pass all other validators
+        // to be sure we're using our custom one.
         self::assertFalse(
-        //Need to pick a failing value which would pass all other validators
-        //to be sure we're using our custom one
             $this->Mail->addAddress('bananas@example.com'),
             'Custom default validator false positive'
         );
-        //Set validator back to default
+
+        // Set validator back to default
         PHPMailer::$validator = 'php';
+
+        // This is a valid address that FILTER_VALIDATE_EMAIL thinks is invalid.
         self::assertFalse(
-        //This is a valid address that FILTER_VALIDATE_EMAIL thinks is invalid
             $this->Mail->addAddress('first.last@example.123'),
             'PHP validator not behaving as expected'
         );
+    }
 
-        //Test denying function name callables as validators
-        //See SECURITY.md and CVE-2021-3603
-        //If a `php` function defined in validators.php successfully overrides this built-in validator name,
-        //this would return false – and we don't want to allow that
-        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'php'));
-        //Check that a non-existent validator name falls back to a built-in validator
-        //and does not call a global function with that name
-        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'phpx'));
+    /**
+     * Test denying function name callables as validators.
+     *
+     * See SECURITY.md and CVE-2021-3603.
+     *
+     * @dataProvider dataRejectCallables
+     *
+     * @param string $callback Callback function name.
+     * @param string $message  Message to display if the test would fail.
+     */
+    public function testRejectCallables($callback, $message)
+    {
+        self::assertTrue(PHPMailer::validateAddress('test@example.com', $callback), $message);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataRejectCallables()
+    {
+        return [
+            // If a `php` function defined in validators.php successfully overrides this built-in validator name,
+            // this would return false - and we don't want to allow that.
+            'php'  => [
+                'callback' => 'php',
+                'message'  => 'Build-in php validator overridden',
+            ],
+            // Check that a non-existent validator name falls back to a built-in validator
+            // and does not call a global function with that name.
+            'phpx' => [
+                'callback' => 'phpx',
+                'message'  => 'Global function called instead of default validator',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/ValidateAddressCustomValidatorTest.php
+++ b/test/PHPMailer/ValidateAddressCustomValidatorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test email address validation using a custom validator.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::validateAddress
+ */
+final class ValidateAddressCustomValidatorTest extends TestCase
+{
+
+    /**
+     * Test injecting a custom validator.
+     */
+    public function testCustomValidator()
+    {
+        //Inject a one-off custom validator
+        self::assertTrue(
+            PHPMailer::validateAddress(
+                'user@example.com',
+                static function ($address) {
+                    return strpos($address, '@') !== false;
+                }
+            ),
+            'Custom validator false negative'
+        );
+        self::assertFalse(
+            PHPMailer::validateAddress(
+                'userexample.com',
+                static function ($address) {
+                    return strpos($address, '@') !== false;
+                }
+            ),
+            'Custom validator false positive'
+        );
+        //Set the default validator to an injected function
+        PHPMailer::$validator = static function ($address) {
+            return 'user@example.com' === $address;
+        };
+        self::assertTrue(
+            $this->Mail->addAddress('user@example.com'),
+            'Custom default validator false negative'
+        );
+        self::assertFalse(
+        //Need to pick a failing value which would pass all other validators
+        //to be sure we're using our custom one
+            $this->Mail->addAddress('bananas@example.com'),
+            'Custom default validator false positive'
+        );
+        //Set validator back to default
+        PHPMailer::$validator = 'php';
+        self::assertFalse(
+        //This is a valid address that FILTER_VALIDATE_EMAIL thinks is invalid
+            $this->Mail->addAddress('first.last@example.123'),
+            'PHP validator not behaving as expected'
+        );
+
+        //Test denying function name callables as validators
+        //See SECURITY.md and CVE-2021-3603
+        //If a `php` function defined in validators.php successfully overrides this built-in validator name,
+        //this would return false – and we don't want to allow that
+        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'php'));
+        //Check that a non-existent validator name falls back to a built-in validator
+        //and does not call a global function with that name
+        self::assertTrue(PHPMailer::validateAddress('test@example.com', 'phpx'));
+    }
+}


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378 

## Commit details

### Tests/reorganize: move email validation using custom validator test to own file

### ValidateAddressCustomValidatorTest: reorganize test

Split the test into three tests, each testing a specific situation and use a data provider for one of the tests.

