### PR TITLE
Tests: move POP before SMTP tests to separate file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -16,7 +16,6 @@ namespace PHPMailer\Test\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\OAuth;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\POP3;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
@@ -1855,60 +1854,6 @@ EOT;
             $this->Mail->getReplyToAddresses(),
             'Bad count of "reply-to" addresses'
         );
-    }
-
-    /**
-     * Use a fake POP3 server to test POP-before-SMTP auth with a known-good login.
-     *
-     * @group pop3
-     */
-    public function testPopBeforeSmtpGood()
-    {
-        //Start a fake POP server
-        $pid = shell_exec(
-            '/usr/bin/nohup ' .
-            \PHPMAILER_INCLUDE_DIR .
-            '/test/runfakepopserver.sh 1100 >/dev/null 2>/dev/null & printf "%u" $!'
-        );
-        $this->pids[] = $pid;
-
-        sleep(1);
-        //Test a known-good login
-        self::assertTrue(
-            POP3::popBeforeSmtp('localhost', 1100, 10, 'user', 'test'),
-            'POP before SMTP failed'
-        );
-        //Kill the fake server, don't care if it fails
-        @shell_exec('kill -TERM ' . escapeshellarg($pid));
-        sleep(2);
-    }
-
-    /**
-     * Use a fake POP3 server to test POP-before-SMTP auth
-     * with a known-bad login.
-     *
-     * @group pop3
-     */
-    public function testPopBeforeSmtpBad()
-    {
-        //Start a fake POP server on a different port
-        //so we don't inadvertently connect to the previous instance
-        $pid = shell_exec(
-            '/usr/bin/nohup ' .
-            \PHPMAILER_INCLUDE_DIR .
-            '/test/runfakepopserver.sh 1101 >/dev/null 2>/dev/null & printf "%u" $!'
-        );
-        $this->pids[] = $pid;
-
-        sleep(2);
-        //Test a known-bad login
-        self::assertFalse(
-            POP3::popBeforeSmtp('localhost', 1101, 10, 'user', 'xxx'),
-            'POP before SMTP should have failed'
-        );
-        //Kill the fake server, don't care if it fails
-        @shell_exec('kill -TERM ' . escapeshellarg($pid));
-        sleep(2);
     }
 
     /**

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -20,6 +20,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Test Pop before Smtp functionality.
  *
  * @group pop3
+ *
+ * @covers PHPMailer\PHPMailer\POP3
  */
 final class PopBeforeSmtpTest extends TestCase
 {
@@ -61,7 +63,7 @@ final class PopBeforeSmtpTest extends TestCase
      */
     public function testPopBeforeSmtpGood()
     {
-        //Start a fake POP server
+        // Start a fake POP server.
         $pid = shell_exec(
             '/usr/bin/nohup ' .
             \PHPMAILER_INCLUDE_DIR .
@@ -70,12 +72,14 @@ final class PopBeforeSmtpTest extends TestCase
         $this->pids[] = $pid;
 
         sleep(1);
-        //Test a known-good login
+
+        // Test a known-good login.
         self::assertTrue(
             POP3::popBeforeSmtp('localhost', 1100, 10, 'user', 'test'),
             'POP before SMTP failed'
         );
-        //Kill the fake server, don't care if it fails
+
+        // Kill the fake server, don't care if it fails.
         @shell_exec('kill -TERM ' . escapeshellarg($pid));
         sleep(2);
     }
@@ -86,8 +90,8 @@ final class PopBeforeSmtpTest extends TestCase
      */
     public function testPopBeforeSmtpBad()
     {
-        //Start a fake POP server on a different port
-        //so we don't inadvertently connect to the previous instance
+        // Start a fake POP server on a different port,
+        // so we don't inadvertently connect to the previous instance.
         $pid = shell_exec(
             '/usr/bin/nohup ' .
             \PHPMAILER_INCLUDE_DIR .
@@ -96,12 +100,14 @@ final class PopBeforeSmtpTest extends TestCase
         $this->pids[] = $pid;
 
         sleep(2);
-        //Test a known-bad login
+
+        // Test a known-bad login.
         self::assertFalse(
             POP3::popBeforeSmtp('localhost', 1101, 10, 'user', 'xxx'),
             'POP before SMTP should have failed'
         );
-        //Kill the fake server, don't care if it fails
+
+        // Kill the fake server, don't care if it fails.
         @shell_exec('kill -TERM ' . escapeshellarg($pid));
         sleep(2);
     }

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -1,0 +1,110 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\POP3;
+
+use PHPMailer\PHPMailer\POP3;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test Pop before Smtp functionality.
+ */
+final class PopBeforeSmtpTest extends TestCase
+{
+
+    /**
+     * PIDs of any processes we need to kill.
+     *
+     * @var array
+     */
+    protected $pids = [];
+
+    /**
+     * Run before each test class.
+     */
+    public static function set_up_before_class()
+    {
+        if (defined('PHPMAILER_INCLUDE_DIR') === false) {
+            /*
+             * Set up default include path.
+             * Default to the dir above the test dir, i.e. the project home dir.
+             */
+            define('PHPMAILER_INCLUDE_DIR', dirname(__DIR__));
+        }
+    }
+
+    /**
+     * Run after each test is completed.
+     */
+    protected function tear_down()
+    {
+        foreach ($this->pids as $pid) {
+            $p = escapeshellarg($pid);
+            shell_exec("ps $p && kill -TERM $p");
+        }
+    }
+
+    /**
+     * Use a fake POP3 server to test POP-before-SMTP auth with a known-good login.
+     *
+     * @group pop3
+     */
+    public function testPopBeforeSmtpGood()
+    {
+        //Start a fake POP server
+        $pid = shell_exec(
+            '/usr/bin/nohup ' .
+            \PHPMAILER_INCLUDE_DIR .
+            '/test/runfakepopserver.sh 1100 >/dev/null 2>/dev/null & printf "%u" $!'
+        );
+        $this->pids[] = $pid;
+
+        sleep(1);
+        //Test a known-good login
+        self::assertTrue(
+            POP3::popBeforeSmtp('localhost', 1100, 10, 'user', 'test'),
+            'POP before SMTP failed'
+        );
+        //Kill the fake server, don't care if it fails
+        @shell_exec('kill -TERM ' . escapeshellarg($pid));
+        sleep(2);
+    }
+
+    /**
+     * Use a fake POP3 server to test POP-before-SMTP auth
+     * with a known-bad login.
+     *
+     * @group pop3
+     */
+    public function testPopBeforeSmtpBad()
+    {
+        //Start a fake POP server on a different port
+        //so we don't inadvertently connect to the previous instance
+        $pid = shell_exec(
+            '/usr/bin/nohup ' .
+            \PHPMAILER_INCLUDE_DIR .
+            '/test/runfakepopserver.sh 1101 >/dev/null 2>/dev/null & printf "%u" $!'
+        );
+        $this->pids[] = $pid;
+
+        sleep(2);
+        //Test a known-bad login
+        self::assertFalse(
+            POP3::popBeforeSmtp('localhost', 1101, 10, 'user', 'xxx'),
+            'POP before SMTP should have failed'
+        );
+        //Kill the fake server, don't care if it fails
+        @shell_exec('kill -TERM ' . escapeshellarg($pid));
+        sleep(2);
+    }
+}

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test Pop before Smtp functionality.
+ *
+ * @group pop3
  */
 final class PopBeforeSmtpTest extends TestCase
 {
@@ -56,8 +58,6 @@ final class PopBeforeSmtpTest extends TestCase
 
     /**
      * Use a fake POP3 server to test POP-before-SMTP auth with a known-good login.
-     *
-     * @group pop3
      */
     public function testPopBeforeSmtpGood()
     {
@@ -83,8 +83,6 @@ final class PopBeforeSmtpTest extends TestCase
     /**
      * Use a fake POP3 server to test POP-before-SMTP auth
      * with a known-bad login.
-     *
-     * @group pop3
      */
     public function testPopBeforeSmtpBad()
     {

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -51,13 +51,6 @@ abstract class TestCase extends PolyfillTestCase
     private $NoteLog = [];
 
     /**
-     * PIDs of any processes we need to kill.
-     *
-     * @var array
-     */
-    protected $pids = [];
-
-    /**
      * Run before each test class.
      */
     public static function set_up_before_class()
@@ -143,11 +136,6 @@ abstract class TestCase extends PolyfillTestCase
         $this->Mail = null;
         $this->ChangeLog = [];
         $this->NoteLog = [];
-
-        foreach ($this->pids as $pid) {
-            $p = escapeshellarg($pid);
-            shell_exec("ps $p && kill -TERM $p");
-        }
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381


## Commit details

### Tests/reorganize: move POP before SMTP tests to own file

This also removed the `$pids` property and handling from the PHPMailer base `TestCase` and moves this to the POP test class.

As this test now does not actually need an instantiated PHPMailer object, this class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase`.

### PopBeforeSmtpTest: move `@group` tags

... to the class level and remove them from the individual test functions.

### PopBeforeSmtpTest: various test tweaks

Minor test tweaks:
* Add `@covers` tag at class level.
* Inline comment punctuation.
* Minor code readability tweaks.

