### PR TITLE
Tests: move OAuth test to own file

### DIFF
--- a/test/OAuth/OAuthTest.php
+++ b/test/OAuth/OAuthTest.php
@@ -24,7 +24,11 @@ final class OAuthTest extends TestCase
 {
 
     /**
-     * Test OAuth method
+     * Test OAuth method.
+     *
+     * @covers PHPMailer\PHPMailer\PHPMailer::getOAuth
+     * @covers PHPMailer\PHPMailer\PHPMailer::setOAuth
+     * @covers PHPMailer\PHPMailer\OAuth::__construct
      */
     public function testOAuth()
     {
@@ -33,7 +37,7 @@ final class OAuthTest extends TestCase
         $property = $reflection->getProperty('oauth');
         $property->setAccessible(true);
         $property->setValue($PHPMailer, true);
-        self::assertTrue($PHPMailer->getOAuth());
+        self::assertTrue($PHPMailer->getOAuth(), 'Initial value of oauth property is not true');
 
         $options = [
             'provider' => 'dummyprovider',
@@ -44,9 +48,13 @@ final class OAuthTest extends TestCase
         ];
 
         $oauth = new OAuth($options);
-        self::assertInstanceOf(OAuth::class, $oauth);
+        self::assertInstanceOf(OAuth::class, $oauth, 'Instantiation of OAuth class failed');
         $subject = $PHPMailer->setOAuth($oauth);
-        self::assertNull($subject);
-        self::assertInstanceOf(OAuth::class, $PHPMailer->getOAuth());
+        self::assertNull($subject, 'setOAuth() is not a void function');
+        self::assertInstanceOf(
+            OAuth::class,
+            $PHPMailer->getOAuth(),
+            'Setting Oauth property to an instance of the OAuth class failed'
+        );
     }
 }

--- a/test/OAuth/OAuthTest.php
+++ b/test/OAuth/OAuthTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\OAuth;
+
+use PHPMailer\PHPMailer\OAuth;
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test OAuth functionality.
+ */
+final class OAuthTest extends TestCase
+{
+
+    /**
+     * Test OAuth method
+     */
+    public function testOAuth()
+    {
+        $PHPMailer = new PHPMailer();
+        $reflection = new \ReflectionClass($PHPMailer);
+        $property = $reflection->getProperty('oauth');
+        $property->setAccessible(true);
+        $property->setValue($PHPMailer, true);
+        self::assertTrue($PHPMailer->getOAuth());
+
+        $options = [
+            'provider' => 'dummyprovider',
+            'userName' => 'dummyusername',
+            'clientSecret' => 'dummyclientsecret',
+            'clientId' => 'dummyclientid',
+            'refreshToken' => 'dummyrefreshtoken',
+        ];
+
+        $oauth = new OAuth($options);
+        self::assertInstanceOf(OAuth::class, $oauth);
+        $subject = $PHPMailer->setOAuth($oauth);
+        self::assertNull($subject);
+        self::assertInstanceOf(OAuth::class, $PHPMailer->getOAuth());
+    }
+}

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -14,7 +14,6 @@
 namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\Exception;
-use PHPMailer\PHPMailer\OAuth;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
@@ -1894,33 +1893,6 @@ EOT;
         self::assertFalse($this->Smtp->startTLS(), 'SMTP connect with options failed');
         self::assertFalse($this->Mail->SMTPAuth);
         $this->Mail->smtpClose();
-    }
-
-    /**
-     * Test OAuth method
-     */
-    public function testOAuth()
-    {
-        $PHPMailer = new PHPMailer();
-        $reflection = new \ReflectionClass($PHPMailer);
-        $property = $reflection->getProperty('oauth');
-        $property->setAccessible(true);
-        $property->setValue($PHPMailer, true);
-        self::assertTrue($PHPMailer->getOAuth());
-
-        $options = [
-            'provider' => 'dummyprovider',
-            'userName' => 'dummyusername',
-            'clientSecret' => 'dummyclientsecret',
-            'clientId' => 'dummyclientid',
-            'refreshToken' => 'dummyrefreshtoken',
-        ];
-
-        $oauth = new OAuth($options);
-        self::assertInstanceOf(OAuth::class, $oauth);
-        $subject = $PHPMailer->setOAuth($oauth);
-        self::assertNull($subject);
-        self::assertInstanceOf(OAuth::class, $PHPMailer->getOAuth());
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382


## Commit details


### Tests/reorganize: move OAuth test to own file

This test uses the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase` base class as it doesn't need the `set_up()` or `tear_down()` methods from the PHPMailer base test class.

### OAuthTest: various test tweaks

Minor test tweaks:
* Add `@covers` tags.
* Add "failure" messages to assertions.
* Minor comment punctuation.

