### PR TITLE
Tests: move message ID test to own file

### DIFF
--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -17,6 +17,9 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test setting and retrieving message ID.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::createHeader
+ * @covers \PHPMailer\PHPMailer\PHPMailer::getLastMessageID
  */
 final class GetLastMessageIDTest extends TestCase
 {

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -22,9 +22,9 @@ final class GetLastMessageIDTest extends TestCase
 {
 
     /**
-     * Test setting and retrieving message ID.
+     * Test setting and retrieving an invalid message ID.
      */
-    public function testMessageID()
+    public function testMessageIDInvalid()
     {
         $this->Mail->Body = 'Test message ID.';
         $id = hash('sha256', 12345);
@@ -33,12 +33,28 @@ final class GetLastMessageIDTest extends TestCase
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
         self::assertNotSame($id, $lastid, 'Invalid Message ID allowed');
+    }
+
+    /**
+     * Test setting and retrieving a valid, custom message ID.
+     */
+    public function testMessageIDValid()
+    {
+        $this->Mail->Body = 'Test message ID.';
         $id = '<' . hash('sha256', 12345) . '@example.com>';
         $this->Mail->MessageID = $id;
         $this->buildBody();
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
         self::assertSame($id, $lastid, 'Custom Message ID not used');
+    }
+
+    /**
+     * Test setting and retrieving an empty message ID.
+     */
+    public function testMessageIDEmpty()
+    {
+        $this->Mail->Body = 'Test message ID.';
         $this->Mail->MessageID = '';
         $this->buildBody();
         $this->Mail->preSend();

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -45,8 +45,12 @@ final class GetLastMessageIDTest extends TestCase
      */
     public function dataMessageIDInvalid()
     {
+        $hash = hash('sha256', 12345);
+
         return [
-            'Invalid: plain hash' => [ hash('sha256', 12345) ],
+            'Invalid: plain hash'       => [ $hash ],
+            'Invalid: missing brackets' => [ $hash . '@example.com' ],
+            'Invalid: missing @'        => [ '<' . $hash . 'example.com>' ],
         ];
     }
 
@@ -74,8 +78,17 @@ final class GetLastMessageIDTest extends TestCase
      */
     public function dataMessageIDValid()
     {
+        $hash = hash('sha256', 12345);
+
         return [
-            'hashed pre @' => [ '<' . hash('sha256', 12345) . '@example.com>' ],
+            'hashed pre @'               => [ '<' . $hash . '@example.com>' ],
+            'no text before @'           => [ '<@example.com>' ],
+            'no text after @'            => [ '<' . $hash . '@>' ],
+            'no text before or after @'  => [ '<@>' ],
+            'new line after end bracket' => [ '<' . $hash . "@>\n" ],
+            'multiple @ signs'           => [ '<' . $hash . '@example@com>' ],
+            'brackets within 1'          => [ '<' . $hash . '<@>example.com>' ],
+            'brackets within 2'          => [ '<<' . $hash . '@example>com>' ],
         ];
     }
 

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test setting and retrieving message ID.
+ */
+final class GetLastMessageIDTest extends TestCase
+{
+
+    /**
+     * Test setting and retrieving message ID.
+     */
+    public function testMessageID()
+    {
+        $this->Mail->Body = 'Test message ID.';
+        $id = hash('sha256', 12345);
+        $this->Mail->MessageID = $id;
+        $this->buildBody();
+        $this->Mail->preSend();
+        $lastid = $this->Mail->getLastMessageID();
+        self::assertNotSame($lastid, $id, 'Invalid Message ID allowed');
+        $id = '<' . hash('sha256', 12345) . '@example.com>';
+        $this->Mail->MessageID = $id;
+        $this->buildBody();
+        $this->Mail->preSend();
+        $lastid = $this->Mail->getLastMessageID();
+        self::assertSame($lastid, $id, 'Custom Message ID not used');
+        $this->Mail->MessageID = '';
+        $this->buildBody();
+        $this->Mail->preSend();
+        $lastid = $this->Mail->getLastMessageID();
+        self::assertMatchesRegularExpression('/^<.*@.*>$/', $lastid, 'Invalid default Message ID');
+    }
+}

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -32,13 +32,13 @@ final class GetLastMessageIDTest extends TestCase
         $this->buildBody();
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
-        self::assertNotSame($lastid, $id, 'Invalid Message ID allowed');
+        self::assertNotSame($id, $lastid, 'Invalid Message ID allowed');
         $id = '<' . hash('sha256', 12345) . '@example.com>';
         $this->Mail->MessageID = $id;
         $this->buildBody();
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
-        self::assertSame($lastid, $id, 'Custom Message ID not used');
+        self::assertSame($id, $lastid, 'Custom Message ID not used');
         $this->Mail->MessageID = '';
         $this->buildBody();
         $this->Mail->preSend();

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -23,11 +23,14 @@ final class GetLastMessageIDTest extends TestCase
 
     /**
      * Test setting and retrieving an invalid message ID.
+     *
+     * @dataProvider dataMessageIDInvalid
+     *
+     * @param string $id Custom, invalid message ID.
      */
-    public function testMessageIDInvalid()
+    public function testMessageIDInvalid($id)
     {
         $this->Mail->Body = 'Test message ID.';
-        $id = hash('sha256', 12345);
         $this->Mail->MessageID = $id;
         $this->buildBody();
         $this->Mail->preSend();
@@ -36,17 +39,44 @@ final class GetLastMessageIDTest extends TestCase
     }
 
     /**
-     * Test setting and retrieving a valid, custom message ID.
+     * Data provider.
+     *
+     * @return array
      */
-    public function testMessageIDValid()
+    public function dataMessageIDInvalid()
+    {
+        return [
+            'Invalid: plain hash' => [ hash('sha256', 12345) ],
+        ];
+    }
+
+    /**
+     * Test setting and retrieving a valid, custom message ID.
+     *
+     * @dataProvider dataMessageIDValid
+     *
+     * @param string $id Custom, valid message ID.
+     */
+    public function testMessageIDValid($id)
     {
         $this->Mail->Body = 'Test message ID.';
-        $id = '<' . hash('sha256', 12345) . '@example.com>';
         $this->Mail->MessageID = $id;
         $this->buildBody();
         $this->Mail->preSend();
         $lastid = $this->Mail->getLastMessageID();
         self::assertSame($id, $lastid, 'Custom Message ID not used');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMessageIDValid()
+    {
+        return [
+            'hashed pre @' => [ '<' . hash('sha256', 12345) . '@example.com>' ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1451,31 +1451,6 @@ EOT;
     }
 
     /**
-     * Test setting and retrieving message ID.
-     */
-    public function testMessageID()
-    {
-        $this->Mail->Body = 'Test message ID.';
-        $id = hash('sha256', 12345);
-        $this->Mail->MessageID = $id;
-        $this->buildBody();
-        $this->Mail->preSend();
-        $lastid = $this->Mail->getLastMessageID();
-        self::assertNotSame($lastid, $id, 'Invalid Message ID allowed');
-        $id = '<' . hash('sha256', 12345) . '@example.com>';
-        $this->Mail->MessageID = $id;
-        $this->buildBody();
-        $this->Mail->preSend();
-        $lastid = $this->Mail->getLastMessageID();
-        self::assertSame($lastid, $id, 'Custom Message ID not used');
-        $this->Mail->MessageID = '';
-        $this->buildBody();
-        $this->Mail->preSend();
-        $lastid = $this->Mail->getLastMessageID();
-        self::assertMatchesRegularExpression('/^<.*@.*>$/', $lastid, 'Invalid default Message ID');
-    }
-
-    /**
      * Check whether setting a bad custom header throws exceptions.
      *
      * @throws Exception


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385


## Commit details

### Tests/reorganize: move message ID test to own file

### GetLastMessageIDTest: use the correct parameter order

For PHPUnit assertions which expect an `$expected` and a `$result` parameter, the parameter order is always `( $expected, $result, ...).

While it may not seem important to use the correct parameter order for assertions doing a straight comparison, in actual fact, it is.
The PHPUnit output when the assertions fail expects this order and the failure message will be reversed if the parameters are passed in reversed order which leads to confusion and makes it more difficult to debug a failing test.

### GetLastMessageIDTest: split into separate tests

### GetLastMessageIDTest: reorganize to use data providers

While initially still only addressing the original test cases, using a data provider here will allow for adding additional test cases more easily.

### GetLastMessageIDTest: add additional tests

Adding additional tests based on the code this is supposed to be testing.

👉🏻  **Note**: I've put the test cases in the "valid"/"invalid" data providers based on the current reality.
Some of the test cases I've added to the "valid" data provider _might_ actually be **_invalid_**. If that's the case, [the regex used on line 2554](https://github.com/PHPMailer/PHPMailer/blob/4ad936e3b5f5bd90ce6e2c08f6ae94a5a3074e22/src/PHPMailer.php#L2554) needs adjusting (or replacing with alternative logic) to account for them (after which the test cases can be moved to the "invalid" data provider).


### GetLastMessageIDTest: add @covers tags 