### PR TITLE
Tests: move utf8CharBoundary test to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1744,15 +1744,4 @@ EOT;
         $this->assertSame($expectedqp, $this->Mail->wrapText($message, 50, true));
         $this->assertSame($expected, $this->Mail->wrapText($message, 50, false));
     }
-
-    public function testEncodedText_utf8CharBoundary_returnsCorrectMaxLength()
-    {
-        $encodedWordWithMultiByteCharFirstByte = 'H=E4tten';
-        $encodedSingleByteCharacter = '=0C';
-        $encodedWordWithMultiByteCharMiddletByte = 'L=C3=B6rem';
-
-        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharFirstByte, 3));
-        $this->assertSame(3, $this->Mail->utf8CharBoundary($encodedSingleByteCharacter, 3));
-        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharMiddletByte, 6));
-    }
 }

--- a/test/PHPMailer/Utf8CharBoundaryTest.php
+++ b/test/PHPMailer/Utf8CharBoundaryTest.php
@@ -20,6 +20,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  * Test UTF8 character boundary functionality.
  *
  * @covers \PHPMailer\PHPMailer\PHPMailer::utf8CharBoundary
+ *
+ * @todo Add more testcases to properly cover all paths in the method!
  */
 final class Utf8CharBoundaryTest extends TestCase
 {

--- a/test/PHPMailer/Utf8CharBoundaryTest.php
+++ b/test/PHPMailer/Utf8CharBoundaryTest.php
@@ -13,22 +13,55 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\TestCase;
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test UTF8 character boundary functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::utf8CharBoundary
  */
 final class Utf8CharBoundaryTest extends TestCase
 {
 
-    public function testEncodedText_utf8CharBoundary_returnsCorrectMaxLength()
+    /**
+     * Verify that the utf8CharBoundary() returns the correct last character boundary for encoded text.
+     *
+     * @dataProvider dataUtf8CharBoundary
+     *
+     * @param string $encodedText UTF-8 QP text to use as input string.
+     * @param int    $maxLength   Max length to pass to the function.
+     * @param int    $expected    Expected function output.
+     */
+    public function testUtf8CharBoundary($encodedText, $maxLength, $expected)
     {
-        $encodedWordWithMultiByteCharFirstByte = 'H=E4tten';
-        $encodedSingleByteCharacter = '=0C';
-        $encodedWordWithMultiByteCharMiddletByte = 'L=C3=B6rem';
+        $mail = new PHPMailer();
+        $this->assertSame($expected, $mail->utf8CharBoundary($encodedText, $maxLength));
+    }
 
-        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharFirstByte, 3));
-        $this->assertSame(3, $this->Mail->utf8CharBoundary($encodedSingleByteCharacter, 3));
-        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharMiddletByte, 6));
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataUtf8CharBoundary()
+    {
+        return [
+            'Encoded word with multibyte char first byte' => [
+                'encodedText' => 'H=E4tten',
+                'maxLength'   => 3,
+                'expected'    => 1,
+            ],
+            'Encoded single byte char' => [
+                'encodedText' => '=0C',
+                'maxLength'   => 3,
+                'expected'    => 3,
+            ],
+            'Encoded word with multi byte char middle byte' => [
+                'encodedText' => 'L=C3=B6rem',
+                'maxLength'   => 6,
+                'expected'    => 1,
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/Utf8CharBoundaryTest.php
+++ b/test/PHPMailer/Utf8CharBoundaryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test UTF8 character boundary functionality.
+ */
+final class Utf8CharBoundaryTest extends TestCase
+{
+
+    public function testEncodedText_utf8CharBoundary_returnsCorrectMaxLength()
+    {
+        $encodedWordWithMultiByteCharFirstByte = 'H=E4tten';
+        $encodedSingleByteCharacter = '=0C';
+        $encodedWordWithMultiByteCharMiddletByte = 'L=C3=B6rem';
+
+        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharFirstByte, 3));
+        $this->assertSame(3, $this->Mail->utf8CharBoundary($encodedSingleByteCharacter, 3));
+        $this->assertSame(1, $this->Mail->utf8CharBoundary($encodedWordWithMultiByteCharMiddletByte, 6));
+    }
+}


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387

## Commit details

### Tests/reorganize: move utf8CharBoundary test to own file

### Utf8CharBoundaryTest: reorganize to use data providers

This:
* Renames the test method and moves the description to the docblock.
* Decouples the test from the PHPMailer `TestCase` as it doesn't need the complete `set_up()` and `tear_down()`.
* Moves the test cases to a data provider.
* Adds a `@covers` tag.

### Utf8CharBoundaryTest: add @todo reminder

This really could do with some more test cases to properly cover all paths and branching in the method.

