### PR TITLE
Tests: move Auth CRAM MD5 test to own file

### DIFF
--- a/test/PHPMailer/AuthCRAMMD5Test.php
+++ b/test/PHPMailer/AuthCRAMMD5Test.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test CRAM-MD5 authentication functionality.
+ */
+final class AuthCRAMMD5Test extends TestCase
+{
+
+    /**
+     * Test CRAM-MD5 authentication.
+     * Needs a connection to a server that supports this auth mechanism, so commented out by default.
+     */
+    public function testAuthCRAMMD5()
+    {
+        $this->markTestIncomplete(
+            'Test needs a connection to a server supporting the CRAMMD5 auth mechanism.'
+        );
+
+        $this->Mail->Host = 'hostname';
+        $this->Mail->Port = 587;
+        $this->Mail->SMTPAuth = true;
+        $this->Mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+        $this->Mail->AuthType = 'CRAM-MD5';
+        $this->Mail->Username = 'username';
+        $this->Mail->Password = 'password';
+        $this->Mail->Body = 'Test body';
+        $this->Mail->Subject .= ': Auth CRAM-MD5';
+        $this->Mail->From = 'from@example.com';
+        $this->Mail->Sender = 'from@example.com';
+        $this->Mail->clearAllRecipients();
+        $this->Mail->addAddress('user@example.com');
+        //self::assertTrue($this->mail->send(), $this->mail->ErrorInfo);
+    }
+}

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -36,32 +36,6 @@ final class PHPMailerTest extends TestCase
     }
 
     /**
-     * Test CRAM-MD5 authentication.
-     * Needs a connection to a server that supports this auth mechanism, so commented out by default.
-     */
-    public function testAuthCRAMMD5()
-    {
-        $this->markTestIncomplete(
-            'Test needs a connection to a server supporting the CRAMMD5 auth mechanism.'
-        );
-
-        $this->Mail->Host = 'hostname';
-        $this->Mail->Port = 587;
-        $this->Mail->SMTPAuth = true;
-        $this->Mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
-        $this->Mail->AuthType = 'CRAM-MD5';
-        $this->Mail->Username = 'username';
-        $this->Mail->Password = 'password';
-        $this->Mail->Body = 'Test body';
-        $this->Mail->Subject .= ': Auth CRAM-MD5';
-        $this->Mail->From = 'from@example.com';
-        $this->Mail->Sender = 'from@example.com';
-        $this->Mail->clearAllRecipients();
-        $this->Mail->addAddress('user@example.com');
-        //self::assertTrue($this->mail->send(), $this->mail->ErrorInfo);
-    }
-
-    /**
      * Word-wrap an ASCII message.
      */
     public function testWordWrap()


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389

## Commit details

### Tests/reorganize: move Auth CRAM MD5 test to own file

As this test is marked _incomplete_, no further review of the test has been done and no `@covers` tag has been added.