### PR TITLE
PopBeforeSmtpTest: skip on Windows

### DIFF
--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -48,6 +48,16 @@ final class PopBeforeSmtpTest extends TestCase
     }
 
     /**
+     * Run before each test is started.
+     */
+    protected function set_up()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('This test needs a non-Windows OS to run');
+        }
+    }
+
+    /**
      * Run after each test is completed.
      */
     protected function tear_down()


### PR DESCRIPTION
Follow up on #2382

The shell commands used in the test are not available on Windows, so these tests would always fail, so we may as well skip them.