### PR TITLE
Tests: move wrapText test to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1707,15 +1707,4 @@ EOT;
         );
         $this->assertSame('test@xn--franois-xxa.ch', $result);
     }
-
-    public function testVeryLongWordInMessage_wrapText_returnsWrappedText()
-    {
-        $message = 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy';
-        $expected = 'Lorem' . PHPMailer::getLE() .
-            'ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy' . PHPMailer::getLE();
-        $expectedqp = 'Lorem ipsumdolorsitametconsetetursadipscingelitrs=' .
-            PHPMailer::getLE() . 'eddiamnonumy' . PHPMailer::getLE();
-        $this->assertSame($expectedqp, $this->Mail->wrapText($message, 50, true));
-        $this->assertSame($expected, $this->Mail->wrapText($message, 50, false));
-    }
 }

--- a/test/PHPMailer/WrapTextTest.php
+++ b/test/PHPMailer/WrapTextTest.php
@@ -22,14 +22,41 @@ use PHPMailer\Test\TestCase;
 final class WrapTextTest extends TestCase
 {
 
-    public function testVeryLongWordInMessage_wrapText_returnsWrappedText()
+    /**
+     * Test wrapping text.
+     *
+     * @dataProvider dataWrapText
+     *
+     * @param string $message  Input text string.
+     * @param string $expected Expected funtion output.
+     * @param bool   $qp_mode  Optional. Whether to run in Quoted-Printable mode. Defaults to `false`.
+     * @param int    $length   Optional. Length to wrap at. Defaults to `50`.
+     */
+    public function testWrapText($message, $expected, $qp_mode = false, $length = 50)
     {
-        $message = 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy';
-        $expected = 'Lorem' . PHPMailer::getLE() .
-            'ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy' . PHPMailer::getLE();
-        $expectedqp = 'Lorem ipsumdolorsitametconsetetursadipscingelitrs=' .
-            PHPMailer::getLE() . 'eddiamnonumy' . PHPMailer::getLE();
-        $this->assertSame($expectedqp, $this->Mail->wrapText($message, 50, true));
-        $this->assertSame($expected, $this->Mail->wrapText($message, 50, false));
+        $this->assertSame($expected, $this->Mail->wrapText($message, $length, $qp_mode));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataWrapText()
+    {
+        return [
+            'very long word in message, qp: false' => [
+                'message'  => 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy',
+                'expected' => 'Lorem' . PHPMailer::getLE()
+                    . 'ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy' . PHPMailer::getLE(),
+                'qp_mode'  => false,
+            ],
+            'very long word in message, qp: true' => [
+                'message'  => 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy',
+                'expected' => 'Lorem ipsumdolorsitametconsetetursadipscingelitrs=' . PHPMailer::getLE()
+                    . 'eddiamnonumy' . PHPMailer::getLE(),
+                'qp_mode'  => true,
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/WrapTextTest.php
+++ b/test/PHPMailer/WrapTextTest.php
@@ -18,6 +18,8 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test word wrapping functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::wrapText
  */
 final class WrapTextTest extends TestCase
 {

--- a/test/PHPMailer/WrapTextTest.php
+++ b/test/PHPMailer/WrapTextTest.php
@@ -45,6 +45,60 @@ final class WrapTextTest extends TestCase
     public function dataWrapText()
     {
         return [
+            'empty string' => [
+                'message'  => '',
+                'expected' => PHPMailer::getLE(),
+                'qp_mode'  => false,
+            ],
+            'line length less than wrap limit, qp: false' => [
+                'message'  => 'Lorem ipsum dolor sit amet.',
+                'expected' => 'Lorem ipsum dolor sit amet.' . PHPMailer::getLE(),
+                'qp_mode'  => false,
+            ],
+            'line length less than wrap limit, qp: true' => [
+                'message'  => 'Lorem ipsum dolor sit amet.',
+                'expected' => 'Lorem ipsum dolor sit amet.' . PHPMailer::getLE(),
+                'qp_mode'  => true,
+            ],
+            'message with line ending at end' => [
+                'message'  => 'Lorem ipsum dolor' . PHPMailer::CRLF,
+                'expected' => 'Lorem ipsum dolor' . PHPMailer::getLE(),
+            ],
+            'line length more than wrap limit, qp: false' => [
+                'message'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+                    . ' Maecenas ultricies nisi justo, eu convallis tortor porttitor a.'
+                    . ' Nam ut risus tellus. Vivamus imperdiet dictum nibh, in faucibus nunc pretium ac.',
+                'expected' => 'Lorem ipsum dolor sit amet, consectetur adipiscing' . PHPMailer::getLE()
+                    . 'elit. Maecenas ultricies nisi justo, eu convallis' . PHPMailer::getLE()
+                    . 'tortor porttitor a. Nam ut risus tellus. Vivamus' . PHPMailer::getLE()
+                    . 'imperdiet dictum nibh, in faucibus nunc pretium' . PHPMailer::getLE()
+                    . 'ac.' . PHPMailer::getLE(),
+                'qp_mode'  => false,
+            ],
+            'line length more than wrap limit, qp: true' => [
+                'message'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+                    . ' Maecenas ultricies nisi justo, eu convallis tortor porttitor a.'
+                    . ' Nam ut risus tellus. Vivamus imperdiet dictum nibh, in faucibus nunc pretium ac.',
+                'expected' => 'Lorem ipsum dolor sit amet, consectetur adipiscing =' . PHPMailer::getLE()
+                    . 'elit. Maecenas ultricies nisi justo, eu convallis =' . PHPMailer::getLE()
+                    . 'tortor porttitor a. Nam ut risus tellus. Vivamus =' . PHPMailer::getLE()
+                    . 'imperdiet dictum nibh, in faucibus nunc pretium =' . PHPMailer::getLE()
+                    . 'ac.' . PHPMailer::getLE(),
+                'qp_mode'  => true,
+            ],
+            'line length more than wrap limit, message already in qp format, qp: true' => [
+                'message'  => 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. =' . PHPMailer::CRLF
+                    . 'Maecenas ultricies nisi justo, eu convallis tortor porttitor a. =' . PHPMailer::CRLF
+                    . 'Nam ut risus tellus. Vivamus imperdiet dictum nibh, in faucibus nunc pretium ac.'
+                    . PHPMailer::CRLF,
+                'expected' => 'Lorem ipsum dolor sit amet, consectetur adipiscing =' . PHPMailer::getLE()
+                    . 'elit. =' . PHPMailer::getLE()
+                    . 'Maecenas ultricies nisi justo, eu convallis tortor =' . PHPMailer::getLE()
+                    . 'porttitor a. =' . PHPMailer::getLE()
+                    . 'Nam ut risus tellus. Vivamus imperdiet dictum =' . PHPMailer::getLE()
+                    . 'nibh, in faucibus nunc pretium ac.' . PHPMailer::getLE(),
+                'qp_mode'  => true,
+            ],
             'very long word in message, qp: false' => [
                 'message'  => 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy',
                 'expected' => 'Lorem' . PHPMailer::getLE()
@@ -55,6 +109,14 @@ final class WrapTextTest extends TestCase
                 'message'  => 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy',
                 'expected' => 'Lorem ipsumdolorsitametconsetetursadipscingelitrs=' . PHPMailer::getLE()
                     . 'eddiamnonumy' . PHPMailer::getLE(),
+                'qp_mode'  => true,
+            ],
+            'very long word in message, message already in qp format, qp: true' => [
+                'message'  => 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiam=' . PHPMailer::CRLF
+                    . 'nonumy',
+                'expected' => 'Lorem =' . PHPMailer::getLE()
+                    . 'ipsumdolorsitametconsetetursadipscingelitrseddiam=' . PHPMailer::getLE()
+                    . 'nonumy' . PHPMailer::getLE(),
                 'qp_mode'  => true,
             ],
         ];

--- a/test/PHPMailer/WrapTextTest.php
+++ b/test/PHPMailer/WrapTextTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test word wrapping functionality.
+ */
+final class WrapTextTest extends TestCase
+{
+
+    public function testVeryLongWordInMessage_wrapText_returnsWrappedText()
+    {
+        $message = 'Lorem ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy';
+        $expected = 'Lorem' . PHPMailer::getLE() .
+            'ipsumdolorsitametconsetetursadipscingelitrseddiamnonumy' . PHPMailer::getLE();
+        $expectedqp = 'Lorem ipsumdolorsitametconsetetursadipscingelitrs=' .
+            PHPMailer::getLE() . 'eddiamnonumy' . PHPMailer::getLE();
+        $this->assertSame($expectedqp, $this->Mail->wrapText($message, 50, true));
+        $this->assertSame($expected, $this->Mail->wrapText($message, 50, false));
+    }
+}


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392

## Commit details

### Tests/reorganize: move wrapText test to own file

### WrapTextTest: reorganize to use data providers

* Maintains the existing test cases.
* Prevent one failing assertion hiding a potential second failure.
* Makes it easier to add additional test cases in the future.

### WrapTextTest: add additional test cases

... in part to document the behaviour of the function, in part to actually test it.

By the looks of it more tests are still needed though to raise the code coverage of this function to 100%.

👉🏻 I'd also recommend adding tests with different charset settings as the current tests are all based on the default charset (`CHARSET_ISO88591`).

**_Also note: the "empty string" test may need looking at.... is this a bug ?_**

### WrapTextTest: add `@covers` tag 