### PR TITLE
Tests: stabilize handling of static properties in PHPMailer class

### DIFF
--- a/test/PHPMailer/ValidateAddressTest.php
+++ b/test/PHPMailer/ValidateAddressTest.php
@@ -35,6 +35,23 @@ final class ValidateAddressTest extends TestCase
 {
 
     /**
+     * Run before this test class.
+     */
+    public static function set_up_before_class()
+    {
+        // Make sure that validator property starts off with its default value.
+        PHPMailer::$validator = 'php';
+    }
+
+    /**
+     * Run after this test class.
+     */
+    public static function tear_down_after_class()
+    {
+        self::set_up_before_class();
+    }
+
+    /**
      * Testing against the pre-defined patterns with a valid address (for coverage).
      *
      * @dataProvider dataPatterns

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -51,6 +51,17 @@ abstract class TestCase extends PolyfillTestCase
     private $NoteLog = [];
 
     /**
+     * List of *public static* properties in the PHPMailer class with their default values.
+     *
+     * This list is used by the `set_up()` method.
+     *
+     * @var array Key is the property name, value the default as per the PHPMailer class.
+     */
+    private $PHPMailerStaticProps = [
+        'validator' => 'php',
+    ];
+
+    /**
      * Run before each test class.
      */
     public static function set_up_before_class()
@@ -69,6 +80,11 @@ abstract class TestCase extends PolyfillTestCase
      */
     protected function set_up()
     {
+        // Make sure that public static variables contain their default values at the start of each test.
+        foreach ($this->PHPMailerStaticProps as $key => $value) {
+            PHPMailer::${$key} = $value;
+        }
+
         if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
             include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; //Overrides go in here
         }


### PR DESCRIPTION
### TestCase: stabilize handling of static properties in PHPMailer class

Public static properties changed by individual tests were not being reset to their default value prior to the next test being run.
This could influence the test results of subsequent tests as static properties are not automatically reset when a new instance of a class is instantiated. See: https://3v4l.org/8s1RB

Luckily this didn't adversely affect the tests so far, but should be safeguarded for the future.

There are only three static properties in the `PHPMailer` class, with only one of these being `public`.

This commit introduces a code snippet which will reset any static properties as listed in the `$PHPMailerStaticProps` property of the `TestCase` to the default value, as also set in the `$PHPMailerStaticProps` property, at the start of the `set_up()` which is run before each test using the `TestCase`.

For now, this is only relevant for the `ValidateAddressCustomValidatorTest` test and only when the `testSetDefaultValidatorToCustom()` test would fail before resetting the property. All the same, having the reset in place by default will ensure that future tests which change this property won't introduce side-effects to other tests.

### ValidateAddressTest: stabilize handling of static $validator property in PHPMailer class

While this class does not (currently) _change_ the `PHPMailer::$validator` property, it does rely on the default value being the expected default.

By resetting the value of the property before and after the class, this is safeguarded for the current tests.

