### PR TITLE
TestCase: various tweaks

### DIFF
--- a/test/PHPMailer/DKIMTest.php
+++ b/test/PHPMailer/DKIMTest.php
@@ -25,6 +25,13 @@ use PHPMailer\Test\TestCase;
 final class DKIMTest extends TestCase
 {
 
+    /**
+     * Whether or not to initialize the PHPMailer object to throw exceptions.
+     *
+     * @var bool|null
+     */
+    const USE_EXCEPTIONS = true;
+
     const PRIVATE_KEY_FILE = 'dkim_private.pem';
 
     /**
@@ -250,7 +257,6 @@ final class DKIMTest extends TestCase
         $this->expectException(Exception::class);
         $this->expectExceptionMessage('Extension missing: openssl');
 
-        $mail = new PHPMailer(true);
-        $mail->DKIM_Sign('foo');
+        $this->Mail->DKIM_Sign('foo');
     }
 }

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -81,7 +81,7 @@ final class MailTransportTest extends TestCase
         $this->setAddress('testmailsend@example.com', 'totest');
         $this->setAddress('cctestmailsend@example.com', 'cctest', $sType = 'cc');
         $this->setAddress('bcctestmailsend@example.com', 'bcctest', $sType = 'bcc');
-        $this->Mail->addReplyTo('replytotestmailsend@example.com', 'replytotest');
+        $this->setAddress('replytotestmailsend@example.com', 'replytotest', $sType = 'ReplyTo');
 
         self::assertContains('testmailsend@example.com', $this->Mail->getToAddresses()[0], 'To address not found');
         self::assertContains('cctestmailsend@example.com', $this->Mail->getCcAddresses()[0], 'CC address not found');

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -90,7 +90,7 @@ abstract class TestCase extends PolyfillTestCase
         }
 
         if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
-            include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; //Overrides go in here
+            include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; // Overrides go in here.
         }
 
         // Initialize the PHPMailer class.
@@ -100,7 +100,7 @@ abstract class TestCase extends PolyfillTestCase
             $this->Mail = new PHPMailer();
         }
 
-        $this->Mail->SMTPDebug = SMTP::DEBUG_CONNECTION; //Full debug output
+        $this->Mail->SMTPDebug = SMTP::DEBUG_CONNECTION; // Full debug output.
         $this->Mail->Debugoutput = ['PHPMailer\Test\DebugLogTestListener', 'debugLog'];
         $this->Mail->Priority = 3;
         $this->Mail->Encoding = '8bit';
@@ -159,7 +159,7 @@ abstract class TestCase extends PolyfillTestCase
      */
     protected function tear_down()
     {
-        //Clean global variables
+        // Clean test class native properties between tests.
         $this->Mail = null;
         $this->ChangeLog = [];
         $this->NoteLog = [];
@@ -172,7 +172,7 @@ abstract class TestCase extends PolyfillTestCase
     {
         $this->checkChanges();
 
-        //Determine line endings for message
+        // Determine line endings for message.
         if ('text/html' === $this->Mail->ContentType || $this->Mail->AltBody !== '') {
             $eol = "<br>\r\n";
             $bullet_start = '<li>';
@@ -200,7 +200,7 @@ abstract class TestCase extends PolyfillTestCase
             $ReportBody .= 'Host: ' . $this->Mail->Host . $eol;
         }
 
-        //If attachments then create an attachment list
+        // If attachments then create an attachment list.
         $attachments = $this->Mail->getAttachments();
         if (count($attachments) > 0) {
             $ReportBody .= 'Attachments:' . $eol;
@@ -213,7 +213,7 @@ abstract class TestCase extends PolyfillTestCase
             $ReportBody .= $list_end . $eol;
         }
 
-        //If there are changes then list them
+        // If there are changes then list them.
         if (count($this->ChangeLog) > 0) {
             $ReportBody .= 'Changes' . $eol;
             $ReportBody .= '-------' . $eol;
@@ -226,7 +226,7 @@ abstract class TestCase extends PolyfillTestCase
             $ReportBody .= $list_end . $eol . $eol;
         }
 
-        //If there are notes then list them
+        // If there are notes then list them.
         if (count($this->NoteLog) > 0) {
             $ReportBody .= 'Notes' . $eol;
             $ReportBody .= '-----' . $eol;
@@ -238,7 +238,7 @@ abstract class TestCase extends PolyfillTestCase
             $ReportBody .= $list_end;
         }
 
-        //Re-attach the original body
+        // Re-attach the original body.
         $this->Mail->Body .= $eol . $ReportBody;
     }
 

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -30,13 +30,6 @@ abstract class TestCase extends PolyfillTestCase
     protected $Mail;
 
     /**
-     * Holds the SMTP mail host.
-     *
-     * @var string
-     */
-    private $Host = '';
-
-    /**
      * Holds the change log.
      *
      * @var string[]

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -121,7 +121,7 @@ abstract class TestCase extends PolyfillTestCase
         if (array_key_exists('mail_userpass', $_REQUEST)) {
             $this->Mail->Password = $_REQUEST['mail_userpass'];
         }
-        $this->Mail->addReplyTo('no_reply@phpmailer.example.com', 'Reply Guy');
+        $this->setAddress('no_reply@phpmailer.example.com', 'Reply Guy', 'ReplyTo');
         $this->Mail->Sender = 'unit_test@phpmailer.example.com';
         if ($this->Mail->Host != '') {
             $this->Mail->isSMTP();
@@ -297,6 +297,8 @@ abstract class TestCase extends PolyfillTestCase
                 return $this->Mail->addCC($sAddress, $sName);
             case 'bcc':
                 return $this->Mail->addBCC($sAddress, $sName);
+            case 'ReplyTo':
+                return $this->Mail->addReplyTo($sAddress, $sName);
         }
 
         return false;

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -22,6 +22,17 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillTestCase;
  */
 abstract class TestCase extends PolyfillTestCase
 {
+
+    /**
+     * Whether or not to initialize the PHPMailer object to throw exceptions.
+     *
+     * Overload this constant in a concrete test class and set the value to `true`
+     * to initialize PHPMailer with Exceptions turned on.
+     *
+     * @var bool|null
+     */
+    const USE_EXCEPTIONS = null;
+
     /**
      * Holds the PHPMailer instance.
      *
@@ -81,7 +92,14 @@ abstract class TestCase extends PolyfillTestCase
         if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
             include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; //Overrides go in here
         }
-        $this->Mail = new PHPMailer();
+
+        // Initialize the PHPMailer class.
+        if (is_bool(static::USE_EXCEPTIONS)) {
+            $this->Mail = new PHPMailer(static::USE_EXCEPTIONS);
+        } else {
+            $this->Mail = new PHPMailer();
+        }
+
         $this->Mail->SMTPDebug = SMTP::DEBUG_CONNECTION; //Full debug output
         $this->Mail->Debugoutput = ['PHPMailer\Test\DebugLogTestListener', 'debugLog'];
         $this->Mail->Priority = 3;


### PR DESCRIPTION
Follow up on #2376

## Commit Details

### TestCase: remove unused property

### TestCase::setAddress(): add support for ReplyTo

This allows for using the `setAddress()` method in a more consistent manner (where appropriate).

Includes introducing the use of the `setAddress()` function in a few select places.

Note: I do wonder whether this method should ever be used outside of `set_up()` and `tear_down()`, but that is for further discussion and outside the scope of this commit.

### TestCase: add support for initializing PHPMailer with exceptions

The `PHPMailer::__construct()` method has an optional `$exceptions` property to throw exceptions on errors.

Up to now, the `PHPMailer` instance created by the `set_up()` would not pass any parameters, effectively instantiating `PHPMailer` without turning on exceptions.

In a test situation it may be useful for tests to test the behaviour of a method _with_ and _without_ the exceptions option and to test that certain exceptions are thrown and throw the correct message.

With that in mind, I'm introducing a `USE_EXCEPTIONS` class constant to the `TestCase` which can be overloaded in individual test classes and will be used by the `set_up()` method to determine whether it will be instantiated with exceptions or not.

Includes introducing an overload of the class constant in one of the test class for which it would seem appropriate at this time.
Note: this does mean that the `testDKIMSigningMail()` test will show as errored instead of failed if no SMTP connection could be made, but that IMO is the more correct status anyhow.


### TestCase: minor tidying up

... of the inline comments in the `TestCase` file.

