### PR TITLE
Tests: move line break normalization tests to own file

### DIFF
--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test normalize line breaks functionality.
+ */
+final class NormalizeBreaksTest extends TestCase
+{
+
+    /**
+     * Test line break reformatting.
+     */
+    public function testLineBreaks()
+    {
+        $unixsrc = "hello\nWorld\nAgain\n";
+        $macsrc = "hello\rWorld\rAgain\r";
+        $windowssrc = "hello\r\nWorld\r\nAgain\r\n";
+        $mixedsrc = "hello\nWorld\rAgain\r\n";
+        $target = "hello\r\nWorld\r\nAgain\r\n";
+        self::assertSame($target, PHPMailer::normalizeBreaks($unixsrc), 'UNIX break reformatting failed');
+        self::assertSame($target, PHPMailer::normalizeBreaks($macsrc), 'Mac break reformatting failed');
+        self::assertSame($target, PHPMailer::normalizeBreaks($windowssrc), 'Windows break reformatting failed');
+        self::assertSame($target, PHPMailer::normalizeBreaks($mixedsrc), 'Mixed break reformatting failed');
+    }
+
+    /**
+     * Miscellaneous calls to improve test coverage and some small tests.
+     */
+    public function testMiscellaneous()
+    {
+        //Line break normalization
+        $eol = PHPMailer::getLE();
+        $b1 = "1\r2\r3\r";
+        $b2 = "1\n2\n3\n";
+        $b3 = "1\r\n2\r3\n";
+        $t1 = "1{$eol}2{$eol}3{$eol}";
+        self::assertSame($t1, PHPMailer::normalizeBreaks($b1), 'Failed to normalize line breaks (1)');
+        self::assertSame($t1, PHPMailer::normalizeBreaks($b2), 'Failed to normalize line breaks (2)');
+        self::assertSame($t1, PHPMailer::normalizeBreaks($b3), 'Failed to normalize line breaks (3)');
+    }
+}

--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -14,6 +14,7 @@
 namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase as MailerTestCase;
 use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
@@ -84,5 +85,26 @@ final class NormalizeBreaksTest extends TestCase
                 'breaktype' => $LE,
             ],
         ];
+    }
+
+    /**
+     * Test line break normalization with a custom line ending setting.
+     */
+    public function testNormalizeBreaksWithCustomLineEnding()
+    {
+        $input    = "hello\rWorld\rAgain\r";
+        $expected = "hello\n\rWorld\n\rAgain\n\r";
+
+        $origLE = PHPMailer::getLE();
+        MailerTestCase::updateStaticProperty(PHPMailer::class, 'LE', "\n\r");
+        $result = PHPMailer::normalizeBreaks($input);
+
+        /*
+         * Reset the static property *before* the assertion to ensure the reset executes
+         * even when the test would fail.
+         */
+        MailerTestCase::updateStaticProperty(PHPMailer::class, 'LE', $origLE);
+
+        self::assertSame($expected, $result, 'Line break reformatting failed');
     }
 }

--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -23,34 +23,62 @@ final class NormalizeBreaksTest extends TestCase
 {
 
     /**
-     * Test line break reformatting.
+     * Test line break normalization.
+     *
+     * @dataProvider dataNormalizeBreaks
+     *
+     * @param string $input     Input text string.
+     * @param string $expected  Expected funtion output.
+     * @param string $breaktype Optional. What kind of line break to use.
      */
-    public function testLineBreaks()
+    public function testNormalizeBreaks($input, $expected, $breaktype = null)
     {
-        $unixsrc = "hello\nWorld\nAgain\n";
-        $macsrc = "hello\rWorld\rAgain\r";
-        $windowssrc = "hello\r\nWorld\r\nAgain\r\n";
-        $mixedsrc = "hello\nWorld\rAgain\r\n";
-        $target = "hello\r\nWorld\r\nAgain\r\n";
-        self::assertSame($target, PHPMailer::normalizeBreaks($unixsrc), 'UNIX break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($macsrc), 'Mac break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($windowssrc), 'Windows break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($mixedsrc), 'Mixed break reformatting failed');
+        $result = PHPMailer::normalizeBreaks($input, $breaktype);
+        self::assertSame($expected, $result, 'Line break reformatting failed');
     }
 
     /**
-     * Miscellaneous calls to improve test coverage and some small tests.
+     * Data provider.
+     *
+     * @return array
      */
-    public function testMiscellaneous()
+    public function dataNormalizeBreaks()
     {
-        //Line break normalization
-        $eol = PHPMailer::getLE();
-        $b1 = "1\r2\r3\r";
-        $b2 = "1\n2\n3\n";
-        $b3 = "1\r\n2\r3\n";
-        $t1 = "1{$eol}2{$eol}3{$eol}";
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b1), 'Failed to normalize line breaks (1)');
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b2), 'Failed to normalize line breaks (2)');
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b3), 'Failed to normalize line breaks (3)');
+        $LE           = PHPMailer::getLE();
+        $baseExpected = 'hello' . PHPMailer::CRLF . 'World' . PHPMailer::CRLF . 'Again' . PHPMailer::CRLF;
+
+        return [
+            'Unix line breaks' => [
+                'input'    => "hello\nWorld\nAgain\n",
+                'expected' => $baseExpected,
+            ],
+            'Mac line breaks' => [
+                'input'    => "hello\rWorld\rAgain\r",
+                'expected' => $baseExpected,
+            ],
+            'Windows line breaks' => [
+                'input'    => "hello\r\nWorld\r\nAgain\r\n",
+                'expected' => $baseExpected,
+            ],
+            'Mixed line breaks' => [
+                'input'    => "hello\nWorld\rAgain\r\n",
+                'expected' => $baseExpected,
+            ],
+            'Mac line breaks, enforce Unix' => [
+                'input'     => "1\r2\r3\r",
+                'expected'  => "1\n2\n3\n",
+                'breaktype' => "\n",
+            ],
+            'Unix line breaks, enforce Mac' => [
+                'input'     => "1\n2\n3\n",
+                'expected'  => "1\r2\r3\r",
+                'breaktype' => "\r",
+            ],
+            'Mixed line breaks, enforce preset' => [
+                'input'     => "1\r\n2\r3\n",
+                'expected'  => "1{$LE}2{$LE}3{$LE}",
+                'breaktype' => $LE,
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -48,6 +48,10 @@ final class NormalizeBreaksTest extends TestCase
         $baseExpected = 'hello' . PHPMailer::CRLF . 'World' . PHPMailer::CRLF . 'Again' . PHPMailer::CRLF;
 
         return [
+            'Text without line breaks' => [
+                'input'    => 'hello World!',
+                'expected' => 'hello World!',
+            ],
             'Unix line breaks' => [
                 'input'    => "hello\nWorld\nAgain\n",
                 'expected' => $baseExpected,

--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -19,6 +19,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test normalize line breaks functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::normalizeBreaks
  */
 final class NormalizeBreaksTest extends TestCase
 {

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1298,15 +1298,6 @@ EOT;
         //May have been altered by earlier tests, can interfere with line break format
         $this->Mail->isSMTP();
         $this->Mail->preSend();
-        $unixsrc = "hello\nWorld\nAgain\n";
-        $macsrc = "hello\rWorld\rAgain\r";
-        $windowssrc = "hello\r\nWorld\r\nAgain\r\n";
-        $mixedsrc = "hello\nWorld\rAgain\r\n";
-        $target = "hello\r\nWorld\r\nAgain\r\n";
-        self::assertSame($target, PHPMailer::normalizeBreaks($unixsrc), 'UNIX break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($macsrc), 'Mac break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($windowssrc), 'Windows break reformatting failed');
-        self::assertSame($target, PHPMailer::normalizeBreaks($mixedsrc), 'Mixed break reformatting failed');
 
         //To see accurate results when using postfix, set `sendmail_fix_line_endings = never` in main.cf
         $this->Mail->Subject = 'PHPMailer DOS line breaks';
@@ -1394,16 +1385,6 @@ EOT;
             PHPMailer::filenameToType('abc.xyzpdq'),
             'Default MIME type not applied to unknown extension'
         );
-
-        //Line break normalization
-        $eol = PHPMailer::getLE();
-        $b1 = "1\r2\r3\r";
-        $b2 = "1\n2\n3\n";
-        $b3 = "1\r\n2\r3\n";
-        $t1 = "1{$eol}2{$eol}3{$eol}";
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b1), 'Failed to normalize line breaks (1)');
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b2), 'Failed to normalize line breaks (2)');
-        self::assertSame($t1, PHPMailer::normalizeBreaks($b3), 'Failed to normalize line breaks (3)');
     }
 
     public function testBadSMTP()


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395

## Commit details

### Tests/reorganize: move line break normalization tests to own file

As this test does not actually need an instantiated PHPMailer object, this class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase`.

Note: this doesn't move the complete tests from the original test file, just select parts of two test methods.

### NormalizeBreaksTest: reorganize to use data providers

* Maintains (largely) the same test code and test cases.
* Removes code duplication.
* Makes it easier to add additional test cases in the future.

### NormalizeBreaksTest: add additional test case

... to ensure text without line breaks is returned unchanged.

### NormalizeBreaksTest: add extra test

... to verify the behaviour of the `PHPMailer::normalizeBreaks()` method when the `PHPMailer::$LE` property has been customized.

_Note: this test uses the new `TestCase::updateStaticProperty()` method as introduced in #2399._

### NormalizeBreaksTest: add `@covers` tag 