### PR TITLE
Tests: move file name to type tests to own file

### DIFF
--- a/test/PHPMailer/FilenameToTypeTest.php
+++ b/test/PHPMailer/FilenameToTypeTest.php
@@ -23,19 +23,35 @@ final class FilenameToTypeTest extends TestCase
 {
 
     /**
-     * Miscellaneous calls to improve test coverage and some small tests.
+     * Verify mapping a file name to a MIME type.
+     *
+     * @dataProvider dataFilenameToType
+     *
+     * @param string $filename Filename input.
+     * @param string $expected Expected function output.
      */
-    public function testMiscellaneous()
+    public function testFilenameToType($filename, $expected)
     {
-        self::assertSame(
-            'image/jpeg',
-            PHPMailer::filenameToType('abc.jpg?xyz=1'),
-            'Query string not ignored in filename'
-        );
-        self::assertSame(
-            'application/octet-stream',
-            PHPMailer::filenameToType('abc.xyzpdq'),
-            'Default MIME type not applied to unknown extension'
-        );
+        $result = PHPMailer::filenameToType($filename);
+        self::assertSame($expected, $result, 'Failed to map file name to a MIME type');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataFilenameToType()
+    {
+        return [
+            'File name with query string' => [
+                'filename' => 'abc.jpg?xyz=1',
+                'expected' => 'image/jpeg',
+            ],
+            'Unknown extension, should return default MIME type' => [
+                'filename' => 'abc.xyzpdq',
+                'expected' => 'application/octet-stream',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/FilenameToTypeTest.php
+++ b/test/PHPMailer/FilenameToTypeTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test file name to type functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::filenameToType
  */
 final class FilenameToTypeTest extends TestCase
 {

--- a/test/PHPMailer/FilenameToTypeTest.php
+++ b/test/PHPMailer/FilenameToTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test file name to type functionality.
+ */
+final class FilenameToTypeTest extends TestCase
+{
+
+    /**
+     * Miscellaneous calls to improve test coverage and some small tests.
+     */
+    public function testMiscellaneous()
+    {
+        self::assertSame(
+            'image/jpeg',
+            PHPMailer::filenameToType('abc.jpg?xyz=1'),
+            'Query string not ignored in filename'
+        );
+        self::assertSame(
+            'application/octet-stream',
+            PHPMailer::filenameToType('abc.xyzpdq'),
+            'Default MIME type not applied to unknown extension'
+        );
+    }
+}

--- a/test/PHPMailer/FilenameToTypeTest.php
+++ b/test/PHPMailer/FilenameToTypeTest.php
@@ -44,9 +44,25 @@ final class FilenameToTypeTest extends TestCase
     public function dataFilenameToType()
     {
         return [
+            'Empty string' => [
+                'filename' => '',
+                'expected' => 'application/octet-stream',
+            ],
+            'File name without query string' => [
+                'filename' => 'abc.png',
+                'expected' => 'image/png',
+            ],
             'File name with query string' => [
                 'filename' => 'abc.jpg?xyz=1',
                 'expected' => 'image/jpeg',
+            ],
+            'Full path to file, linux style' => [
+                'filename' => '/usr/sbin/subdir/docs.pdf',
+                'expected' => 'application/pdf',
+            ],
+            'Full path to file, windows style' => [
+                'filename' => 'D:\subdir\with spaces\subdir\myapp.zip',
+                'expected' => 'application/zip',
             ],
             'Unknown extension, should return default MIME type' => [
                 'filename' => 'abc.xyzpdq',

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1374,17 +1374,6 @@ EOT;
         self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'Windows basename not matched');
         self::assertSame('mp3', $q['extension'], 'Windows extension not matched');
         self::assertSame('飛兒樂 團光茫', $q['filename'], 'Windows filename not matched');
-
-        self::assertSame(
-            'image/jpeg',
-            PHPMailer::filenameToType('abc.jpg?xyz=1'),
-            'Query string not ignored in filename'
-        );
-        self::assertSame(
-            'application/octet-stream',
-            PHPMailer::filenameToType('abc.xyzpdq'),
-            'Default MIME type not applied to unknown extension'
-        );
     }
 
     public function testBadSMTP()


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400

## Commit details

###  Tests/reorganize: move file name to type tests to own file

As this test does not actually need an instantiated PHPMailer object, this class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase`.

Note: this doesn't move the complete test from the original test file, just select parts of the test method.

### FilenameToTypeTest: reorganize to use data providers

* Maintains the same test code and test cases.
* Removes code duplication.
* Makes it easier to add additional test cases in the future.

### FilenameToTypeTest: add some additional test cases

... which should be supported based on the function docs.

Note: the "empty string" test may need looking at.... is this a bug ?

### FilenameToTypeTest: add `@covers` tag 