### PR TITLE
GH Actions: various tweaks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,10 @@ jobs:
           coverage: none
           tools: cs2pr
 
-      - name: Install dependencies
-        run: composer install --no-interaction
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
 
       - name: Check coding standards
         continue-on-error: true
@@ -61,13 +63,17 @@ jobs:
           ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8, error_reporting=E_ALL, display_errors=On
           extensions: xdebug, imap, mbstring, intl, ctype, filter, hash
 
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install PHP packages - normal
         if: ${{ matrix.php != '8.1' }}
-        run: composer install --no-interaction
+        uses: "ramsey/composer-install@v1"
 
       - name: Install PHP packages - ignore-platform-reqs
         if: ${{ matrix.php == '8.1' }}
-        run: composer install --no-interaction --ignore-platform-reqs
+        uses: "ramsey/composer-install@v1"
+        with:
+          composer-options: --ignore-platform-reqs
 
       - name: Install postfix
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,15 +39,13 @@ jobs:
     strategy:
       matrix:
         php: ['5.5', '5.6', '7.0.', '7.1', '7.2', '7.3', '7.4', '8.0']
-        dependency-version: [prefer-stable]
         experimental: [false]
         include:
           # Experimental builds. These are allowed to fail.
           - php: '8.1'
-            dependency-version: 'prefer-stable'
             experimental: true
 
-    name: P${{ matrix.php }} - ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }}
 
     continue-on-error: ${{ matrix.experimental }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,10 +10,6 @@ jobs:
 
   coding-standard:
     runs-on: ubuntu-18.04
-    strategy:
-      matrix:
-        php: ['8.0']
-        dependency-version: [prefer-stable]
     name: Coding standards
 
     steps:
@@ -23,7 +19,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php }}
+          php-version: '8.0'
           coverage: none
           tools: cs2pr
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
           php-version: ${{ matrix.php }}
           coverage: xdebug
           ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8, error_reporting=E_ALL, display_errors=On
-          extensions: xdebug, imap, mbstring, intl, ctype, filter, hash
+          extensions: imap, mbstring, intl, ctype, filter, hash
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: ['5.5', '5.6', '7.0.', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
         experimental: [false]
         include:
           # Experimental builds. These are allowed to fail.


### PR DESCRIPTION
### GH Actions: CS run - remove matrix

The CS run only needs to run against one PHP version, so there is no need to set up a matrix for this.

### GH Actions: test run - remove "dependency version" matrix key

Running against stable/lowest dependencies is relevant when a package has runtime (non-dev) dependencies.
However, PHPMailer does not have runtime dependencies.

In other words, the `dependency-version` matrix key is redundant and unused, so we may as well remove it.

### GH Actions: use predefined action to run composer install with caching

It is generally speaking a good idea to cache downloaded Composer packages between runs for performance reasons.

Now, this can be set up manually and would add two more steps to the scripts, or Ben's `composer-install` action can be used which will handle it all for you. The `composer-install` action is versatile and allows for passing additional parameters, so is perfectly suitable for this.

Ref: https://github.com/marketplace/actions/install-composer-dependencies

### GH Actions: test run - remove redundant dependency

The `xdebug` extension is already tagged as needed via the `coverage` setting, no need to add it to the `extensions` list.
---

Note: generally speaking, I personally normally don't pass an `extensions` list and allow the `setup-php` action to run with the default extensions, which is sufficient in most cases and would be sufficient here as well.

More than anything, I use the `extensions` key to _disable_ extensions for certain test runs, rather than enable them. Just something to consider.

The below documentation should give more insight.

Refs:
* https://github.com/shivammathur/setup-php/wiki/Php-extensions-loaded-on-ubuntu-18.04
* https://github.com/shivammathur/setup-php#heavy_plus_sign-php-extension-support

### GH Actions: test matrix - fix typo

There was a stray `.` in the string.

