### PR TITLE
GH Actions: add PHP linting job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,8 +35,45 @@ jobs:
       - name: Show PHPCS results in PR
         run: cs2pr ./phpcs-report.xml
 
+  lint:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        php: ['5.5', '7.2', '8.0']
+        experimental: [false]
+        include:
+          - php: '8.1'
+            experimental: true
+
+    name: "Lint: PHP ${{ matrix.php }}"
+    continue-on-error: ${{ matrix.experimental }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+          tools: cs2pr
+
+      # Install dependencies and handle caching in one go.
+      # @link https://github.com/marketplace/actions/install-composer-dependencies
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v1"
+
+      - name: Lint against parse errors
+        if: ${{ matrix.php != '8.1' }}
+        run: composer lint -- --checkstyle | cs2pr
+
+      - name: Lint against parse errors (PHP 8.1)
+        if: ${{ matrix.php == '8.1' }}
+        run: composer lint
+
   test:
-    needs: ['coding-standard']
+    needs: ['coding-standard', 'lint']
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -47,7 +84,7 @@ jobs:
           - php: '8.1'
             experimental: true
 
-    name: PHP ${{ matrix.php }}
+    name: "Test: PHP ${{ matrix.php }}"
 
     continue-on-error: ${{ matrix.experimental }}
 

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "doctrine/annotations": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6.0",
@@ -60,6 +62,9 @@
     "license": "LGPL-2.1-only",
     "scripts": {
         "check": "./vendor/bin/phpcs",
-        "test": "./vendor/bin/phpunit"
+        "test": "./vendor/bin/phpunit",
+        "lint": [
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php,phps --exclude vendor --exclude .git --exclude build"
+        ]
     }
 }


### PR DESCRIPTION
This commit:
* Add a new dependency on the PHP Parallel Lint package for fast PHP linting.
    The PHP Parallel Lint package, in combination with the PHP Console Highlighter provides the following advantages in comparison with "plain" PHP linting:
    - Higher speed due to the parallel processes.
    - Improved usability by providing color coded syntax highlighting of found errors on the command-line.
    - Integration with the `cs2pr` tool, allowing for the results of the lint command to be shown in-line in PRs.
* Adds a Composer `lint` script for easy access to the tool for devs, while making sure the correct command line parameters will be used.
    The linting command as currently set up, will also check the example files for linting errors.
* Adds a GH Actions job for linting the code on the high/low supported PHP versions, one arbitrary interim version + an experimental build against PHP 8.1.
    The `cs2pr` tool has been enabled and will show the results of the non-experimental lint runs in-line in PRs.
    **Note**: For PHP 8.1, the `cs2pr` tool is not used as there is a known issue in the Parallel Lint tool with PHP 8.1 which breaks on the checkstyle reporting. There is already a [PR open](https://github.com/php-parallel-lint/PHP-Parallel-Lint/pull/64) to fix this upstream. Once this PR has been merged and a new version of Parallel Lint has been released, the separate step for PHP 8.1 linting can be removed.
 * Makes the `test` job in the GHA workflow dependent on the `lint` job having passed...
     ... as the tests would fail anyway if there are linting errors.
    Also adjusts the name of the `test` jobs to include the word "Test" so they can be easily distinguished from the Lint jobs.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint