### PR TITLE
Tests: move pathinfo tests to own file

### DIFF
--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -141,6 +141,26 @@ final class MbPathinfoTest extends TestCase
                 'options'  => PATHINFO_BASENAME,
                 'expected' => '飛兒樂 團光茫.mp3',
             ],
+            'Option: PATHINFO_EXTENSION' => [
+                'options'  => PATHINFO_EXTENSION,
+                'expected' => 'mp3',
+            ],
+            'Option: PATHINFO_FILENAME' => [
+                'options'  => PATHINFO_FILENAME,
+                'expected' => '飛兒樂 團光茫',
+            ],
+            'Option: dirname' => [
+                'options'  => 'dirname',
+                'expected' => '/mnt/files',
+            ],
+            'Option: basename' => [
+                'options'  => 'basename',
+                'expected' => '飛兒樂 團光茫.mp3',
+            ],
+            'Option: extension' => [
+                'options'  => 'extension',
+                'expected' => 'mp3',
+            ],
             'Option: filename' => [
                 'options'  => 'filename',
                 'expected' => '飛兒樂 團光茫',

--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test Multi-byte-safe pathinfo replacement functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::mb_pathinfo
  */
 final class MbPathinfoTest extends TestCase
 {

--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -44,6 +44,33 @@ final class MbPathinfoTest extends TestCase
     public function dataMb_pathinfoWithoutOptions()
     {
         return [
+            'Empty string' => [
+                'path'     => '',
+                'expected' => [
+                    'dirname'   => '',
+                    'basename'  => '',
+                    'extension' => '',
+                    'filename'  => '',
+                ],
+            ],
+            'Unix path with singlebyte filename' => [
+                'path'     => '/mnt/music/music.mp3',
+                'expected' => [
+                    'dirname'   => '/mnt/music',
+                    'basename'  => 'music.mp3',
+                    'extension' => 'mp3',
+                    'filename'  => 'music',
+                ],
+            ],
+            'Windows path with singlebyte filename' => [
+                'path'     => 'c:\mnt\music\music.mp3',
+                'expected' => [
+                    'dirname'   => 'c:\mnt\music',
+                    'basename'  => 'music.mp3',
+                    'extension' => 'mp3',
+                    'filename'  => 'music',
+                ],
+            ],
             'Unix path with multibyte filename' => [
                 'path'     => '/mnt/files/飛兒樂 團光茫.mp3',
                 'expected' => [
@@ -60,6 +87,24 @@ final class MbPathinfoTest extends TestCase
                     'basename'  => '飛兒樂 團光茫.mp3',
                     'extension' => 'mp3',
                     'filename'  => '飛兒樂 團光茫',
+                ],
+            ],
+            'Filename, not path, contains spaces' => [
+                'path'     => 'my file.png',
+                'expected' => [
+                    'dirname'   => '',
+                    'basename'  => 'my file.png',
+                    'extension' => 'png',
+                    'filename'  => 'my file',
+                ],
+            ],
+            'Path, no file name, linux style, contains spaces' => [
+                'path'     => '/mnt/sub directory/another sub/',
+                'expected' => [
+                    'dirname'   => '/mnt/sub directory',
+                    'basename'  => 'another sub',
+                    'extension' => '',
+                    'filename'  => 'another sub',
                 ],
             ],
         ];

--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test Multi-byte-safe pathinfo replacement functionality.
+ */
+final class MbPathinfoTest extends TestCase
+{
+
+    /**
+     * Miscellaneous calls to improve test coverage and some small tests.
+     */
+    public function testMiscellaneous()
+    {
+        $a = '/mnt/files/飛兒樂 團光茫.mp3';
+        $q = PHPMailer::mb_pathinfo($a);
+        self::assertSame('/mnt/files', $q['dirname'], 'UNIX dirname not matched');
+        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'UNIX basename not matched');
+        self::assertSame('mp3', $q['extension'], 'UNIX extension not matched');
+        self::assertSame('飛兒樂 團光茫', $q['filename'], 'UNIX filename not matched');
+        self::assertSame(
+            '/mnt/files',
+            PHPMailer::mb_pathinfo($a, PATHINFO_DIRNAME),
+            'Dirname path element not matched'
+        );
+        self::assertSame(
+            '飛兒樂 團光茫.mp3',
+            PHPMailer::mb_pathinfo($a, PATHINFO_BASENAME),
+            'Basename path element not matched'
+        );
+        self::assertSame('飛兒樂 團光茫', PHPMailer::mb_pathinfo($a, 'filename'), 'Filename path element not matched');
+        $a = 'c:\mnt\files\飛兒樂 團光茫.mp3';
+        $q = PHPMailer::mb_pathinfo($a);
+        self::assertSame('c:\mnt\files', $q['dirname'], 'Windows dirname not matched');
+        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'Windows basename not matched');
+        self::assertSame('mp3', $q['extension'], 'Windows extension not matched');
+        self::assertSame('飛兒樂 團光茫', $q['filename'], 'Windows filename not matched');
+    }
+}

--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -23,32 +23,83 @@ final class MbPathinfoTest extends TestCase
 {
 
     /**
-     * Miscellaneous calls to improve test coverage and some small tests.
+     * Verify retrieving information about a file path when the $options parameter has been passed.
+     *
+     * @dataProvider dataMb_pathinfoWithoutOptions
+     *
+     * @param string $path     Path input.
+     * @param string $expected Expected function output.
      */
-    public function testMiscellaneous()
+    public function testMb_pathinfoWithoutOptions($path, $expected)
     {
-        $a = '/mnt/files/飛兒樂 團光茫.mp3';
-        $q = PHPMailer::mb_pathinfo($a);
-        self::assertSame('/mnt/files', $q['dirname'], 'UNIX dirname not matched');
-        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'UNIX basename not matched');
-        self::assertSame('mp3', $q['extension'], 'UNIX extension not matched');
-        self::assertSame('飛兒樂 團光茫', $q['filename'], 'UNIX filename not matched');
-        self::assertSame(
-            '/mnt/files',
-            PHPMailer::mb_pathinfo($a, PATHINFO_DIRNAME),
-            'Dirname path element not matched'
-        );
-        self::assertSame(
-            '飛兒樂 團光茫.mp3',
-            PHPMailer::mb_pathinfo($a, PATHINFO_BASENAME),
-            'Basename path element not matched'
-        );
-        self::assertSame('飛兒樂 團光茫', PHPMailer::mb_pathinfo($a, 'filename'), 'Filename path element not matched');
-        $a = 'c:\mnt\files\飛兒樂 團光茫.mp3';
-        $q = PHPMailer::mb_pathinfo($a);
-        self::assertSame('c:\mnt\files', $q['dirname'], 'Windows dirname not matched');
-        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'Windows basename not matched');
-        self::assertSame('mp3', $q['extension'], 'Windows extension not matched');
-        self::assertSame('飛兒樂 團光茫', $q['filename'], 'Windows filename not matched');
+        $result = PHPMailer::mb_pathinfo($path);
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMb_pathinfoWithoutOptions()
+    {
+        return [
+            'Unix path with multibyte filename' => [
+                'path'     => '/mnt/files/飛兒樂 團光茫.mp3',
+                'expected' => [
+                    'dirname'   => '/mnt/files',
+                    'basename'  => '飛兒樂 團光茫.mp3',
+                    'extension' => 'mp3',
+                    'filename'  => '飛兒樂 團光茫',
+                ],
+            ],
+            'Windows path with multibyte filename' => [
+                'path'     => 'c:\mnt\files\飛兒樂 團光茫.mp3',
+                'expected' => [
+                    'dirname'   => 'c:\mnt\files',
+                    'basename'  => '飛兒樂 團光茫.mp3',
+                    'extension' => 'mp3',
+                    'filename'  => '飛兒樂 團光茫',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Verify retrieving information about a file path when the $options parameter has been passed.
+     *
+     * @dataProvider dataMb_pathinfoWithOptions
+     *
+     * @param int|string $options  Input to pass to the $options parameter.
+     * @param string     $expected Expected function output.
+     */
+    public function testMb_pathinfoWithOptions($options, $expected)
+    {
+        $path   = '/mnt/files/飛兒樂 團光茫.mp3';
+        $result = PHPMailer::mb_pathinfo($path, $options);
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMb_pathinfoWithOptions()
+    {
+        return [
+            'Option: PATHINFO_DIRNAME' => [
+                'options'  => PATHINFO_DIRNAME,
+                'expected' => '/mnt/files',
+            ],
+            'Option: PATHINFO_BASENAME' => [
+                'options'  => PATHINFO_BASENAME,
+                'expected' => '飛兒樂 團光茫.mp3',
+            ],
+            'Option: filename' => [
+                'options'  => 'filename',
+                'expected' => '飛兒樂 團光茫',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1350,30 +1350,6 @@ EOT;
         self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
         self::assertTrue($this->Mail->set('AllowEmpty', null), 'Null property set failed');
         self::assertTrue($this->Mail->set('AllowEmpty', false), 'Valid property set of null property failed');
-        //Test pathinfo
-        $a = '/mnt/files/飛兒樂 團光茫.mp3';
-        $q = PHPMailer::mb_pathinfo($a);
-        self::assertSame('/mnt/files', $q['dirname'], 'UNIX dirname not matched');
-        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'UNIX basename not matched');
-        self::assertSame('mp3', $q['extension'], 'UNIX extension not matched');
-        self::assertSame('飛兒樂 團光茫', $q['filename'], 'UNIX filename not matched');
-        self::assertSame(
-            '/mnt/files',
-            PHPMailer::mb_pathinfo($a, PATHINFO_DIRNAME),
-            'Dirname path element not matched'
-        );
-        self::assertSame(
-            '飛兒樂 團光茫.mp3',
-            PHPMailer::mb_pathinfo($a, PATHINFO_BASENAME),
-            'Basename path element not matched'
-        );
-        self::assertSame('飛兒樂 團光茫', PHPMailer::mb_pathinfo($a, 'filename'), 'Filename path element not matched');
-        $a = 'c:\mnt\files\飛兒樂 團光茫.mp3';
-        $q = PHPMailer::mb_pathinfo($a);
-        self::assertSame('c:\mnt\files', $q['dirname'], 'Windows dirname not matched');
-        self::assertSame('飛兒樂 團光茫.mp3', $q['basename'], 'Windows basename not matched');
-        self::assertSame('mp3', $q['extension'], 'Windows extension not matched');
-        self::assertSame('飛兒樂 團光茫', $q['filename'], 'Windows filename not matched');
     }
 
     public function testBadSMTP()


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401

## Commit details

### Tests/reorganize: move pathinfo tests to own file

As this test does not actually need an instantiated PHPMailer object, this class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase`.

Note: this doesn't move the complete test from the original test file, just select parts of the test method.

### MbPathinfoTest: reorganize to use data providers

* Replace the existing test code with two new test methods using data providers.
* Maintains the same test code and test cases.
* Makes it easier to add additional test cases in the future.

### MbPathinfoTest: add additional test cases for `testMb_pathinfoWithoutOptions()`

Including test cases with:
* Spaces in the paths.
* Incomplete file paths.

👉🏻 Note: the "empty string" test may need looking at.... should this return an empty array instead ?

### MbPathinfoTest: add additional test cases for `testMb_pathinfoWithOptions()`

... to ensure all supported options are covered by a test.

### MbPathinfoTest: add `@covers` tag 
