### PR TITLE
Remove PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,0 @@
-Before submitting your pull request, check whether your code adheres to PHPMailer coding standards (which is mostly [PSR-12](https://www.php-fig.org/psr/psr-12/)) by running [PHP CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer):
-
-    ./vendor/bin/phpcs
-
-Any problems reported can probably be fixed automatically by using its partner tool, PHP code beautifier:
-
-    ./vendor/bin/phpcbf


### PR DESCRIPTION
PR #2373 changed the CI in such a way that coding standards errors will now be shown inline in the code of PRs.

With that change in place, having the information about running PHPCS in the pull request template has become redundant.