### PR TITLE
GH Actions: set up code coverage monitoring via codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,21 @@
+codecov:
+  notify:
+    after_n_builds: 2
+
+coverage:
+  round: nearest
+  # Status will be green when coverage is between 70 and 100%.
+  range: "70...100"
+  status:
+    project:
+      default:
+        threshold: 2%
+        paths:
+          - "src"
+    patch:
+      default:
+        threshold: 0%
+        paths:
+          - "src"
+
+comment: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,11 +77,21 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        php: ['5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4']
+        coverage: [false]
         experimental: [false]
         include:
+          # Run code coverage on high/low PHP.
+          - php: '5.5'
+            coverage: true
+            experimental: false
+          - php: '8.0'
+            coverage: true
+            experimental: false
+
           # Experimental builds. These are allowed to fail.
           - php: '8.1'
+            coverage: false
             experimental: true
 
     name: "Test: PHP ${{ matrix.php }}"
@@ -92,11 +102,20 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
 
+      - name: Set coverage variable
+        id: set_cov
+        run: |
+          if [ ${{ matrix.coverage }} == "true" ]; then
+            echo '::set-output name=COV::xdebug'
+          else
+            echo '::set-output name=COV::none'
+          fi
+
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: xdebug
+          coverage: ${{ steps.set_cov.outputs.COV }}
           ini-values: sendmail_path=/usr/sbin/sendmail -t -i, zend.multibyte=1, zend.script_encoding=UTF-8, default_charset=UTF-8, error_reporting=E_ALL, display_errors=On
           extensions: imap, mbstring, intl, ctype, filter, hash
 
@@ -127,5 +146,18 @@ jobs:
           sudo cp test/fakesendmail.sh /var/qmail/bin/sendmail
           sudo cp test/fakesendmail.sh /usr/sbin/sendmail
       
-      - name: Run tests
-        run: ./vendor/bin/phpunit --configuration ./phpunit.xml.dist
+      - name: Run tests, no code coverage
+        if: ${{ matrix.coverage == false }}
+        run: ./vendor/bin/phpunit --no-coverage
+
+      - name: Run tests with code coverage
+        if: ${{ matrix.coverage == true }}
+        run: vendor/bin/phpunit
+
+      - name: Send coverage report to Codecov
+        if: ${{ success() && matrix.coverage == true }}
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./build/logs/clover.xml
+          fail_ci_if_error: true
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,12 @@
 
 # PHPMailer – A full-featured email creation and transfer class for PHP
 
-[![Test status](https://github.com/PHPMailer/PHPMailer/workflows/Tests/badge.svg)](https://github.com/PHPMailer/PHPMailer/actions) [![Latest Stable Version](https://poser.pugx.org/phpmailer/phpmailer/v/stable.svg)](https://packagist.org/packages/phpmailer/phpmailer) [![Total Downloads](https://poser.pugx.org/phpmailer/phpmailer/downloads)](https://packagist.org/packages/phpmailer/phpmailer) [![License](https://poser.pugx.org/phpmailer/phpmailer/license.svg)](https://packagist.org/packages/phpmailer/phpmailer) [![API Docs](https://github.com/phpmailer/phpmailer/workflows/Docs/badge.svg)](https://phpmailer.github.io/PHPMailer/)
+[![Test status](https://github.com/PHPMailer/PHPMailer/workflows/Tests/badge.svg)](https://github.com/PHPMailer/PHPMailer/actions)
+[![codecov.io](https://codecov.io/gh/PHPMailer/PHPMailer/branch/stable/graph/badge.svg?branch=master)](https://codecov.io/gh/PHPMailer/PHPMailer?branch=master)
+[![Latest Stable Version](https://poser.pugx.org/phpmailer/phpmailer/v/stable.svg)](https://packagist.org/packages/phpmailer/phpmailer)
+[![Total Downloads](https://poser.pugx.org/phpmailer/phpmailer/downloads)](https://packagist.org/packages/phpmailer/phpmailer)
+[![License](https://poser.pugx.org/phpmailer/phpmailer/license.svg)](https://packagist.org/packages/phpmailer/phpmailer)
+[![API Docs](https://github.com/phpmailer/phpmailer/workflows/Docs/badge.svg)](https://phpmailer.github.io/PHPMailer/)
 
 ## Features
 - Probably the world's most popular code for sending email from PHP!

--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     "license": "LGPL-2.1-only",
     "scripts": {
         "check": "./vendor/bin/phpcs",
-        "test": "./vendor/bin/phpunit",
+        "test": "./vendor/bin/phpunit --no-coverage",
+        "coverage": "./vendor/bin/phpunit",
         "lint": [
             "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php,phps --exclude vendor --exclude .git --exclude build"
         ]


### PR DESCRIPTION
The Codecov service is a way to monitor test vs code coverage of a project over time and allows for the code coverage % + delta to be reported in each PR.

This commits:
* Adds a Codecov configuration.
* Adds a convenience script to the `composer.json` file to run the tests with or without code coverage.
* Adds a new matrix variable to the GH Actions `test` workflow to run the tests with code coverage and send the results to the Codecov service.
    Notes:
    - This disables the code coverage reporting in the "normal" test runs, including disabling `xdebug` for those runs which should make them slightly faster.
    - This splits the test runs into two sets:
        * High/low PHP are being run with code coverage (and have been removed from the "normal" test run matrix).
        * For all other PHP versions, the tests are being run without code coverage.
* Adds a badge to the README to show the current code coverage %.

👉🏻 Note: the code for the badge may need some tweaking as IIRC it needs a token, which I don't have access to.