### PR TITLE
Tests: move mime type test(s) to own file

### DIFF
--- a/test/PHPMailer/MimeTypesTest.php
+++ b/test/PHPMailer/MimeTypesTest.php
@@ -23,10 +23,31 @@ final class MimeTypesTest extends TestCase
 {
 
     /**
-     * Miscellaneous calls to improve test coverage and some small tests.
+     * Test mime type mapping.
+     *
+     * @dataProvider dataMime_Types
+     *
+     * @param string $input     Input text string.
+     * @param string $expected  Expected funtion output.
      */
-    public function testMiscellaneous()
+    public function testMime_Types($input, $expected)
     {
-        self::assertSame('application/pdf', PHPMailer::_mime_types('pdf'), 'MIME TYPE lookup failed');
+        $result = PHPMailer::_mime_types($input);
+        self::assertSame($expected, $result, 'MIME TYPE lookup failed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataMime_Types()
+    {
+        return [
+            'Extension: pdf (lowercase)' => [
+                'input'    => 'pdf',
+                'expected' => 'application/pdf',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/MimeTypesTest.php
+++ b/test/PHPMailer/MimeTypesTest.php
@@ -48,6 +48,22 @@ final class MimeTypesTest extends TestCase
                 'input'    => 'pdf',
                 'expected' => 'application/pdf',
             ],
+            'Extension: PHP (uppercase)' => [
+                'input'    => 'PHP',
+                'expected' => 'application/x-httpd-php',
+            ],
+            'Extension: Doc (mixed case)' => [
+                'input'    => 'Doc',
+                'expected' => 'application/msword',
+            ],
+            'Extension which is not in the list' => [
+                'input'    => 'md',
+                'expected' => 'application/octet-stream',
+            ],
+            'Empty string' => [
+                'input'    => '',
+                'expected' => 'application/octet-stream',
+            ],
         ];
     }
 }

--- a/test/PHPMailer/MimeTypesTest.php
+++ b/test/PHPMailer/MimeTypesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+/**
+ * Test mime type mapping functionality.
+ */
+final class MimeTypesTest extends TestCase
+{
+
+    /**
+     * Miscellaneous calls to improve test coverage and some small tests.
+     */
+    public function testMiscellaneous()
+    {
+        self::assertSame('application/pdf', PHPMailer::_mime_types('pdf'), 'MIME TYPE lookup failed');
+    }
+}

--- a/test/PHPMailer/MimeTypesTest.php
+++ b/test/PHPMailer/MimeTypesTest.php
@@ -18,6 +18,8 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
 
 /**
  * Test mime type mapping functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::_mime_types
  */
 final class MimeTypesTest extends TestCase
 {

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1336,7 +1336,6 @@ EOT;
      */
     public function testMiscellaneous()
     {
-        self::assertSame('application/pdf', PHPMailer::_mime_types('pdf'), 'MIME TYPE lookup failed');
         $this->Mail->clearAttachments();
         $this->Mail->isHTML(false);
         $this->Mail->isSMTP();


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404

## Commit details

###  Tests/reorganize: move mime type tests to own file

As this test does not actually need an instantiated PHPMailer object, this class extends the `Yoast\PHPUnitPolyfills\TestCases\TestCase` instead of the `PHPMailer\Test\TestCase`.

Note: this doesn't move the complete test from the original test file, just select parts of the test method.

### MimeTypesTest: reorganize to use data provider

* Maintains the same test code and test case.
* Makes it easier to add additional test cases in the future.

### MimeTypesTest: add additional test cases

Including test cases with:
* Different text case.
* An extension not in the list.
* Passing an empty string

### MimeTypesTest: add @covers tag 