### PR TITLE
Tests: split `TestCase` class into three base test case classes and make more flexible

### DIFF
--- a/test/PHPMailer/AuthCRAMMD5Test.php
+++ b/test/PHPMailer/AuthCRAMMD5Test.php
@@ -13,12 +13,12 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\SendTestCase;
 
 /**
  * Test CRAM-MD5 authentication functionality.
  */
-final class AuthCRAMMD5Test extends TestCase
+final class AuthCRAMMD5Test extends SendTestCase
 {
 
     /**

--- a/test/PHPMailer/DKIMTest.php
+++ b/test/PHPMailer/DKIMTest.php
@@ -15,14 +15,14 @@ namespace PHPMailer\Test\PHPMailer;
 
 use Exception;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\SendTestCase;
 
 /**
  * Test DKIM signing functionality.
  *
  * @group dkim
  */
-final class DKIMTest extends TestCase
+final class DKIMTest extends SendTestCase
 {
 
     /**

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -13,7 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test setting and retrieving message ID.
@@ -21,7 +21,7 @@ use PHPMailer\Test\TestCase;
  * @covers \PHPMailer\PHPMailer\PHPMailer::createHeader
  * @covers \PHPMailer\PHPMailer\PHPMailer::getLastMessageID
  */
-final class GetLastMessageIDTest extends TestCase
+final class GetLastMessageIDTest extends PreSendTestCase
 {
 
     /**

--- a/test/PHPMailer/HasLineLongerThanMaxTest.php
+++ b/test/PHPMailer/HasLineLongerThanMaxTest.php
@@ -14,12 +14,12 @@
 namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\SendTestCase;
 
 /**
  * Test line length detection and handling.
  */
-final class HasLineLongerThanMaxTest extends TestCase
+final class HasLineLongerThanMaxTest extends SendTestCase
 {
 
     /**

--- a/test/PHPMailer/ICalTest.php
+++ b/test/PHPMailer/ICalTest.php
@@ -13,12 +13,12 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test ICal calendar events handling.
  */
-final class ICalTest extends TestCase
+final class ICalTest extends PreSendTestCase
 {
 
     /**

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -13,12 +13,12 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\SendTestCase;
 
 /**
  * Test sending mail using the various available mail transport options.
  */
-final class MailTransportTest extends TestCase
+final class MailTransportTest extends SendTestCase
 {
 
     /**

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -16,12 +16,12 @@ namespace PHPMailer\Test\PHPMailer;
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
-use PHPMailer\Test\TestCase;
+use PHPMailer\Test\SendTestCase;
 
 /**
  * PHPMailer - PHP email transport unit test class.
  */
-final class PHPMailerTest extends TestCase
+final class PHPMailerTest extends SendTestCase
 {
     /**
      * Check that we have loaded default test params.

--- a/test/PreSendTestCase.php
+++ b/test/PreSendTestCase.php
@@ -13,7 +13,6 @@
 
 namespace PHPMailer\Test;
 
-use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
@@ -38,26 +37,8 @@ abstract class PreSendTestCase extends TestCase
         'SMTPDebug'   => SMTP::DEBUG_CONNECTION, // Full debug output.
         'Debugoutput' => ['PHPMailer\Test\DebugLogTestListener', 'debugLog'],
 
-        'Priority'    => 3,
-        'Encoding'    => '8bit',
-        'CharSet'     => PHPMailer::CHARSET_ISO88591,
+        // Minimal set of properties which are needed for the preSend() command to succeed.
         'From'        => 'unit_test@phpmailer.example.com',
-        'FromName'    => 'Unit Tester',
-        'Sender'      => 'unit_test@phpmailer.example.com',
-        'Subject'     => 'Unit Test',
-        'Body'        => '',
-        'AltBody'     => '',
-        'WordWrap'    => 0,
-        'Host'        => 'mail.example.com',
-        'Port'        => 25,
-        'Helo'        => 'localhost.localdomain',
-        'SMTPAuth'    => false,
-        'Username'    => '',
-        'Password'    => '',
-        'ReplyTo'     => [
-            'address' => 'no_reply@phpmailer.example.com',
-            'name'    => 'Reply Guy',
-        ],
         'to'          => [
             'address' => 'somebody@example.com',
             'name'    => 'Test User',

--- a/test/PreSendTestCase.php
+++ b/test/PreSendTestCase.php
@@ -14,6 +14,7 @@
 namespace PHPMailer\Test;
 
 use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
 /**
@@ -23,36 +24,43 @@ abstract class PreSendTestCase extends TestCase
 {
 
     /**
-     * Run before each test is started.
+     * Property names and their values for the test instance of the PHPMailer class.
+     *
+     * These properties will be set in the `set_up()` method.
+     *
+     * This property can be enhanced/overloaded in concrete test classes to change the presets
+     * or add additional properties.
+     *
+     * @var array
      */
-    protected function set_up()
-    {
-        parent::set_up();
+    protected $propertyChanges = [
+        // Generic changes.
+        'SMTPDebug'   => SMTP::DEBUG_CONNECTION, // Full debug output.
+        'Debugoutput' => ['PHPMailer\Test\DebugLogTestListener', 'debugLog'],
 
-        $this->Mail->Priority = 3;
-        $this->Mail->Encoding = '8bit';
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        $this->Mail->From = 'unit_test@phpmailer.example.com';
-        $this->Mail->FromName = 'Unit Tester';
-        $this->Mail->Sender = '';
-        $this->Mail->Subject = 'Unit Test';
-        $this->Mail->Body = '';
-        $this->Mail->AltBody = '';
-        $this->Mail->WordWrap = 0;
-        $this->Mail->Host = 'mail.example.com';
-        $this->Mail->Port = 25;
-        $this->Mail->Helo = 'localhost.localdomain';
-        $this->Mail->SMTPAuth = false;
-        $this->Mail->Username = '';
-        $this->Mail->Password = '';
-        $this->setAddress('no_reply@phpmailer.example.com', 'Reply Guy', 'ReplyTo');
-        $this->Mail->Sender = 'unit_test@phpmailer.example.com';
-        $this->setAddress('somebody@example.com', 'Test User', 'to');
-
-        if ($this->Mail->Host != '') {
-            $this->Mail->isSMTP();
-        } else {
-            $this->Mail->isMail();
-        }
-    }
+        'Priority'    => 3,
+        'Encoding'    => '8bit',
+        'CharSet'     => PHPMailer::CHARSET_ISO88591,
+        'From'        => 'unit_test@phpmailer.example.com',
+        'FromName'    => 'Unit Tester',
+        'Sender'      => 'unit_test@phpmailer.example.com',
+        'Subject'     => 'Unit Test',
+        'Body'        => '',
+        'AltBody'     => '',
+        'WordWrap'    => 0,
+        'Host'        => 'mail.example.com',
+        'Port'        => 25,
+        'Helo'        => 'localhost.localdomain',
+        'SMTPAuth'    => false,
+        'Username'    => '',
+        'Password'    => '',
+        'ReplyTo'     => [
+            'address' => 'no_reply@phpmailer.example.com',
+            'name'    => 'Reply Guy',
+        ],
+        'to'          => [
+            'address' => 'somebody@example.com',
+            'name'    => 'Test User',
+        ],
+    ];
 }

--- a/test/PreSendTestCase.php
+++ b/test/PreSendTestCase.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * PHPMailer - Base test class.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * PHPMailer - Test class for tests which need the `PHPMailer::preSend()` method to be called.
+ */
+abstract class PreSendTestCase extends TestCase
+{
+
+    /**
+     * Run before each test is started.
+     */
+    protected function set_up()
+    {
+        parent::set_up();
+
+        $this->Mail->Priority = 3;
+        $this->Mail->Encoding = '8bit';
+        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
+        $this->Mail->From = 'unit_test@phpmailer.example.com';
+        $this->Mail->FromName = 'Unit Tester';
+        $this->Mail->Sender = '';
+        $this->Mail->Subject = 'Unit Test';
+        $this->Mail->Body = '';
+        $this->Mail->AltBody = '';
+        $this->Mail->WordWrap = 0;
+        $this->Mail->Host = 'mail.example.com';
+        $this->Mail->Port = 25;
+        $this->Mail->Helo = 'localhost.localdomain';
+        $this->Mail->SMTPAuth = false;
+        $this->Mail->Username = '';
+        $this->Mail->Password = '';
+        $this->setAddress('no_reply@phpmailer.example.com', 'Reply Guy', 'ReplyTo');
+        $this->Mail->Sender = 'unit_test@phpmailer.example.com';
+        $this->setAddress('somebody@example.com', 'Test User', 'to');
+
+        if ($this->Mail->Host != '') {
+            $this->Mail->isSMTP();
+        } else {
+            $this->Mail->isMail();
+        }
+    }
+}

--- a/test/SendTestCase.php
+++ b/test/SendTestCase.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * PHPMailer - Base test class.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test;
+
+use PHPMailer\Test\PreSendTestCase;
+
+/**
+ * PHPMailer - Test class for tests which need the `PHPMailer::send()` method to be called.
+ */
+abstract class SendTestCase extends PreSendTestCase
+{
+
+    /**
+     * Run before each test is started.
+     */
+    protected function set_up()
+    {
+        parent::set_up();
+
+        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
+            include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; // Overrides go in here.
+        }
+
+        if (array_key_exists('mail_from', $_REQUEST)) {
+            $this->Mail->From = $_REQUEST['mail_from'];
+        }
+        if (array_key_exists('mail_host', $_REQUEST)) {
+            $this->Mail->Host = $_REQUEST['mail_host'];
+        }
+        if (array_key_exists('mail_port', $_REQUEST)) {
+            $this->Mail->Port = $_REQUEST['mail_port'];
+        }
+        if (array_key_exists('mail_useauth', $_REQUEST)) {
+            $this->Mail->SMTPAuth = $_REQUEST['mail_useauth'];
+        }
+        if (array_key_exists('mail_username', $_REQUEST)) {
+            $this->Mail->Username = $_REQUEST['mail_username'];
+        }
+        if (array_key_exists('mail_userpass', $_REQUEST)) {
+            $this->Mail->Password = $_REQUEST['mail_userpass'];
+        }
+        if (array_key_exists('mail_to', $_REQUEST)) {
+            $this->setAddress($_REQUEST['mail_to'], 'Test User', 'to');
+        }
+        if (array_key_exists('mail_cc', $_REQUEST) && $_REQUEST['mail_cc'] !== '') {
+            $this->setAddress($_REQUEST['mail_cc'], 'Carbon User', 'cc');
+        }
+
+        if ($this->Mail->Host != '') {
+            $this->Mail->isSMTP();
+        } else {
+            $this->Mail->isMail();
+        }
+    }
+}
+/*
+ * This is a sample form for setting appropriate test values through a browser
+ * These values can also be set using a file called testbootstrap.php (not in repo) in the same folder as this script
+ * which is probably more useful if you run these tests a lot
+ * <html>
+ * <body>
+ * <h3>PHPMailer Unit Test</h3>
+ * By entering a SMTP hostname it will automatically perform tests with SMTP.
+ *
+ * <form name="phpmailer_unit" action=__FILE__ method="get">
+ * <input type="hidden" name="submitted" value="1"/>
+ * From Address: <input type="text" size="50" name="mail_from" value="<?php echo get("mail_from"); ?>"/>
+ * <br/>
+ * To Address: <input type="text" size="50" name="mail_to" value="<?php echo get("mail_to"); ?>"/>
+ * <br/>
+ * Cc Address: <input type="text" size="50" name="mail_cc" value="<?php echo get("mail_cc"); ?>"/>
+ * <br/>
+ * SMTP Hostname: <input type="text" size="50" name="mail_host" value="<?php echo get("mail_host"); ?>"/>
+ * <p/>
+ * <input type="submit" value="Run Test"/>
+ *
+ * </form>
+ * </body>
+ * </html>
+ */

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -91,10 +91,6 @@ abstract class TestCase extends PolyfillTestCase
      */
     protected function set_up()
     {
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
-            include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; // Overrides go in here.
-        }
-
         // Initialize the PHPMailer class.
         if (is_bool(static::USE_EXCEPTIONS)) {
             $this->Mail = new PHPMailer(static::USE_EXCEPTIONS);
@@ -104,55 +100,11 @@ abstract class TestCase extends PolyfillTestCase
 
         $this->Mail->SMTPDebug = SMTP::DEBUG_CONNECTION; // Full debug output.
         $this->Mail->Debugoutput = ['PHPMailer\Test\DebugLogTestListener', 'debugLog'];
-        $this->Mail->Priority = 3;
-        $this->Mail->Encoding = '8bit';
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        if (array_key_exists('mail_from', $_REQUEST)) {
-            $this->Mail->From = $_REQUEST['mail_from'];
-        } else {
-            $this->Mail->From = 'unit_test@phpmailer.example.com';
-        }
-        $this->Mail->FromName = 'Unit Tester';
-        $this->Mail->Sender = '';
-        $this->Mail->Subject = 'Unit Test';
-        $this->Mail->Body = '';
-        $this->Mail->AltBody = '';
-        $this->Mail->WordWrap = 0;
-        if (array_key_exists('mail_host', $_REQUEST)) {
-            $this->Mail->Host = $_REQUEST['mail_host'];
-        } else {
-            $this->Mail->Host = 'mail.example.com';
-        }
-        if (array_key_exists('mail_port', $_REQUEST)) {
-            $this->Mail->Port = $_REQUEST['mail_port'];
-        } else {
-            $this->Mail->Port = 25;
-        }
-        $this->Mail->Helo = 'localhost.localdomain';
-        $this->Mail->SMTPAuth = false;
-        $this->Mail->Username = '';
-        $this->Mail->Password = '';
-        if (array_key_exists('mail_useauth', $_REQUEST)) {
-            $this->Mail->SMTPAuth = $_REQUEST['mail_useauth'];
-        }
-        if (array_key_exists('mail_username', $_REQUEST)) {
-            $this->Mail->Username = $_REQUEST['mail_username'];
-        }
-        if (array_key_exists('mail_userpass', $_REQUEST)) {
-            $this->Mail->Password = $_REQUEST['mail_userpass'];
-        }
-        $this->setAddress('no_reply@phpmailer.example.com', 'Reply Guy', 'ReplyTo');
-        $this->Mail->Sender = 'unit_test@phpmailer.example.com';
+
         if ($this->Mail->Host != '') {
             $this->Mail->isSMTP();
         } else {
             $this->Mail->isMail();
-        }
-        if (array_key_exists('mail_to', $_REQUEST)) {
-            $this->setAddress($_REQUEST['mail_to'], 'Test User', 'to');
-        }
-        if (array_key_exists('mail_cc', $_REQUEST) && $_REQUEST['mail_cc'] !== '') {
-            $this->setAddress($_REQUEST['mail_cc'], 'Carbon User', 'cc');
         }
     }
 
@@ -366,28 +318,3 @@ abstract class TestCase extends PolyfillTestCase
         return false;
     }
 }
-/*
- * This is a sample form for setting appropriate test values through a browser
- * These values can also be set using a file called testbootstrap.php (not in repo) in the same folder as this script
- * which is probably more useful if you run these tests a lot
- * <html>
- * <body>
- * <h3>PHPMailer Unit Test</h3>
- * By entering a SMTP hostname it will automatically perform tests with SMTP.
- *
- * <form name="phpmailer_unit" action=__FILE__ method="get">
- * <input type="hidden" name="submitted" value="1"/>
- * From Address: <input type="text" size="50" name="mail_from" value="<?php echo get("mail_from"); ?>"/>
- * <br/>
- * To Address: <input type="text" size="50" name="mail_to" value="<?php echo get("mail_to"); ?>"/>
- * <br/>
- * Cc Address: <input type="text" size="50" name="mail_cc" value="<?php echo get("mail_cc"); ?>"/>
- * <br/>
- * SMTP Hostname: <input type="text" size="50" name="mail_host" value="<?php echo get("mail_host"); ?>"/>
- * <p/>
- * <input type="submit" value="Run Test"/>
- *
- * </form>
- * </body>
- * </html>
- */


### PR DESCRIPTION
Follow up to #2376 which created a base `TestCase` class.

## Commit details

### TestCase: split into three different TestCases

The `TestCase::set_up()` was setting quite a number of properties in the `PHPMailer` class.

This makes testing more difficult for the following reasons:
1. The tests can no longer presume the properties in the `PHPMailer` class will have their default values
    This means that tests are not "transparent" (clearly show what is being tested), nor isolated (only target what is specifically being tested).
2. Any changes to the values set in the `set_up()` method may have a ripple effect and create a need for individual test expectations to be adjusted.
3. As the `set_up()` is changing a number of the properties using methods in the `PHPMailer()` class and methods called during the `set_up()` are included in code coverage visualizations, code coverage cannot fully be trusted and it is more difficult to verify that each piece of code has tests covering that code path.

With this in mind, I'm proposing splitting the `TestCase` into three distinct abstract `TestCase`s:
* A basic `TestCase` containing the utility methods and a minimal `set_up()` and `tear_down()`.
* A `PreSendTestCase` for use with tests using the `preSend()` method which requires a few properties to be set.
* A `SendTestCase` for use with tests actually testing the sending of mail using the `send()` method, which needs yet more properties and uses the `testbootstrap.php` file to retrieve the values of those variables.

This commit executes the initial split. Follow-on commits will streamline this further.

Includes adjusting the `TestCase` being extended for select existing unit test classes.

### TestCase: make the property pre-setting more flexible

This commit makes the property setting in the `TestCase::set_up()` more flexible by combining an overloadable property `$propertyChanges` and a `foreach` loop to set the actual property values.

Concrete test classes can either overload the `$propertyChanges` property with their own version or can add to the default setup using the following pattern:
```php
protected function set_up()
{
    $this->propertyChanges['additional_key'] = 'value';
    // Add more properties...

    parent::set_up();
}
```

### PreSendTestCase: implement use of the $propertyChanges property

### PreSendTestCase: reduce amount of properties being preset

After some investigation, it turns out that barely any of these properties are actually needed for the `PHPMailer::preSend()` method to succeed.

This commit removes all presetting of properties for the PHPMailer instance created by the `PreSendTestCase`, save for the bare minimum.

Overloading and/or adding to the `$propertyChanges` array from concrete test cases is, of course, supported, so if individual tests need additional presetting of properties, the same logic as mentioned in the previous commit can be used.

### SendTestCase: implement use of the $propertyChanges property

The `SendTestCase` gets the values of the properties to be set from the `testbootstrap.php` file.

This introduces a `private` property to map the field names used in `$_REQUEST` to the properties in the `PHPMailer` class and adds logic to the overloaded `set_up()` method to fill the `$propertyChanges` TestCase property. The actual setting of the properties in the `PHPMailer` instance is deferred to the underlying `TestCase` parent class.

Includes adding support for presetting the `bcc` value for feature completeness.

Overloading and/or adding to the `$propertyChanges` array from concrete test cases is, of course, supported, so if individual tests need additional presetting of properties, the same logic as mentioned in the previous commit can be used.

### TestCase::checkChanges(): make dynamic

The `TestCase::checkChanges()` method is a way of exposing what properties in the `PHPMailer` class have a changed value compared to their default value in a particular test situation. The method is used for debugging tests.

As things were, the `TestCase::checkChanges()` method would check against a limited set of hard-coded values to determine whether the default value of a property has been updated.

This is unstable as:
1. Default values may change in the `PHPMailer` class and the values within this method would need to be updated to match, which is easily forgotten.
2. New properties may be introduced in the `PHPMailer` class and be relevant to this debug changelog.
    Again, it would require manually adding these new properties to this method to start tracking them.
3. Property values may be changed in the `set_up()` method, which would be a "known change" for a certain test.
    In part such "expected" changes were taken into account in this method based on the previously hard-coded setting changes in `set_up()`.
    With the logic for the property setting from the `set_up()` method now being more flexible, the pre-setting of properties having been reduced to the bare minimum, but also allowing individual test clases to set their own additional changes, keeping track of what is a "known" change by checking against hard-coded values is no longer stable.

With this in mind, I propose to make the `TestCase::checkChanges()` method dynamic.

To that end, this commit:
* Retrieves the default values of all properties of the `PHPMailer` class via the PHP native `get_class_vars()` function.
* Will automatically check for changes in *all* properties, with only a limited set of _exclusions_, effectively changing the changelog from an "inclusion list" to an "exclusion list".
    A select list of properties is excluded from being listed in the changelog via the `TestCase::$changelogExclude` property.
    See the inline documentation in the property for the reasoning behind excluding certain properties from the changelog.
* The value of static properties will always be compared to their default value as registered in the `TestCase::$PHPMailerStaticProps` method and will be listed when different.
    _Note: as documented, this list has to be hard-coded due to Reflection (as well as `get_class_vars()`) not handling default values for static properties correctly._
* The value of non-static properties will be compared to both the known changes made in the `set_up()` method and if the property was not changed in `set_up()`, to their default value. The property will be listed in the changelog when the value is different from the "expected" value, i.e. not a known change from `set_up()` and not the default value.

In addition to this, the representation of the properties will now be created via `var_export()`, which allows for listing `null` and boolean values as well.

