### PR TITLE
Tests: move denial of service tests to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -866,36 +866,6 @@ EOT;
     }
 
     /**
-     * Test this denial of service attack.
-     *
-     * @see http://www.cybsec.com/vuln/PHPMailer-DOS.pdf
-     */
-    public function testDenialOfServiceAttack()
-    {
-        $this->Mail->Body = 'This should no longer cause a denial of service.';
-        $this->buildBody();
-
-        $this->Mail->Subject = substr(str_repeat('0123456789', 100), 0, 998);
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-    }
-
-    /**
-     * Tests this denial of service attack.
-     *
-     * According to the ticket, this should get stuck in a loop, though I can't make it happen.
-     * @see https://sourceforge.net/p/phpmailer/bugs/383/
-     *
-     * @doesNotPerformAssertions
-     */
-    public function testDenialOfServiceAttack2()
-    {
-        //Encoding name longer than 68 chars
-        $this->Mail->Encoding = '1234567890123456789012345678901234567890123456789012345678901234567890';
-        //Call wrapText with a zero length value
-        $this->Mail->wrapText(str_repeat('This should no longer cause a denial of service. ', 30), 0);
-    }
-
-    /**
      * Test error handling.
      */
     public function testError()

--- a/test/Security/DenialOfServiceVectorsTest.php
+++ b/test/Security/DenialOfServiceVectorsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\Security;
+
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test denial of service attack vectors, which have been mitigated.
+ */
+final class DenialOfServiceVectorsTest extends SendTestCase
+{
+
+    /**
+     * Test this denial of service attack.
+     *
+     * @see http://www.cybsec.com/vuln/PHPMailer-DOS.pdf
+     */
+    public function testDenialOfServiceAttack()
+    {
+        $this->Mail->Body = 'This should no longer cause a denial of service.';
+        $this->buildBody();
+
+        $this->Mail->Subject = substr(str_repeat('0123456789', 100), 0, 998);
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Tests this denial of service attack.
+     *
+     * According to the ticket, this should get stuck in a loop, though I can't make it happen.
+     * @see https://sourceforge.net/p/phpmailer/bugs/383/
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testDenialOfServiceAttack2()
+    {
+        //Encoding name longer than 68 chars
+        $this->Mail->Encoding = '1234567890123456789012345678901234567890123456789012345678901234567890';
+        //Call wrapText with a zero length value
+        $this->Mail->wrapText(str_repeat('This should no longer cause a denial of service. ', 30), 0);
+    }
+}

--- a/test/Security/DenialOfServiceVectorsTest.php
+++ b/test/Security/DenialOfServiceVectorsTest.php
@@ -17,6 +17,8 @@ use PHPMailer\Test\SendTestCase;
 
 /**
  * Test denial of service attack vectors, which have been mitigated.
+ *
+ * @coversNothing
  */
 final class DenialOfServiceVectorsTest extends SendTestCase
 {
@@ -24,9 +26,9 @@ final class DenialOfServiceVectorsTest extends SendTestCase
     /**
      * Test this denial of service attack.
      *
-     * @see http://www.cybsec.com/vuln/PHPMailer-DOS.pdf
+     * @link http://www.cybsec.com/vuln/PHPMailer-DOS.pdf
      */
-    public function testDenialOfServiceAttack()
+    public function testDenialOfServiceAttack1()
     {
         $this->Mail->Body = 'This should no longer cause a denial of service.';
         $this->buildBody();
@@ -39,15 +41,15 @@ final class DenialOfServiceVectorsTest extends SendTestCase
      * Tests this denial of service attack.
      *
      * According to the ticket, this should get stuck in a loop, though I can't make it happen.
-     * @see https://sourceforge.net/p/phpmailer/bugs/383/
+     * @link https://sourceforge.net/p/phpmailer/bugs/383/
      *
      * @doesNotPerformAssertions
      */
     public function testDenialOfServiceAttack2()
     {
-        //Encoding name longer than 68 chars
+        // Encoding name longer than 68 chars.
         $this->Mail->Encoding = '1234567890123456789012345678901234567890123456789012345678901234567890';
-        //Call wrapText with a zero length value
+        // Call wrapText with a zero length value.
         $this->Mail->wrapText(str_repeat('This should no longer cause a denial of service. ', 30), 0);
     }
 }


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410

## Commit details

###  Tests/reorganize: move denial of service tests to own file

### SecurityDenialOfServiceVectorsTest: various test tweaks

Minor test tweaks:
* Add `@coversNothing` tag.
* Rename the first test (add a number).
* Use `@link` instead of `@see` for links.
* Minor comment punctuation.

