### PR TITLE
SendTestCase: error out when the testbootstrap file cannot be found

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -24,18 +24,6 @@ use PHPMailer\Test\SendTestCase;
 final class PHPMailerTest extends SendTestCase
 {
     /**
-     * Check that we have loaded default test params.
-     * Pretty much everything will fail due to unset recipient if this is not done.
-     */
-    public function testBootstrap()
-    {
-        self::assertFileExists(
-            \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php',
-            'Test config params missing - copy testbootstrap.php to testbootstrap-dist.php and change as appropriate'
-        );
-    }
-
-    /**
      * Word-wrap an ASCII message.
      */
     public function testWordWrap()

--- a/test/SendTestCase.php
+++ b/test/SendTestCase.php
@@ -13,6 +13,7 @@
 
 namespace PHPMailer\Test;
 
+use Exception;
 use PHPMailer\Test\PreSendTestCase;
 
 /**
@@ -43,11 +44,19 @@ abstract class SendTestCase extends PreSendTestCase
      */
     protected function set_up()
     {
-        parent::set_up();
-
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php')) {
-            include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; // Overrides go in here.
+        /*
+         * Make sure the testbootstrap.php file is available.
+         * Pretty much everything will fail due to unset recipient if this is not done, so error
+         * the tests out before they run if the file does not exist.
+         */
+        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php') === false) {
+            throw new Exception(
+                'Test config params missing - copy testbootstrap-dist.php to testbootstrap.php and change'
+                . ' as appropriate for your own test environment setup.'
+            );
         }
+
+        include \PHPMAILER_INCLUDE_DIR . '/test/testbootstrap.php'; // Overrides go in here.
 
         /*
          * Process the $REQUEST values and add them to the list of properties


### PR DESCRIPTION
The `PHPMailerTest` class contained a `testBootstrap()` method to verify that the `testbootstrap.php` file exists as the first test in the class.
As the order in which tests are run is not predefined, this is not reliable.

Additionally, the check for the `testbootstrap.php` file is checking a pre-requisite for tests using the `PHPMailer::send()` method, so it would be better to verify via a condition in the `set_up()`.

Now, using such a condition, there is choice: the test can either be marked as "skipped" when the `testbootstrap.php` file can not be found, or be marked as an "error".

As the tests _should_ run, skipping them would hide an error in the dev-user test setup, so showing these tests as errors seems more appropriate.

To that end, the `testBootstrap()` method has been removed and a check for the `testbootstrap.php` file has been added to the `SendTestCase::set_up()` which will now throw an appropriate `Exception` when the file is not found.

Oops... also removes a stray `parent::set_up()` at the start of the local `set_up()` which should have been removed in 218fd13c8867ac7342dcafc3ccdeee57eb8e5da8