### PR TITLE
Utf8CharBoundaryTest: switch base test case

### DIFF
--- a/test/PHPMailer/Utf8CharBoundaryTest.php
+++ b/test/PHPMailer/Utf8CharBoundaryTest.php
@@ -13,8 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\PHPMailer\PHPMailer;
-use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+use PHPMailer\Test\TestCase;
 
 /**
  * Test UTF8 character boundary functionality.
@@ -37,8 +36,7 @@ final class Utf8CharBoundaryTest extends TestCase
      */
     public function testUtf8CharBoundary($encodedText, $maxLength, $expected)
     {
-        $mail = new PHPMailer();
-        $this->assertSame($expected, $mail->utf8CharBoundary($encodedText, $maxLength));
+        $this->assertSame($expected, $this->Mail->utf8CharBoundary($encodedText, $maxLength));
     }
 
     /**


### PR DESCRIPTION
Follow up on #2389 and #2412

Now the base `TestCase` has been simplified and only presets the bare minimum of properties in the `PHPMailer` class, the `Utf8CharBoundaryTest` can actually use it.