### PR TITLE
Tests: move puny encoding test to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1567,25 +1567,4 @@ EOT;
     {
         $this->assertFalse($this->Mail->addAddress('mehome.com'));
     }
-
-    public function testGivenIdnAddress_punyencodeAddress_returnsCorrectCode()
-    {
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
-            $this->markTestSkipped('/test/fakefunctions.php file not found');
-        }
-
-        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
-        //This source file is in UTF-8, so characters here are in native charset
-        $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
-        $result = $this->Mail->punyencodeAddress(
-            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_UTF8)
-        );
-        $this->assertSame('test@xn--franois-xxa.ch', $result);
-        //To force working another charset, decode an ASCII string to avoid literal string charset issues
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        $result = $this->Mail->punyencodeAddress(
-            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_ISO88591)
-        );
-        $this->assertSame('test@xn--franois-xxa.ch', $result);
-    }
 }

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test IDN to ASCII functionality.
+ */
+final class PunyencodeAddressTest extends TestCase
+{
+
+    public function testGivenIdnAddress_punyencodeAddress_returnsCorrectCode()
+    {
+        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
+            $this->markTestSkipped('/test/fakefunctions.php file not found');
+        }
+
+        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
+        //This source file is in UTF-8, so characters here are in native charset
+        $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
+        $result = $this->Mail->punyencodeAddress(
+            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_UTF8)
+        );
+        $this->assertSame('test@xn--franois-xxa.ch', $result);
+        //To force working another charset, decode an ASCII string to avoid literal string charset issues
+        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
+        $result = $this->Mail->punyencodeAddress(
+            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_ISO88591)
+        );
+        $this->assertSame('test@xn--franois-xxa.ch', $result);
+    }
+}

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -72,4 +72,64 @@ final class PunyencodeAddressTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * Test IDN to ASCII form/punycode conversion returns the original value when no conversion
+     * is needed or when the requirements to convert an address have not been met.
+     *
+     * @dataProvider dataPunyencodeAddressNoConversion
+     *
+     * @param string $input    Input text string.
+     * @param string $charset  The character set.
+     * @param string $expected Expected funtion output.
+     */
+    public function testPunyencodeAddressNoConversion($input, $charset, $expected)
+    {
+        $this->Mail->CharSet = $charset;
+
+        // Prevent a warning about html_entity_decode() not supporting charset `us-ascii`.
+        if ($charset !== PHPMailer::CHARSET_ASCII) {
+            $input    = html_entity_decode($input, ENT_COMPAT, $charset);
+            $expected = html_entity_decode($expected, ENT_COMPAT, $charset);
+        }
+
+        $result = $this->Mail->punyencodeAddress($input);
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataPunyencodeAddressNoConversion()
+    {
+        return [
+            'ASCII' => [
+                'input'    => 'test@example.com',
+                'charset'  => PHPMailer::CHARSET_ASCII,
+                'expected' => 'test@example.com',
+            ],
+            'Invalid email address' => [
+                'input'    => 'fran&ccedil;ois@',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+                'expected' => 'fran&ccedil;ois@',
+            ],
+            'Not an email address' => [
+                'input'    => 'testing 1-2-3',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+                'expected' => 'testing 1-2-3',
+            ],
+            'Empty string' => [
+                'input'    => '',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+                'expected' => '',
+            ],
+            'Empty charset' => [
+                'input'    => 'test@fran&ccedil;ois.ch',
+                'charset'  => '',
+                'expected' => 'test@fran&ccedil;ois.ch',
+            ],
+        ];
+    }
 }

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -23,22 +23,45 @@ final class PunyencodeAddressTest extends TestCase
 {
 
     /**
+     * Test IDN to ASCII form/punycode conversion for an email address.
+     *
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     *
+     * @dataProvider dataPunyencodeAddressConversion
+     *
+     * @param string $input    Input text string.
+     * @param string $charset  The character set.
+     * @param string $expected Expected funtion output.
      */
-    public function testGivenIdnAddress_punyencodeAddress_returnsCorrectCode()
+    public function testPunyencodeAddressConversion($input, $charset, $expected)
     {
-        //This source file is in UTF-8, so characters here are in native charset
-        $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
-        $result = $this->Mail->punyencodeAddress(
-            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_UTF8)
-        );
-        $this->assertSame('test@xn--franois-xxa.ch', $result);
-        //To force working another charset, decode an ASCII string to avoid literal string charset issues
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        $result = $this->Mail->punyencodeAddress(
-            html_entity_decode('test@fran&ccedil;ois.ch', ENT_COMPAT, PHPMailer::CHARSET_ISO88591)
-        );
-        $this->assertSame('test@xn--franois-xxa.ch', $result);
+        $this->Mail->CharSet = $charset;
+
+        $result = $this->Mail->punyencodeAddress(html_entity_decode($input, ENT_COMPAT, $charset));
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataPunyencodeAddressConversion()
+    {
+        return [
+            // This source file is in UTF-8, so characters here are in native charset.
+            'UTF8' => [
+                'input'    => 'test@fran&ccedil;ois.ch',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+                'expected' => 'test@xn--franois-xxa.ch',
+            ],
+            // To force working another charset, decode an ASCII string to avoid literal string charset issues.
+            'ISO88591' => [
+                'input'    => 'test@fran&ccedil;ois.ch',
+                'charset'  => PHPMailer::CHARSET_ISO88591,
+                'expected' => 'test@xn--franois-xxa.ch',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -38,7 +38,10 @@ final class PunyencodeAddressTest extends TestCase
     {
         $this->Mail->CharSet = $charset;
 
-        $result = $this->Mail->punyencodeAddress(html_entity_decode($input, ENT_COMPAT, $charset));
+        $input    = html_entity_decode($input, ENT_COMPAT, $charset);
+        $expected = html_entity_decode($expected, ENT_COMPAT, $charset);
+
+        $result = $this->Mail->punyencodeAddress($input);
         $this->assertSame($expected, $result);
     }
 
@@ -61,6 +64,11 @@ final class PunyencodeAddressTest extends TestCase
                 'input'    => 'test@fran&ccedil;ois.ch',
                 'charset'  => PHPMailer::CHARSET_ISO88591,
                 'expected' => 'test@xn--franois-xxa.ch',
+            ],
+            'Decode only domain' => [
+                'input'    => 'fran&ccedil;ois@fran&ccedil;ois.ch',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+                'expected' => 'fran&ccedil;ois@xn--franois-xxa.ch',
             ],
         ];
     }

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -22,13 +22,12 @@ use PHPMailer\Test\TestCase;
 final class PunyencodeAddressTest extends TestCase
 {
 
+    /**
+     * @requires extension mbstring
+     * @requires function idn_to_ascii
+     */
     public function testGivenIdnAddress_punyencodeAddress_returnsCorrectCode()
     {
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
-            $this->markTestSkipped('/test/fakefunctions.php file not found');
-        }
-
-        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
         //This source file is in UTF-8, so characters here are in native charset
         $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
         $result = $this->Mail->punyencodeAddress(

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -18,6 +18,8 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test IDN to ASCII functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::punyencodeAddress
  */
 final class PunyencodeAddressTest extends TestCase
 {


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414

## Commit details

###  Tests/reorganize: move puny encoding test to own file

### PunyencodeAddressTest: set proper run requirements

The "fakefunctions" are all nice and dandy to get past the `idnSupported()` check, but if either of these functions is not _really_ available and therefore doesn't behave as expected, the test would still fail as the expected output of the `PHPMailer::punyencodeAddress()` function would not match.

In other words, this test should not use the `fakefunctions`, but should have a hard requirement for the `mbstring` extension (for the `mb_check_encoding()` and the `mb_convert_encoding()` function calls) and a check for the `idn_to_ascii()` function.

### PunyencodeAddressTest: reorganize to use data provider

* Maintains the same test code and test cases.
* Makes it easier to add additional test cases in the future.

### PunyencodeAddressTest: add additional test case

... to ensure that the `PHPMailer::punyencodeAddress()` only acts on the domain.

### PunyencodeAddressTest: add additional test method

This new test method covers a range of cases where the `PHPMailer::punyencodeAddress()` method should (and does) return the original input value unchanged.

This test does not require the `mbstring` extension or `idn_to_ascii()` function to be available, which is why it has been set up as a separate test with a separate data provider.

### PunyencodeAddressTest: add @covers tag 