### PR TITLE
Tests: move setWordWrap tests to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -24,50 +24,6 @@ use PHPMailer\Test\SendTestCase;
 final class PHPMailerTest extends SendTestCase
 {
     /**
-     * Word-wrap an ASCII message.
-     */
-    public function testWordWrap()
-    {
-        $this->Mail->WordWrap = 40;
-        $my_body = str_repeat(
-            'Here is the main body of this message.  It should ' .
-            'be quite a few lines.  It should be wrapped at ' .
-            '40 characters.  Make sure that it is. ',
-            10
-        );
-        $nBodyLen = strlen($my_body);
-        $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
-
-        $this->Mail->Body = $my_body;
-        $this->Mail->Subject .= ': Wordwrap';
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-    }
-
-    /**
-     * Word-wrap a multibyte message.
-     */
-    public function testWordWrapMultibyte()
-    {
-        $this->Mail->WordWrap = 40;
-        $my_body = str_repeat(
-            '飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 ' .
-            '飛飛兒樂 團光茫兒樂 團光茫飛兒樂 團光飛兒樂 團光茫飛兒樂 團光茫兒樂 團光茫 ' .
-            '飛兒樂 團光茫飛兒樂 團飛兒樂 團光茫光茫飛兒樂 團光茫. ',
-            10
-        );
-        $nBodyLen = strlen($my_body);
-        $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
-
-        $this->Mail->Body = $my_body;
-        $this->Mail->Subject .= ': Wordwrap multibyte';
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-    }
-
-    /**
      * Test low priority.
      */
     public function testLowPriority()

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -85,4 +85,34 @@ final class SetWordWrapTest extends PreSendTestCase
             ],
         ];
     }
+
+    /**
+     * Test explicitly NOT word-wrapping a message.
+     */
+    public function testNoWordWrap()
+    {
+        $this->Mail->WordWrap = 0;
+        $my_body = str_repeat('Irrelevant text, we\'re not wrapping', 10);
+        $nBodyLen = strlen($my_body);
+        $my_body .= "\n\nLong unwrapped message: " . $nBodyLen;
+
+        $this->Mail->Body = $my_body;
+        $this->Mail->Subject .= ': No wordwrap';
+
+        $this->buildBody();
+        $originalLines = explode("\n", $this->Mail->Body);
+        $this->Mail->preSend();
+
+        $lines = explode("\n", $this->Mail->Body);
+        self::assertSameSize($originalLines, $lines, 'Line count of message has changed');
+
+        foreach ($lines as $i => $line) {
+            self::assertSame(
+                $originalLines[$i],
+                $line,
+                'Line ' . ($i + 1) . ' has been changed while it shouldn\'t have been'
+                    . PHP_EOL . 'Line contents: "' . $originalLines[$i] . '"'
+            );
+        }
+    }
 }

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -22,46 +22,47 @@ final class SetWordWrapTest extends PreSendTestCase
 {
 
     /**
-     * Word-wrap an ASCII message.
+     * Test word-wrapping a message.
+     *
+     * @dataProvider dataWordWrap
+     *
+     * @param string $message       The message to use.
+     * @param string $subjectSuffix Subject suffix to use.
      */
-    public function testWordWrap()
+    public function testWordWrap($message, $subjectSuffix)
     {
         $this->Mail->WordWrap = 40;
-        $my_body = str_repeat(
-            'Here is the main body of this message.  It should ' .
-            'be quite a few lines.  It should be wrapped at ' .
-            '40 characters.  Make sure that it is. ',
-            10
-        );
+        $my_body = str_repeat($message, 10);
         $nBodyLen = strlen($my_body);
         $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
 
         $this->Mail->Body = $my_body;
-        $this->Mail->Subject .= ': Wordwrap';
+        $this->Mail->Subject .= ': ' . $subjectSuffix;
 
         $this->buildBody();
         self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 
     /**
-     * Word-wrap a multibyte message.
+     * Data provider.
+     *
+     * @return array
      */
-    public function testWordWrapMultibyte()
+    public function dataWordWrap()
     {
-        $this->Mail->WordWrap = 40;
-        $my_body = str_repeat(
-            '飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 ' .
-            '飛飛兒樂 團光茫兒樂 團光茫飛兒樂 團光飛兒樂 團光茫飛兒樂 團光茫兒樂 團光茫 ' .
-            '飛兒樂 團光茫飛兒樂 團飛兒樂 團光茫光茫飛兒樂 團光茫. ',
-            10
-        );
-        $nBodyLen = strlen($my_body);
-        $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
-
-        $this->Mail->Body = $my_body;
-        $this->Mail->Subject .= ': Wordwrap multibyte';
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
+        return [
+            'ascii message' => [
+                'message'       => 'Here is the main body of this message.  It should ' .
+                    'be quite a few lines.  It should be wrapped at ' .
+                    '40 characters.  Make sure that it is. ',
+                'subjectSuffix' => 'Wordwrap',
+            ],
+            'multibyte message' => [
+                'message'       => '飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 ' .
+                    '飛飛兒樂 團光茫兒樂 團光茫飛兒樂 團光飛兒樂 團光茫飛兒樂 團光茫兒樂 團光茫 ' .
+                    '飛兒樂 團光茫飛兒樂 團飛兒樂 團光茫光茫飛兒樂 團光茫. ',
+                'subjectSuffix' => 'Wordwrap multibyte',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -17,6 +17,9 @@ use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test automatic wordwrap functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::setWordWrap
+ * @covers \PHPMailer\PHPMailer\PHPMailer::wrapText
  */
 final class SetWordWrapTest extends PreSendTestCase
 {

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -13,12 +13,12 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test automatic wordwrap functionality.
  */
-final class SetWordWrapTest extends SendTestCase
+final class SetWordWrapTest extends PreSendTestCase
 {
 
     /**
@@ -40,7 +40,7 @@ final class SetWordWrapTest extends SendTestCase
         $this->Mail->Subject .= ': Wordwrap';
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 
     /**
@@ -62,6 +62,6 @@ final class SetWordWrapTest extends SendTestCase
         $this->Mail->Subject .= ': Wordwrap multibyte';
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 }

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test automatic wordwrap functionality.
+ */
+final class SetWordWrapTest extends SendTestCase
+{
+
+    /**
+     * Word-wrap an ASCII message.
+     */
+    public function testWordWrap()
+    {
+        $this->Mail->WordWrap = 40;
+        $my_body = str_repeat(
+            'Here is the main body of this message.  It should ' .
+            'be quite a few lines.  It should be wrapped at ' .
+            '40 characters.  Make sure that it is. ',
+            10
+        );
+        $nBodyLen = strlen($my_body);
+        $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
+
+        $this->Mail->Body = $my_body;
+        $this->Mail->Subject .= ': Wordwrap';
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Word-wrap a multibyte message.
+     */
+    public function testWordWrapMultibyte()
+    {
+        $this->Mail->WordWrap = 40;
+        $my_body = str_repeat(
+            '飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 ' .
+            '飛飛兒樂 團光茫兒樂 團光茫飛兒樂 團光飛兒樂 團光茫飛兒樂 團光茫兒樂 團光茫 ' .
+            '飛兒樂 團光茫飛兒樂 團飛兒樂 團光茫光茫飛兒樂 團光茫. ',
+            10
+        );
+        $nBodyLen = strlen($my_body);
+        $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
+
+        $this->Mail->Body = $my_body;
+        $this->Mail->Subject .= ': Wordwrap multibyte';
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+}

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -26,12 +26,13 @@ final class SetWordWrapTest extends PreSendTestCase
      *
      * @dataProvider dataWordWrap
      *
+     * @param int    $wrapAt        The number of characters to wrap at.
      * @param string $message       The message to use.
      * @param string $subjectSuffix Subject suffix to use.
      */
-    public function testWordWrap($message, $subjectSuffix)
+    public function testWordWrap($wrapAt, $message, $subjectSuffix)
     {
-        $this->Mail->WordWrap = 40;
+        $this->Mail->WordWrap = $wrapAt;
         $my_body = str_repeat($message, 10);
         $nBodyLen = strlen($my_body);
         $my_body .= "\n\nThis is the above body length: " . $nBodyLen;
@@ -52,12 +53,14 @@ final class SetWordWrapTest extends PreSendTestCase
     {
         return [
             'ascii message' => [
+                'wrapAt'        => 40,
                 'message'       => 'Here is the main body of this message.  It should ' .
                     'be quite a few lines.  It should be wrapped at ' .
                     '40 characters.  Make sure that it is. ',
                 'subjectSuffix' => 'Wordwrap',
             ],
             'multibyte message' => [
+                'wrapAt'        => 40,
                 'message'       => '飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 飛兒樂 團光茫 ' .
                     '飛飛兒樂 團光茫兒樂 團光茫飛兒樂 團光飛兒樂 團光茫飛兒樂 團光茫兒樂 團光茫 ' .
                     '飛兒樂 團光茫飛兒樂 團飛兒樂 團光茫光茫飛兒樂 團光茫. ',

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -41,7 +41,24 @@ final class SetWordWrapTest extends PreSendTestCase
         $this->Mail->Subject .= ': ' . $subjectSuffix;
 
         $this->buildBody();
-        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
+        $originalLines = explode("\n", $this->Mail->Body);
+        $this->Mail->preSend();
+
+        $lines = explode("\n", $this->Mail->Body);
+        self::assertGreaterThanOrEqual(
+            count($originalLines),
+            count($lines),
+            'Line count of message less than expected'
+        );
+
+        foreach ($lines as $i => $line) {
+            self::assertLessThanOrEqual(
+                $wrapAt,
+                strlen(trim($line)),
+                'Character count for line ' . ($i + 1) . ' does not comply with the expected ' . $wrapAt
+                . ' characters.' . PHP_EOL . 'Line contents: "' . $line . '"'
+            );
+        }
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421

## Commit details

### Tests/reorganize: move setWordWrap tests to own file

### SetWordWrapTest: use preSend() not send()

For this test, there is no need to actually try to _send_ the message, we just need to make sure that `setWordWrap()` is triggered, which can be done by calling `preSend()` instead of `send()`.

### SetWordWrapTest: reorganize to use data providers

* Maintains the same test code and test cases.
* Removes code duplication.
* Makes it easier to add additional test cases in the future.

### SetWordWrapTest: make $WordWrap variable

Make the `WordWrap` setting variable and provide it via the data provider.

### SetWordWrapTest: actually test the wordwrapping has been applied

Previously, the test didn't actually test whether the wordwrapping had been applied, just that the message was (pre)send successfully.

Changing the assertions to actually test that the wordwrapping has been correctly applied.

### SetWordWrapTest: add "no-wrapping" test

... to increase code coverage.

### SetWordWrapTest: add @covers tags 