### PR TITLE
HasLineLongerThanMaxTest: switch to preSend()

### DIFF
--- a/test/PHPMailer/HasLineLongerThanMaxTest.php
+++ b/test/PHPMailer/HasLineLongerThanMaxTest.php
@@ -14,12 +14,12 @@
 namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test line length detection and handling.
  */
-final class HasLineLongerThanMaxTest extends SendTestCase
+final class HasLineLongerThanMaxTest extends PreSendTestCase
 {
 
     /**
@@ -114,7 +114,7 @@ final class HasLineLongerThanMaxTest extends SendTestCase
         $this->Mail->Encoding = '8bit';
         $this->Mail->Body = $oklen . $badlen . $oklen . $badlen;
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
         self::assertSame('quoted-printable', $this->Mail->Encoding, 'Long line did not override transfer encoding');
     }
 }


### PR DESCRIPTION
Follow up to #2385 and #2412

The line length adjustments are executed within `createBody()` which is called from `preSend()`, so this test doesn't actually need to call `send()`.

I also wonder if this test can be further improved by having more targeted tests for `PHPMailer::hasLineLongerThanMax()` and whether these more extensive tests can be included in a test class which is more targeted at the `createBody()` and/or `preSend()` methods, but that is for later.