### PR TITLE
Tests: move custom header tests to own file

### DIFF
--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -84,6 +84,14 @@ final class CustomHeaderTest extends TestCase
                     ['yux', ''],
                 ],
             ],
+            'Custom header: whitespace around name and value' => [
+                'headers' => [
+                    ['  name  ', '  value  '],
+                ],
+                'expected' => [
+                    ['name', 'value'],
+                ],
+            ],
             'Custom headers: "name: value" sets' => [
                 'headers' => [
                     ['Content-Type: application/json'],
@@ -92,6 +100,40 @@ final class CustomHeaderTest extends TestCase
                 'expected' => [
                     ['Content-Type', 'application/json'],
                     ['SomeHeader', 'Some Value'],
+                ],
+            ],
+            'Custom headers: "name:value" sets, no space and lots of space' => [
+                'headers' => [
+                    ['Content-Type:application/json'],
+                    ['SomeHeader    :     Some Value'],
+                ],
+                'expected' => [
+                    ['Content-Type', 'application/json'],
+                    ['SomeHeader', 'Some Value'],
+                ],
+            ],
+            'Custom headers: "name: value" set with a colon in the value' => [
+                'headers' => [
+                    ['name: value:value'],
+                ],
+                'expected' => [
+                    ['name', 'value:value'],
+                ],
+            ],
+            'Custom headers: "name: value" set without a value' => [
+                'headers' => [
+                    ['name:'],
+                ],
+                'expected' => [
+                    ['name', ''],
+                ],
+            ],
+            'Custom header: "name: value" set with whitespace around name and value' => [
+                'headers' => [
+                    ['  name  :  value  '],
+                ],
+                'expected' => [
+                    ['name', 'value'],
                 ],
             ],
             'Custom headers: duplicate headers' => [

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -26,6 +26,9 @@ final class CustomHeaderTest extends TestCase
     /**
      * Tests setting and getting custom headers.
      *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::addCustomHeader
+     * @covers \PHPMailer\PHPMailer\PHPMailer::getCustomHeaders
+     *
      * @dataProvider dataAddAndGetCustomHeader
      *
      * @param array      $headers  Array of headers to set.
@@ -152,6 +155,7 @@ final class CustomHeaderTest extends TestCase
     /**
      * Tests failing to set custom headers when the header info provided does not validate.
      *
+     * @covers       \PHPMailer\PHPMailer\PHPMailer::addCustomHeader
      * @dataProvider dataAddCustomHeaderInvalid
      *
      * @param string $name  Custom header name.
@@ -189,6 +193,8 @@ final class CustomHeaderTest extends TestCase
 
     /**
      * Test removing previously set custom headers.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::clearCustomHeaders
      */
     public function testClearCustomHeaders()
     {
@@ -204,6 +210,8 @@ final class CustomHeaderTest extends TestCase
 
     /**
      * Check whether setting a bad custom header throws exceptions.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::addCustomHeader
      *
      * @throws Exception
      */

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -98,6 +98,21 @@ final class CustomHeaderTest extends TestCase
     }
 
     /**
+     * Test removing previously set custom headers.
+     */
+    public function testClearCustomHeaders()
+    {
+        $this->Mail->addCustomHeader('foo', 'bar');
+        self::assertSame([['foo', 'bar']], $this->Mail->getCustomHeaders());
+
+        $this->Mail->clearCustomHeaders();
+
+        $cleared = $this->Mail->getCustomHeaders();
+        self::assertIsArray($cleared);
+        self::assertEmpty($cleared);
+    }
+
+    /**
      * Check whether setting a bad custom header throws exceptions.
      *
      * @throws Exception

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -72,9 +72,10 @@ final class CustomHeaderTest extends TestCase
      *
      * @throws Exception
      */
-    public function testHeaderException()
+    public function testInvalidHeaderException()
     {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid header name or value');
 
         $mail = new PHPMailer(true);
         $mail->addCustomHeader('SomeHeader', "Some\n Value");

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -178,6 +178,12 @@ final class CustomHeaderTest extends TestCase
                 'name'  => "Some\nHeader",
                 'value' => 'Some Value',
             ],
+            'Invalid: empty name' => [
+                'name'  => '   ',
+            ],
+            'Invalid: empty name and empty value' => [
+                'name'  => '  :  ',
+            ],
         ];
     }
 

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -63,8 +63,38 @@ final class CustomHeaderTest extends TestCase
         $headers = $this->Mail->getCustomHeaders();
         self::assertSame(['SomeHeader', 'Some Value'], $headers[0]);
         $this->Mail->clearCustomHeaders();
-        self::assertFalse($this->Mail->addCustomHeader('SomeHeader', "Some\n Value"));
-        self::assertFalse($this->Mail->addCustomHeader("Some\nHeader", 'Some Value'));
+    }
+
+    /**
+     * Tests failing to set custom headers when the header info provided does not validate.
+     *
+     * @dataProvider dataAddCustomHeaderInvalid
+     *
+     * @param string $name  Custom header name.
+     * @param mixed  $value Optional. Custom header value.
+     */
+    public function testAddCustomHeaderInvalid($name, $value = null)
+    {
+        self::assertFalse($this->Mail->addCustomHeader($name, $value));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataAddCustomHeaderInvalid()
+    {
+        return [
+            'Invalid: new line in value' => [
+                'name'  => 'SomeHeader',
+                'value' => "Some\n Value",
+            ],
+            'Invalid: new line in name' => [
+                'name'  => "Some\nHeader",
+                'value' => 'Some Value',
+            ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test custom header functionality.
+ */
+final class CustomHeaderTest extends TestCase
+{
+
+    /**
+     * Tests the Custom header getter.
+     */
+    public function testCustomHeaderGetter()
+    {
+        $this->Mail->addCustomHeader('foo', 'bar');
+        self::assertSame([['foo', 'bar']], $this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('foo', 'baz');
+        self::assertSame(
+            [
+                ['foo', 'bar'],
+                ['foo', 'baz'],
+            ],
+            $this->Mail->getCustomHeaders()
+        );
+
+        $this->Mail->clearCustomHeaders();
+        self::assertEmpty($this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('yux');
+        self::assertSame([['yux', '']], $this->Mail->getCustomHeaders());
+
+        $this->Mail->addCustomHeader('Content-Type: application/json');
+        self::assertSame(
+            [
+                ['yux', ''],
+                ['Content-Type', 'application/json'],
+            ],
+            $this->Mail->getCustomHeaders()
+        );
+        $this->Mail->clearCustomHeaders();
+        $this->Mail->addCustomHeader('SomeHeader: Some Value');
+        $headers = $this->Mail->getCustomHeaders();
+        self::assertSame(['SomeHeader', 'Some Value'], $headers[0]);
+        $this->Mail->clearCustomHeaders();
+        $this->Mail->addCustomHeader('SomeHeader', 'Some Value');
+        $headers = $this->Mail->getCustomHeaders();
+        self::assertSame(['SomeHeader', 'Some Value'], $headers[0]);
+        $this->Mail->clearCustomHeaders();
+        self::assertFalse($this->Mail->addCustomHeader('SomeHeader', "Some\n Value"));
+        self::assertFalse($this->Mail->addCustomHeader("Some\nHeader", 'Some Value'));
+    }
+
+    /**
+     * Check whether setting a bad custom header throws exceptions.
+     *
+     * @throws Exception
+     */
+    public function testHeaderException()
+    {
+        $this->expectException(Exception::class);
+
+        $mail = new PHPMailer(true);
+        $mail->addCustomHeader('SomeHeader', "Some\n Value");
+    }
+}

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1233,19 +1233,6 @@ EOT;
     }
 
     /**
-     * Check whether setting a bad custom header throws exceptions.
-     *
-     * @throws Exception
-     */
-    public function testHeaderException()
-    {
-        $this->expectException(Exception::class);
-
-        $mail = new PHPMailer(true);
-        $mail->addCustomHeader('SomeHeader', "Some\n Value");
-    }
-
-    /**
      * Miscellaneous calls to improve test coverage and some small tests.
      */
     public function testMiscellaneous()
@@ -1270,50 +1257,6 @@ EOT;
         $this->Mail->smtpConnect();
         $smtp = $this->Mail->getSMTPInstance();
         self::assertFalse($smtp->mail("somewhere\nbad"), 'Bad SMTP command containing breaks accepted');
-    }
-
-    /**
-     * Tests the Custom header getter.
-     */
-    public function testCustomHeaderGetter()
-    {
-        $this->Mail->addCustomHeader('foo', 'bar');
-        self::assertSame([['foo', 'bar']], $this->Mail->getCustomHeaders());
-
-        $this->Mail->addCustomHeader('foo', 'baz');
-        self::assertSame(
-            [
-                ['foo', 'bar'],
-                ['foo', 'baz'],
-            ],
-            $this->Mail->getCustomHeaders()
-        );
-
-        $this->Mail->clearCustomHeaders();
-        self::assertEmpty($this->Mail->getCustomHeaders());
-
-        $this->Mail->addCustomHeader('yux');
-        self::assertSame([['yux', '']], $this->Mail->getCustomHeaders());
-
-        $this->Mail->addCustomHeader('Content-Type: application/json');
-        self::assertSame(
-            [
-                ['yux', ''],
-                ['Content-Type', 'application/json'],
-            ],
-            $this->Mail->getCustomHeaders()
-        );
-        $this->Mail->clearCustomHeaders();
-        $this->Mail->addCustomHeader('SomeHeader: Some Value');
-        $headers = $this->Mail->getCustomHeaders();
-        self::assertSame(['SomeHeader', 'Some Value'], $headers[0]);
-        $this->Mail->clearCustomHeaders();
-        $this->Mail->addCustomHeader('SomeHeader', 'Some Value');
-        $headers = $this->Mail->getCustomHeaders();
-        self::assertSame(['SomeHeader', 'Some Value'], $headers[0]);
-        $this->Mail->clearCustomHeaders();
-        self::assertFalse($this->Mail->addCustomHeader('SomeHeader', "Some\n Value"));
-        self::assertFalse($this->Mail->addCustomHeader("Some\nHeader", 'Some Value'));
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422

## Commit details

###  Tests/reorganize: move custom header tests to own file

### CustomHeaderTest: rename exception test and improve

... by also testing that the exception message matches the expected message.

### CustomHeaderTest: move "failure" tests to own method with data provider

### CustomHeaderTest: add dedicated test for clearCustomHeaders() method

Includes adding an assertion to ensure that the `PHPMailer::CustomHeader` property is still in array format after clearing it out.

### CustomHeaderTest: reorganize rest to use data provider

* Maintains (largely) the same test cases.
* Prevent one failing assertion hiding a potential second failure.
* Makes it easier to add additional test cases in the future.

Note:
This removes the intermittent calls to `clearCustomHeaders()` from this test. This is now tested via a separate method and as each test case will receive a fresh instance of the `PHPMailer` class, there is no need to clear the set custom headers between tests.

### CustomHeaderTest: add extra test cases for `testAddAndGetCustomHeader()` method

### CustomHeaderTest: add extra test cases for `testAddCustomHeaderInvalid()` method

### CustomHeaderTest: add @covers tags 