### PR TITLE
Tests: move addEmbeddedImage tests to own file

### DIFF
--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -15,12 +15,12 @@ namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding embedded image(s) functionality.
  */
-final class AddEmbeddedImageTest extends SendTestCase
+final class AddEmbeddedImageTest extends PreSendTestCase
 {
 
     /**
@@ -49,7 +49,7 @@ final class AddEmbeddedImageTest extends SendTestCase
         }
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
         $this->Mail->clearAttachments();
 
         //For code coverage

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test adding embedded image(s) functionality.
+ */
+final class AddEmbeddedImageTest extends SendTestCase
+{
+
+    /**
+     * An embedded attachment test.
+     */
+    public function testEmbeddedImage()
+    {
+        $this->Mail->Body = 'Embedded Image: <img alt="phpmailer" src="' .
+            'cid:my-attach">' .
+            'Here is an image!';
+        $this->Mail->Subject .= ': Embedded Image';
+        $this->Mail->isHTML(true);
+
+        if (
+            !$this->Mail->addEmbeddedImage(
+                realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer.png'),
+                'my-attach',
+                'phpmailer.png',
+                'base64',
+                'image/png'
+            )
+        ) {
+            self::assertTrue(false, $this->Mail->ErrorInfo);
+
+            return;
+        }
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        $this->Mail->clearAttachments();
+
+        //For code coverage
+        $this->Mail->addEmbeddedImage('thisfiledoesntexist', 'xyz'); //Non-existent file
+        $this->Mail->addEmbeddedImage(__FILE__, '123'); //Missing name
+    }
+
+    /**
+     * Expect exceptions on bad encoding
+     */
+    public function testEmbeddedImageEncodingException()
+    {
+        $this->expectException(Exception::class);
+
+        $mail = new PHPMailer(true);
+        $mail->addEmbeddedImage(__FILE__, 'cid', 'test.png', 'invalidencoding');
+    }
+}

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -135,6 +135,12 @@ final class AddEmbeddedImageTest extends PreSendTestCase
                 'path' => 'thisfiledoesntexist',
                 'cid'  => 'xyz',
             ],
+            'Invalid: invalid encoding' => [
+                'path'     => __FILE__,
+                'cid'      => 'cid',
+                'name'     => 'test.png',
+                'encoding' => 'invalidencoding',
+            ],
         ];
     }
 

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -19,6 +19,11 @@ use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding embedded image(s) functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::addEmbeddedImage
+ * @covers \PHPMailer\PHPMailer\PHPMailer::createBody
+ * @covers \PHPMailer\PHPMailer\PHPMailer::getAttachments
+ * @covers \PHPMailer\PHPMailer\PHPMailer::inlineImageExists
  */
 final class AddEmbeddedImageTest extends PreSendTestCase
 {

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -51,9 +51,22 @@ final class AddEmbeddedImageTest extends PreSendTestCase
         $this->buildBody();
         self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
         $this->Mail->clearAttachments();
+    }
 
-        //For code coverage
-        $this->Mail->addEmbeddedImage(__FILE__, '123'); //Missing name
+    /**
+     * Test adding an image without explicitly adding a name for the image will set the name as the existing file name.
+     */
+    public function testAddingImageWithoutExplicitName()
+    {
+        $result = $this->Mail->addEmbeddedImage(__FILE__, '123');
+        self::assertTrue($result, 'File failed to attach');
+
+        self::assertTrue($this->Mail->inlineImageExists(), 'Inline image not present in attachments array');
+
+        $attachments = $this->Mail->getAttachments();
+        self::assertIsArray($attachments, 'Attachments is not an array');
+        self::assertArrayHasKey(0, $attachments, 'Attachments does not have the expected array entry');
+        self::assertSame($attachments[0][1], $attachments[0][2], 'Name is not the same as filename');
     }
 
     /**

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -24,9 +24,9 @@ final class AddEmbeddedImageTest extends PreSendTestCase
 {
 
     /**
-     * An embedded attachment test.
+     * Test successfully adding an embedded image.
      */
-    public function testEmbeddedImage()
+    public function testAddEmbeddedImage()
     {
         $this->Mail->Body = 'Embedded Image: <img alt="phpmailer" src="' .
             'cid:my-attach">' .
@@ -34,23 +34,18 @@ final class AddEmbeddedImageTest extends PreSendTestCase
         $this->Mail->Subject .= ': Embedded Image';
         $this->Mail->isHTML(true);
 
-        if (
-            !$this->Mail->addEmbeddedImage(
-                realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer.png'),
-                'my-attach',
-                'phpmailer.png',
-                'base64',
-                'image/png'
-            )
-        ) {
-            self::assertTrue(false, $this->Mail->ErrorInfo);
+        $result = $this->Mail->addEmbeddedImage(
+            realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer.png'),
+            'my-attach',
+            'phpmailer.png',
+            'base64',
+            'image/png'
+        );
 
-            return;
-        }
+        self::assertTrue($result, $this->Mail->ErrorInfo);
 
         $this->buildBody();
         self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
-        $this->Mail->clearAttachments();
     }
 
     /**

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -53,8 +53,40 @@ final class AddEmbeddedImageTest extends PreSendTestCase
         $this->Mail->clearAttachments();
 
         //For code coverage
-        $this->Mail->addEmbeddedImage('thisfiledoesntexist', 'xyz'); //Non-existent file
         $this->Mail->addEmbeddedImage(__FILE__, '123'); //Missing name
+    }
+
+    /**
+     * Test that embedding an image fails in select use cases.
+     *
+     * @dataProvider dataFailToAttach
+     *
+     * @param string $path     Path to the attachment.
+     * @param string $cid      Content ID for the attachment.
+     * @param string $name     Optional. Attachment name to use.
+     * @param string $encoding Optional. File encoding to pass.
+     */
+    public function testFailToAttach($path, $cid, $name = '', $encoding = PHPMailer::ENCODING_BASE64)
+    {
+        $result = $this->Mail->addEmbeddedImage($path, $cid, $name, $encoding);
+        self::assertFalse($result, 'Image did not fail to attach');
+
+        self::assertFalse($this->Mail->inlineImageExists(), 'Inline image present in attachments array');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataFailToAttach()
+    {
+        return [
+            'Invalid: non-existent file' => [
+                'path' => 'thisfiledoesntexist',
+                'cid'  => 'xyz',
+            ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -640,29 +640,6 @@ EOT;
      */
     public function testEmbeddedImage()
     {
-        $this->Mail->Body = 'Embedded Image: <img alt="phpmailer" src="' .
-            'cid:my-attach">' .
-            'Here is an image!';
-        $this->Mail->Subject .= ': Embedded Image';
-        $this->Mail->isHTML(true);
-
-        if (
-            !$this->Mail->addEmbeddedImage(
-                realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer.png'),
-                'my-attach',
-                'phpmailer.png',
-                'base64',
-                'image/png'
-            )
-        ) {
-            self::assertTrue(false, $this->Mail->ErrorInfo);
-
-            return;
-        }
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-        $this->Mail->clearAttachments();
         $this->Mail->msgHTML('<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -679,9 +656,6 @@ EOT;
             $this->Mail->getSentMIMEMessage(),
             'Embedded image header encoding incorrect.'
         );
-        //For code coverage
-        $this->Mail->addEmbeddedImage('thisfiledoesntexist', 'xyz'); //Non-existent file
-        $this->Mail->addEmbeddedImage(__FILE__, '123'); //Missing name
     }
 
     /**
@@ -1029,17 +1003,6 @@ EOT;
 
         $mail = new PHPMailer(true);
         $mail->addStringAttachment('hello', 'test.txt', 'invalidencoding');
-    }
-
-    /**
-     * Expect exceptions on bad encoding
-     */
-    public function testEmbeddedImageEncodingException()
-    {
-        $this->expectException(Exception::class);
-
-        $mail = new PHPMailer(true);
-        $mail->addEmbeddedImage(__FILE__, 'cid', 'test.png', 'invalidencoding');
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424

## Commit details

### Tests/reorganize: move addEmbeddedImage tests to own file

Note: this doesn't move the complete test from the original test file, just select parts of the test method.

### AddEmbeddedImageTest: switch to preSend()

The actual "attaching" of the images happens within `createBody()` which is called from `preSend()`, so this test doesn't actually need to call `send()`.

### AddEmbeddedImageTest: split off failure test

The "failure" case when a non-existent file was being passed, wasn't actually being tested at all as no assertion was used.

This commit:
* Moves the particular failure test case to a separate test method with a data provider (to allow for more failure test cases to be added).
* Uses an assertion on the call to `addEmbeddedImage()` to actually test that the method return a failure state.
* Verifies that no attachment for an inline image was added by adding a second assertion with a call to `PHPMailer::inlineImageExists()`.

### AddEmbeddedImageTest: split off "missing name" test

The test case when a file was attached without explicitly adding a filename wasn't actually being tested at all as no assertion was used.

This commit:
* Moves that particular test case to a separate test method.
* Adds relevant assertions to actually test the test case.

### AddEmbeddedImageTest: improve original test [1]

The test code remaining in the `testEmbeddedImage()` constitutes one test.

This commit:
* Renames the test method and improves the description in the docblock.
* Removes the redundant call to `PHPMailer::clearAttachments()`.
    This call was previously needed as multiple situations were being tested in one test method.
    Now each test case has its own test method, the call to `PHPMailer::clearAttachments()` is no longer needed as each test method will receive a fresh, clean instance of the `PHPMailer` class.
* Replace a redundant condition and "forced" failure assertion with an assertion actually testing the result of the method call.
* Removes the redundant `return` - if an assertion fails, the rest of the code within the test method will not be executed anyway.

### AddEmbeddedImageTest: improve original test [2]

This expands the assertions executed in this test to cover the code under test more comprehensively.

### AddEmbeddedImageTest: add extra test case for testFailToAttach() method

... mirroring the same test in the `testEmbeddedImageEncodingException()` method.

### AddEmbeddedImageTest: fully test exceptions for "fail to attach" test cases

This commit:
* Adds an `exceptionMessage` index to the `dataFailToAttach()` data provider.
* Renames the `testEmbeddedImageEncodingException()` method to `testFailToAttachException()`.
* Sets the `testFailToAttachException()` method up to use the `dataFailToAttach()` data provider.
* Adds testing of the exception message to the `testFailToAttachException()` method.

With this change, the "fail to attach" test cases are now fully tested for both a `PHPMailer` instance without exceptions enabled, as well as for an instance _with_ exceptions enabled.

### AddEmbeddedImageTest: add @covers tags 