### PR TITLE
Tests: move addStringAttachment tests to own file

### DIFF
--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test adding string attachments functionality.
+ */
+final class AddStringAttachmentTest extends SendTestCase
+{
+
+    /**
+     * Simple plain string attachment test.
+     */
+    public function testPlainStringAttachment()
+    {
+        $this->Mail->Body = 'Here is the text body';
+        $this->Mail->Subject .= ': Plain + StringAttachment';
+
+        $sAttachment = 'These characters are the content of the ' .
+            "string attachment.\nThis might be taken from a " .
+            'database or some other such thing. ';
+
+        $this->Mail->addStringAttachment($sAttachment, 'string_attach.txt');
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Expect exceptions on bad encoding
+     */
+    public function testStringAttachmentEncodingException()
+    {
+        $this->expectException(Exception::class);
+
+        $mail = new PHPMailer(true);
+        $mail->addStringAttachment('hello', 'test.txt', 'invalidencoding');
+    }
+}

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -15,12 +15,12 @@ namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding string attachments functionality.
  */
-final class AddStringAttachmentTest extends SendTestCase
+final class AddStringAttachmentTest extends PreSendTestCase
 {
 
     /**
@@ -38,7 +38,7 @@ final class AddStringAttachmentTest extends SendTestCase
         $this->Mail->addStringAttachment($sAttachment, 'string_attach.txt');
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 
     /**

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -84,13 +84,42 @@ final class AddStringAttachmentTest extends PreSendTestCase
     }
 
     /**
-     * Expect exceptions on bad encoding
+     * Test that adding a string attachment throws an exception in select use cases.
+     *
+     * @dataProvider dataFailToAttach
+     *
+     * @param string $string           String attachment data.
+     * @param string $filename         Name of the attachment.
+     * @param string $exceptionMessage The exception message to expect.
+     * @param string $encoding         Optional. File encoding to pass.
      */
-    public function testStringAttachmentEncodingException()
-    {
+    public function testFailToAttachException(
+        $string,
+        $filename,
+        $exceptionMessage,
+        $encoding = PHPMailer::ENCODING_BASE64
+    ) {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage($exceptionMessage);
 
         $mail = new PHPMailer(true);
-        $mail->addStringAttachment('hello', 'test.txt', 'invalidencoding');
+        $mail->addStringAttachment($string, $filename, $encoding);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataFailToAttach()
+    {
+        return [
+            'Invalid: invalid encoding' => [
+                'string'           => 'hello',
+                'filename'         => 'test.txt',
+                'exceptionMessage' => 'Unknown encoding: invalidencoding',
+                'encoding'         => 'invalidencoding',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -24,21 +24,63 @@ final class AddStringAttachmentTest extends PreSendTestCase
 {
 
     /**
-     * Simple plain string attachment test.
+     * Test successfully adding a simple plain string attachment.
      */
-    public function testPlainStringAttachment()
+    public function testAddPlainStringAttachment()
     {
-        $this->Mail->Body = 'Here is the text body';
-        $this->Mail->Subject .= ': Plain + StringAttachment';
-
         $sAttachment = 'These characters are the content of the ' .
             "string attachment.\nThis might be taken from a " .
             'database or some other such thing. ';
 
-        $this->Mail->addStringAttachment($sAttachment, 'string_attach.txt');
+        $expected   = [
+            0 => $sAttachment,
+            1 => 'string_attach.txt',
+            2 => 'string_attach.txt',
+            3 => 'base64',
+            4 => 'text/plain',
+            5 => true,
+            6 => 'attachment',
+            7 => 0,
+        ];
 
+        $this->Mail->Body = 'Here is the text body';
+        $this->Mail->Subject .= ': Plain + StringAttachment';
+
+        // Test attaching the plain string attachment.
+        $result = $this->Mail->addStringAttachment($sAttachment, 'string_attach.txt');
+
+        self::assertTrue($result, $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->attachmentExists(), 'Plain text attachment not present in attachments array');
+
+        $attachments = $this->Mail->getAttachments();
+        self::assertIsArray($attachments, 'Attachments is not an array');
+        self::assertArrayHasKey(0, $attachments, 'Attachments does not have the expected array entry');
+        self::assertSame($expected, $attachments[0], 'Attachment info does not match the expected array');
+
+        // Test that the plain text attachment was correctly added to the message body.
         $this->buildBody();
         self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
+
+        $sendMessage = $this->Mail->getSentMIMEMessage();
+        $LE          = PHPMailer::getLE();
+
+        self::assertStringContainsString(
+            'Content-Type: text/plain; name=string_attach.txt' . $LE,
+            $sendMessage,
+            'Embedded image header content type incorrect.'
+        );
+
+        self::assertStringNotContainsString(
+            'Content-ID: ' . $LE,
+            $sendMessage,
+            'Embedded image header content ID not empty.'
+        );
+
+        self::assertStringContainsString(
+            'Content-Disposition: attachment; filename=string_attach.txt' . $LE,
+            $sendMessage,
+            'Embedded image header content disposition incorrect.'
+        );
     }
 
     /**

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -19,6 +19,11 @@ use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding string attachments functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::addStringAttachment
+ * @covers \PHPMailer\PHPMailer\PHPMailer::attachmentExists
+ * @covers \PHPMailer\PHPMailer\PHPMailer::createBody
+ * @covers \PHPMailer\PHPMailer\PHPMailer::getAttachments
  */
 final class AddStringAttachmentTest extends PreSendTestCase
 {

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -84,6 +84,24 @@ final class AddStringAttachmentTest extends PreSendTestCase
     }
 
     /**
+     * Test that adding a string attachment fails in select use cases.
+     *
+     * @dataProvider dataFailToAttach
+     *
+     * @param string $string           String attachment data.
+     * @param string $filename         Name of the attachment.
+     * @param string $exceptionMessage Unused in this test.
+     * @param string $encoding         Optional. File encoding to pass.
+     */
+    public function testFailToAttach($string, $filename, $exceptionMessage, $encoding = PHPMailer::ENCODING_BASE64)
+    {
+        $result = $this->Mail->addStringAttachment($string, $filename, $encoding);
+        self::assertFalse($result, 'String attachment did not fail to attach');
+
+        self::assertFalse($this->Mail->attachmentExists(), 'Attachment present in attachments array');
+    }
+
+    /**
      * Test that adding a string attachment throws an exception in select use cases.
      *
      * @dataProvider dataFailToAttach

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -79,24 +79,6 @@ final class PHPMailerTest extends SendTestCase
     }
 
     /**
-     * Simple plain string attachment test.
-     */
-    public function testPlainStringAttachment()
-    {
-        $this->Mail->Body = 'Here is the text body';
-        $this->Mail->Subject .= ': Plain + StringAttachment';
-
-        $sAttachment = 'These characters are the content of the ' .
-            "string attachment.\nThis might be taken from a " .
-            'database or some other such thing. ';
-
-        $this->Mail->addStringAttachment($sAttachment, 'string_attach.txt');
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-    }
-
-    /**
      * Plain quoted-printable message.
      */
     public function testQuotedPrintable()
@@ -992,17 +974,6 @@ EOT;
         $this->Mail->addAttachment($filename);
         unlink($filename);
         self::assertFalse($this->Mail->send());
-    }
-
-    /**
-     * Expect exceptions on bad encoding
-     */
-    public function testStringAttachmentEncodingException()
-    {
-        $this->expectException(Exception::class);
-
-        $mail = new PHPMailer(true);
-        $mail->addStringAttachment('hello', 'test.txt', 'invalidencoding');
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425

## Commit details

###  Tests/reorganize: move addStringAttachment tests to own file

### AddStringAttachmentTest: switch to preSend()

The actual "attaching" of the string attachment happens within `createBody()` which is called from `preSend()`, so this test doesn't actually need to call `send()`.

### AddStringAttachmentTest: improve original test

This expands the assertions executed in this test to cover the code under test more comprehensively.

### AddStringAttachmentTest: refactor the "fail to attach" test case

This commit:
* Renames the `testStringAttachmentEncodingException()` test to `testFailToAttachException()`.
* Reworks the test to use a data provider.
* Adds testing of the exception message to the `testFailToAttachException()` method.

### AddStringAttachmentTest: add additional "fail to attach" test method

This commit:
* Adds a new `testFailToAttach()` test method to test the behaviour of the `PHPMailer::addStringAttachment()` method when the `PHPMailer` class has been instantiated with `$exceptions` disabled.
* This new test method uses the same data provider - introduced in the previous commit - as the `testFailToAttachException()` method.

### AddStringAttachmentTest: add `@covers` tags 