### PR TITLE
Localization: allow for more text strings to be translated

### DIFF
--- a/language/phpmailer.lang-nl.php
+++ b/language/phpmailer.lang-nl.php
@@ -7,23 +7,28 @@
  */
 
 $PHPMAILER_LANG['authenticate']         = 'SMTP-fout: authenticatie mislukt.';
+$PHPMAILER_LANG['buggy_php']            = 'PHP versie gededecteerd die onderhavig is aan een bug die kan resulteren in gecorrumpeerde berichten. Om dit te voorkomen, gebruik SMTP voor het verzenden van berichten, zet de mail.add_x_header optie in uw php.ini file uit, gebruik MacOS of Linux, of pas de gebruikte PHP versie aan naar versie 7.0.17+ or 7.1.3+.';
 $PHPMAILER_LANG['connect_host']         = 'SMTP-fout: kon niet verbinden met SMTP-host.';
 $PHPMAILER_LANG['data_not_accepted']    = 'SMTP-fout: data niet geaccepteerd.';
 $PHPMAILER_LANG['empty_message']        = 'Berichttekst is leeg';
 $PHPMAILER_LANG['encoding']             = 'Onbekende codering: ';
 $PHPMAILER_LANG['execute']              = 'Kon niet uitvoeren: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensie afwezig: ';
 $PHPMAILER_LANG['file_access']          = 'Kreeg geen toegang tot bestand: ';
 $PHPMAILER_LANG['file_open']            = 'Bestandsfout: kon bestand niet openen: ';
 $PHPMAILER_LANG['from_failed']          = 'Het volgende afzendersadres is mislukt: ';
 $PHPMAILER_LANG['instantiate']          = 'Kon mailfunctie niet initialiseren.';
 $PHPMAILER_LANG['invalid_address']      = 'Ongeldig adres: ';
+$PHPMAILER_LANG['invalid_header']       = 'Ongeldige header naam of waarde';
 $PHPMAILER_LANG['invalid_hostentry']    = 'Ongeldige hostentry: ';
 $PHPMAILER_LANG['invalid_host']         = 'Ongeldige host: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer wordt niet ondersteund.';
 $PHPMAILER_LANG['provide_address']      = 'Er moet minstens één ontvanger worden opgegeven.';
 $PHPMAILER_LANG['recipients_failed']    = 'SMTP-fout: de volgende ontvangers zijn mislukt: ';
 $PHPMAILER_LANG['signing']              = 'Signeerfout: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP code: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Aanvullende SMTP informatie: ';
 $PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Verbinding mislukt.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detail: ';
 $PHPMAILER_LANG['smtp_error']           = 'SMTP-serverfout: ';
 $PHPMAILER_LANG['variable_set']         = 'Kan de volgende variabele niet instellen of resetten: ';
-$PHPMAILER_LANG['extension_missing']    = 'Extensie afwezig: ';

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,4 +36,7 @@
         <exclude name="PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet"/>
     </rule>
 
+    <rule ref="Generic.Files.LineLength.TooLong">
+        <exclude-pattern>*/language/phpmailer\.lang*\.php$</exclude-pattern>
+    </rule>
 </ruleset>

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1510,12 +1510,7 @@ class PHPMailer
             && ini_get('mail.add_x_header') === '1'
             && stripos(PHP_OS, 'WIN') === 0
         ) {
-            trigger_error(
-                'Your version of PHP is affected by a bug that may result in corrupted messages.' .
-                ' To fix it, switch to sending using SMTP, disable the mail.add_x_header option in' .
-                ' your php.ini, switch to MacOS or Linux, or upgrade your PHP to version 7.0.17+ or 7.1.3+.',
-                E_USER_WARNING
-            );
+            trigger_error($this->lang('buggy_php'), E_USER_WARNING);
         }
 
         try {
@@ -2213,26 +2208,33 @@ class PHPMailer
         //Define full set of translatable strings in English
         $PHPMAILER_LANG = [
             'authenticate' => 'SMTP Error: Could not authenticate.',
+            'buggy_php' => 'Your version of PHP is affected by a bug that may result in corrupted messages.' .
+                ' To fix it, switch to sending using SMTP, disable the mail.add_x_header option in' .
+                ' your php.ini, switch to MacOS or Linux, or upgrade your PHP to version 7.0.17+ or 7.1.3+.',
             'connect_host' => 'SMTP Error: Could not connect to SMTP host.',
             'data_not_accepted' => 'SMTP Error: data not accepted.',
             'empty_message' => 'Message body empty',
             'encoding' => 'Unknown encoding: ',
             'execute' => 'Could not execute: ',
+            'extension_missing' => 'Extension missing: ',
             'file_access' => 'Could not access file: ',
             'file_open' => 'File Error: Could not open file: ',
             'from_failed' => 'The following From address failed: ',
             'instantiate' => 'Could not instantiate mail function.',
             'invalid_address' => 'Invalid address: ',
+            'invalid_header' => 'Invalid header name or value',
             'invalid_hostentry' => 'Invalid hostentry: ',
             'invalid_host' => 'Invalid host: ',
             'mailer_not_supported' => ' mailer is not supported.',
             'provide_address' => 'You must provide at least one recipient email address.',
             'recipients_failed' => 'SMTP Error: The following recipients failed: ',
             'signing' => 'Signing Error: ',
+            'smtp_code' => 'SMTP code: ',
+            'smtp_code_ex' => 'Additional SMTP info: ',
             'smtp_connect_failed' => 'SMTP connect() failed.',
+            'smtp_detail' => 'Detail: ',
             'smtp_error' => 'SMTP server error: ',
             'variable_set' => 'Cannot set or reset variable: ',
-            'extension_missing' => 'Extension missing: ',
         ];
         if (empty($lang_path)) {
             //Calculate an absolute path so it can work if CWD is not here
@@ -3947,13 +3949,13 @@ class PHPMailer
             if (!empty($lasterror['error'])) {
                 $msg .= $this->lang('smtp_error') . $lasterror['error'];
                 if (!empty($lasterror['detail'])) {
-                    $msg .= ' Detail: ' . $lasterror['detail'];
+                    $msg .= ' ' . $this->lang('smtp_detail') . $lasterror['detail'];
                 }
                 if (!empty($lasterror['smtp_code'])) {
-                    $msg .= ' SMTP code: ' . $lasterror['smtp_code'];
+                    $msg .= ' ' . $this->lang('smtp_code') . $lasterror['smtp_code'];
                 }
                 if (!empty($lasterror['smtp_code_ex'])) {
-                    $msg .= ' Additional SMTP info: ' . $lasterror['smtp_code_ex'];
+                    $msg .= ' ' . $this->lang('smtp_code_ex') . $lasterror['smtp_code_ex'];
                 }
             }
         }
@@ -4095,7 +4097,7 @@ class PHPMailer
         //Ensure name is not empty, and that neither name nor value contain line breaks
         if (empty($name) || strpbrk($name . $value, "\r\n") !== false) {
             if ($this->exceptions) {
-                throw new Exception('Invalid header name or value');
+                throw new Exception($this->lang('invalid_header'));
             }
 
             return false;


### PR DESCRIPTION
In a number of places in the code base I came across hard-code error messages, which were not set up to be translatable.

For those I found, I've now fixed this.

👉🏻 Note: I've not added the labels used for logging errors via the `PHPMailer:edebug()` method. If so desired, that could be added in a future iteration.

👉🏻 Existing translation files have not been updated. Translators may need to be pinged before the next release to update the translation(s) they maintain.

**[Edit]**
Includes a minor tweak to the PHPCS configuration to allow lines in language files to exceed the "120 chars line max" as using concatenation for text strings in translation files will not work with the current way of loading these files and the new "buggy PHP" message is a long text which would result in nearly all translation files throwing the warning.