### PR TITLE
Tests: move addStringEmbeddedImage tests to own file

### DIFF
--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -19,6 +19,10 @@ use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding stringified attachments functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::addStringEmbeddedImage
+ * @covers \PHPMailer\PHPMailer\PHPMailer::getAttachments
+ * @covers \PHPMailer\PHPMailer\PHPMailer::inlineImageExists
  */
 final class AddStringEmbeddedImageTest extends PreSendTestCase
 {

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test adding stringified attachments functionality.
+ */
+final class AddStringEmbeddedImageTest extends SendTestCase
+{
+
+    /**
+     * Test embedded image without a name.
+     */
+    public function testHTMLStringEmbedNoName()
+    {
+        $this->Mail->Body = 'This is the <strong>HTML</strong> part of the email.';
+        $this->Mail->Subject .= ': HTML + unnamed embedded image';
+        $this->Mail->isHTML(true);
+
+        if (
+            !$this->Mail->addStringEmbeddedImage(
+                file_get_contents(realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer_mini.png')),
+                hash('sha256', 'phpmailer_mini.png') . '@phpmailer.0',
+                '', //Intentionally empty name
+                'base64',
+                '', //Intentionally empty MIME type
+                'inline'
+            )
+        ) {
+            self::assertTrue(false, $this->Mail->ErrorInfo);
+
+            return;
+        }
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Expect exceptions on bad encoding
+     */
+    public function testStringEmbeddedImageEncodingException()
+    {
+        $this->expectException(Exception::class);
+
+        $mail = new PHPMailer(true);
+        $mail->addStringEmbeddedImage('hello', 'cid', 'test.png', 'invalidencoding');
+    }
+}

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -90,6 +90,30 @@ final class AddStringEmbeddedImageTest extends PreSendTestCase
     }
 
     /**
+     * Test that embedding a stringified attachment fails in select use cases.
+     *
+     * @dataProvider dataFailToAttach
+     *
+     * @param string $string           The attachment binary data.
+     * @param string $cid              Content ID for the attachment.
+     * @param string $exceptionMessage Unused in this test.
+     * @param string $name             Optional. Attachment name to use.
+     * @param string $encoding         Optional. File encoding to pass.
+     */
+    public function testFailToAttach(
+        $string,
+        $cid,
+        $exceptionMessage,
+        $name = '',
+        $encoding = PHPMailer::ENCODING_BASE64
+    ) {
+        $result = $this->Mail->addStringEmbeddedImage($string, $cid, $name, $encoding);
+        self::assertFalse($result, 'Stringified attachment did not fail to attach');
+
+        self::assertFalse($this->Mail->inlineImageExists(), 'Stringified attachment present in attachments array');
+    }
+
+    /**
      * Test that embedding a stringified attachment throws an exception in select use cases.
      *
      * @dataProvider dataFailToAttach

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -24,28 +24,24 @@ final class AddStringEmbeddedImageTest extends PreSendTestCase
 {
 
     /**
-     * Test embedded image without a name.
+     * Test successfully adding a stingified embedded image without a name.
      */
-    public function testHTMLStringEmbedNoName()
+    public function testHtmlStringEmbedNoName()
     {
         $this->Mail->Body = 'This is the <strong>HTML</strong> part of the email.';
         $this->Mail->Subject .= ': HTML + unnamed embedded image';
         $this->Mail->isHTML(true);
 
-        if (
-            !$this->Mail->addStringEmbeddedImage(
-                file_get_contents(realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer_mini.png')),
-                hash('sha256', 'phpmailer_mini.png') . '@phpmailer.0',
-                '', //Intentionally empty name
-                'base64',
-                '', //Intentionally empty MIME type
-                'inline'
-            )
-        ) {
-            self::assertTrue(false, $this->Mail->ErrorInfo);
+        $result = $this->Mail->addStringEmbeddedImage(
+            file_get_contents(realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer_mini.png')),
+            hash('sha256', 'phpmailer_mini.png') . '@phpmailer.0',
+            '', // Intentionally empty name.
+            'base64',
+            '', // Intentionally empty MIME type.
+            'inline'
+        );
 
-            return;
-        }
+        self::assertTrue($result, $this->Mail->ErrorInfo);
 
         $this->buildBody();
         self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -15,12 +15,12 @@ namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test adding stringified attachments functionality.
  */
-final class AddStringEmbeddedImageTest extends SendTestCase
+final class AddStringEmbeddedImageTest extends PreSendTestCase
 {
 
     /**
@@ -48,7 +48,7 @@ final class AddStringEmbeddedImageTest extends SendTestCase
         }
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 
     /**

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -90,13 +90,45 @@ final class AddStringEmbeddedImageTest extends PreSendTestCase
     }
 
     /**
-     * Expect exceptions on bad encoding
+     * Test that embedding a stringified attachment throws an exception in select use cases.
+     *
+     * @dataProvider dataFailToAttach
+     *
+     * @param string $string           The attachment binary data.
+     * @param string $cid              Content ID for the attachment.
+     * @param string $exceptionMessage The exception message to expect.
+     * @param string $name             Optional. Attachment name to use.
+     * @param string $encoding         Optional. File encoding to pass.
      */
-    public function testStringEmbeddedImageEncodingException()
-    {
+    public function testFailToAttachException(
+        $string,
+        $cid,
+        $exceptionMessage,
+        $name = '',
+        $encoding = PHPMailer::ENCODING_BASE64
+    ) {
         $this->expectException(Exception::class);
+        $this->expectExceptionMessage($exceptionMessage);
 
         $mail = new PHPMailer(true);
-        $mail->addStringEmbeddedImage('hello', 'cid', 'test.png', 'invalidencoding');
+        $mail->addStringEmbeddedImage($string, $cid, $name, $encoding);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataFailToAttach()
+    {
+        return [
+            'Invalid: invalid encoding' => [
+                'string'           => 'hello',
+                'cid'              => 'cid',
+                'exceptionMessage' => 'Unknown encoding: invalidencoding',
+                'name'             => 'test.png',
+                'encoding'         => 'invalidencoding',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -555,34 +555,6 @@ EOT;
     }
 
     /**
-     * Test embedded image without a name.
-     */
-    public function testHTMLStringEmbedNoName()
-    {
-        $this->Mail->Body = 'This is the <strong>HTML</strong> part of the email.';
-        $this->Mail->Subject .= ': HTML + unnamed embedded image';
-        $this->Mail->isHTML(true);
-
-        if (
-            !$this->Mail->addStringEmbeddedImage(
-                file_get_contents(realpath(\PHPMAILER_INCLUDE_DIR . '/examples/images/phpmailer_mini.png')),
-                hash('sha256', 'phpmailer_mini.png') . '@phpmailer.0',
-                '', //Intentionally empty name
-                'base64',
-                '', //Intentionally empty MIME type
-                'inline'
-            )
-        ) {
-            self::assertTrue(false, $this->Mail->ErrorInfo);
-
-            return;
-        }
-
-        $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
-    }
-
-    /**
      * Simple HTML and multiple attachment test.
      */
     public function testHTMLMultiAttachment()
@@ -974,17 +946,6 @@ EOT;
         $this->Mail->addAttachment($filename);
         unlink($filename);
         self::assertFalse($this->Mail->send());
-    }
-
-    /**
-     * Expect exceptions on bad encoding
-     */
-    public function testStringEmbeddedImageEncodingException()
-    {
-        $this->expectException(Exception::class);
-
-        $mail = new PHPMailer(true);
-        $mail->addStringEmbeddedImage('hello', 'cid', 'test.png', 'invalidencoding');
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427

## Commit details

### Tests/reorganize: move addStringEmbeddedImage tests to own file

### AddStringEmbeddedImageTest: switch to preSend()

The actual "attaching" of the string attachment happens within `createBody()` which is called from `preSend()`, so this test doesn't actually need to call `send()`.

### AddStringEmbeddedImageTest: improve original test [1]

This commit:
* Improves the test name and the description in the docblock.
* Replace a redundant condition and "forced" failure assertion with an assertion actually testing the result of the method call.
* Removes the redundant `return` - if an assertion fails, the rest of the code within the test method will not be executed anyway.
* Minor inline comment tweaks.

### AddStringEmbeddedImageTest: improve original test [2]

This expands the assertions executed in this test to cover the code under test more comprehensively.

### AddStringEmbeddedImageTest: refactor the "fail to attach" test case

This commit:
* Renames the `testStringEmbeddedImageEncodingException()` test to `testFailToAttachException()`.
* Reworks the test to use a data provider.
* Adds testing of the exception message to the `testFailToAttachException()` method.

### AddStringEmbeddedImageTest: add additional "fail to attach" test method

This commit:
* Adds a new `testFailToAttach()` test method to test the behaviour of the `PHPMailer::AddStringEmbeddedImageTest()` method when the `PHPMailer` class has been instantiated with `$exceptions` disabled.
* This new test method uses the same data provider - introduced in the previous commit - as the `testFailToAttachException()` method.

### AddStringEmbeddedImageTest: add `@covers` tags 