### PR TITLE
Tests: move encodeString tests to own file

### DIFF
--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -24,19 +24,47 @@ final class EncodeStringTest extends TestCase
 
     /**
      * Encoding and charset tests.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::encodeString
+     *
+     * @dataProvider dataEncodeString
+     *
+     * @param string $input    Text to encode.
+     * @param string $expected Expected function return value.
+     * @param string $encoding Optional. Encoding to use.
      */
-    public function testEncodings()
+    public function testEncodeString($input, $expected, $encoding = null)
     {
-        self::assertSame(
-            'hello',
-            $this->Mail->encodeString('hello', 'binary'),
-            'Binary encoding changed input'
-        );
-        $this->Mail->ErrorInfo = '';
-        self::assertSame(
-            base64_encode('hello') . PHPMailer::getLE(),
-            $this->Mail->encodeString('hello')
-        );
+        if (isset($encoding)) {
+            $result = $this->Mail->encodeString($input, $encoding);
+        } else {
+            $result = $this->Mail->encodeString($input);
+        }
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEncodeString()
+    {
+        $input = 'hello';
+        $LE    = PHPMailer::getLE();
+
+        return [
+            'Simple string; no explicit encoding (using base64 default)' => [
+                'input'    => $input,
+                'expected' => base64_encode($input) . $LE,
+            ],
+            'Simple string; binary encoding' => [
+                'input'    => $input,
+                'expected' => $input,
+                'encoding' => PHPMailer::ENCODING_BINARY,
+            ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -105,10 +105,16 @@ final class EncodeStringTest extends TestCase
 
     /**
      * Test passing an incorrect encoding.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::encodeString
      */
     public function testInvalidEncoding()
     {
-        $this->Mail->encodeString('hello', 'asdfghjkl');
+        $result = $this->Mail->encodeString('hello', 'asdfghjkl');
+        self::assertSame('', $result, 'Invalid encoding should result in an empty string');
+
         self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
+        self::assertTrue($this->Mail->isError(), 'Error count not correctly incremented');
+        self::assertSame('Unknown encoding: asdfghjkl', $this->Mail->ErrorInfo, 'Error info not correctly set');
     }
 }

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -33,11 +33,18 @@ final class EncodeStringTest extends TestCase
             'Binary encoding changed input'
         );
         $this->Mail->ErrorInfo = '';
-        $this->Mail->encodeString('hello', 'asdfghjkl');
-        self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
         self::assertSame(
             base64_encode('hello') . PHPMailer::getLE(),
             $this->Mail->encodeString('hello')
         );
+    }
+
+    /**
+     * Test passing an incorrect encoding.
+     */
+    public function testInvalidEncoding()
+    {
+        $this->Mail->encodeString('hello', 'asdfghjkl');
+        self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
     }
 }

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -13,6 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
+use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\Test\TestCase;
 
@@ -116,5 +117,20 @@ final class EncodeStringTest extends TestCase
         self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
         self::assertTrue($this->Mail->isError(), 'Error count not correctly incremented');
         self::assertSame('Unknown encoding: asdfghjkl', $this->Mail->ErrorInfo, 'Error info not correctly set');
+    }
+
+    /**
+     * Test passing an incorrect encoding results in an exception being thrown when PHPMailer is
+     * instantiated with `$exceptions = true`.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::encodeString
+     */
+    public function testInvalidEncodingException()
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unknown encoding: asdfghjkl');
+
+        $mail = new PHPMailer(true);
+        $mail->encodeString('hello', 'asdfghjkl');
     }
 }

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test string encoding functionality.
+ */
+final class EncodeStringTest extends TestCase
+{
+
+    /**
+     * Encoding and charset tests.
+     */
+    public function testEncodings()
+    {
+        self::assertSame(
+            'hello',
+            $this->Mail->encodeString('hello', 'binary'),
+            'Binary encoding changed input'
+        );
+        $this->Mail->ErrorInfo = '';
+        $this->Mail->encodeString('hello', 'asdfghjkl');
+        self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
+        self::assertMatchesRegularExpression(
+            '/' . base64_encode('hello') . '/',
+            $this->Mail->encodeString('hello')
+        );
+    }
+}

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -35,8 +35,8 @@ final class EncodeStringTest extends TestCase
         $this->Mail->ErrorInfo = '';
         $this->Mail->encodeString('hello', 'asdfghjkl');
         self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
-        self::assertMatchesRegularExpression(
-            '/' . base64_encode('hello') . '/',
+        self::assertSame(
+            base64_encode('hello') . PHPMailer::getLE(),
             $this->Mail->encodeString('hello')
         );
     }

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -51,18 +51,54 @@ final class EncodeStringTest extends TestCase
      */
     public function dataEncodeString()
     {
-        $input = 'hello';
-        $LE    = PHPMailer::getLE();
+        $input           = 'hello';
+        $LE              = PHPMailer::getLE();
+        $base64_expected = base64_encode($input) . $LE;
 
         return [
             'Simple string; no explicit encoding (using base64 default)' => [
                 'input'    => $input,
-                'expected' => base64_encode($input) . $LE,
+                'expected' => $base64_expected,
+            ],
+            'Simple string; base64 encoding (lowercase)' => [
+                'input'    => $input,
+                'expected' => $base64_expected,
+                'encoding' => PHPMailer::ENCODING_BASE64,
+            ],
+            'Simple string; base64 encoding (uppercase)' => [
+                'input'    => $input,
+                'expected' => $base64_expected,
+                'encoding' => strtoupper(PHPMailer::ENCODING_BASE64),
+            ],
+            'Simple string; 7-bit encoding' => [
+                'input'    => $input,
+                'expected' => $input . $LE,
+                'encoding' => PHPMailer::ENCODING_7BIT,
+            ],
+            'Simple string; 8-bit encoding' => [
+                'input'    => $input,
+                'expected' => $input . $LE,
+                'encoding' => PHPMailer::ENCODING_8BIT,
             ],
             'Simple string; binary encoding' => [
                 'input'    => $input,
                 'expected' => $input,
                 'encoding' => PHPMailer::ENCODING_BINARY,
+            ],
+            'Simple string; binary encoding (mixed case)' => [
+                'input'    => $input,
+                'expected' => $input,
+                'encoding' => ucfirst(PHPMailer::ENCODING_BINARY),
+            ],
+            'Simple string; quoted printable encoding' => [
+                'input'    => $input,
+                'expected' => $input,
+                'encoding' => PHPMailer::ENCODING_QUOTED_PRINTABLE,
+            ],
+            'String with line breaks; 8-bit encoding' => [
+                'input'    => "hello\rWorld\r",
+                'expected' => "hello{$LE}World{$LE}",
+                'encoding' => PHPMailer::ENCODING_8BIT,
             ],
         ];
     }

--- a/test/PHPMailer/HasLineLongerThanMaxTest.php
+++ b/test/PHPMailer/HasLineLongerThanMaxTest.php
@@ -25,7 +25,6 @@ final class HasLineLongerThanMaxTest extends PreSendTestCase
     /**
      * Test constructing a multipart message that contains lines that are too long for RFC compliance.
      *
-     * @covers \PHPMailer\PHPMailer\PHPMailer::encodeString
      * @covers \PHPMailer\PHPMailer\PHPMailer::hasLineLongerThanMax
      */
     public function testLongBody()

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -894,19 +894,6 @@ EOT;
             $this->Mail->encodeQ("Nov\xc3\xa1=", 'text'),
             'Q Encoding (text) failed 2'
         );
-
-        self::assertSame(
-            'hello',
-            $this->Mail->encodeString('hello', 'binary'),
-            'Binary encoding changed input'
-        );
-        $this->Mail->ErrorInfo = '';
-        $this->Mail->encodeString('hello', 'asdfghjkl');
-        self::assertNotEmpty($this->Mail->ErrorInfo, 'Invalid encoding not detected');
-        self::assertMatchesRegularExpression(
-            '/' . base64_encode('hello') . '/',
-            $this->Mail->encodeString('hello')
-        );
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434

## Commit details

### Tests/reorganize: move encodeString tests to own file

Note: this doesn't move the complete test from the original test file, just select parts of the test method.

### EncodeStringTest: fix incorrect assertion

Using a regex assertion with arbitrary input data which is not regex escaped, makes this test suspect.
From the looks of it, the test _should_ be testing that the output is the _same_, so let's use that assertion.

### EncodeStringTest: split off failure test

This commit moves the "incorrect encoding" test case to a separate test method.

### EncodeStringTest: reorganize to use data providers

* Maintains the same test code and test cases.
* Makes it easier to add additional test cases in the future.

Includes adding `@covers` tag.

### EncodeStringTest: add additional test cases

... which should be handled correctly based on the code in the method under test.

### EncodeStringTest: improve the testInvalidEncoding() test

* Ensure that the return value of the call to `PHPMailer::encodeString()` is an empty string.
* Ensure that the error count and info is correctly set.

### EncodeStringTest: add extra test for passing an invalid encoding

... in combination with an instance of the `PHPMailer` class which was instantiated with `$exceptions = true`.

### HasLineLongerThanMaxTest: remove a @covers tag

As the `PHPMailer::encodeString()` method is now fully covered by dedicated tests, this `@covers` tag can be removed.


**With these additional tests and test cases, the method now has 100% code coverage and is fully tested.**
