### PR TITLE
Tests: move encodeQ tests to own file

### DIFF
--- a/test/PHPMailer/EncodeQTest.php
+++ b/test/PHPMailer/EncodeQTest.php
@@ -23,37 +23,65 @@ final class EncodeQTest extends TestCase
 {
 
     /**
-     * Encoding and charset tests.
+     * Test encoding a string using Q encoding.
+     *
+     * @dataProvider dataEncodeQ
+     *
+     * @param string $input    The text to encode.
+     * @param string $expected The expected function return value.
+     * @param string $position Optional. Input for the position parameter.
+     * @param string $charset  Optional. The charset to use.
      */
-    public function testEncodings()
+    public function testEncodeQ($input, $expected, $position = null, $charset = null)
     {
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'text'),
-            'Q Encoding (text) failed'
-        );
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'comment'),
-            'Q Encoding (comment) failed'
-        );
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'phrase'),
-            'Q Encoding (phrase) failed'
-        );
-        $this->Mail->CharSet = 'UTF-8';
-        self::assertSame(
-            '=C2=A1Hola!_Se=C3=B1or!',
-            $this->Mail->encodeQ("\xc2\xa1Hola! Se\xc3\xb1or!", 'text'),
-            'Q Encoding (text) failed'
-        );
-        // Strings containing '=' are a special case.
-        self::assertSame(
-            'Nov=C3=A1=3D',
-            $this->Mail->encodeQ("Nov\xc3\xa1=", 'text'),
-            'Q Encoding (text) failed 2'
-        );
+        if (isset($charset)) {
+            $this->Mail->CharSet = $charset;
+        }
+
+        if (isset($position)) {
+            $result = $this->Mail->encodeQ($input, $position);
+        } else {
+            $result = $this->Mail->encodeQ($input);
+        }
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataEncodeQ()
+    {
+        return [
+            'Encode for text; char encoding default (iso88591)' => [
+                'input'    => "\xa1Hola! Se\xf1or!",
+                'expected' => '=A1Hola!_Se=F1or!',
+                'position' => 'text',
+            ],
+            'Encode for comment; char encoding default (iso88591)' => [
+                'input'    => "\xa1Hola! Se\xf1or!",
+                'expected' => '=A1Hola!_Se=F1or!',
+                'position' => 'comment',
+            ],
+            'Encode for phrase; char encoding default (iso88591)' => [
+                'input'    => "\xa1Hola! Se\xf1or!",
+                'expected' => '=A1Hola!_Se=F1or!',
+                'position' => 'phrase',
+            ],
+            'Encode for text; char encoding explicit: utf-8' => [
+                'input'    => "\xc2\xa1Hola! Se\xc3\xb1or!",
+                'expected' => '=C2=A1Hola!_Se=C3=B1or!',
+                'position' => 'text',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+            ],
+            'Encode for text; char encoding explicit: utf-8; string containg "=" character' => [
+                'input'    => "Nov\xc3\xa1=",
+                'expected' => 'Nov=C3=A1=3D',
+                'position' => 'text',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/EncodeQTest.php
+++ b/test/PHPMailer/EncodeQTest.php
@@ -18,6 +18,8 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test encoding a string using Q encoding functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::encodeQ
  */
 final class EncodeQTest extends TestCase
 {

--- a/test/PHPMailer/EncodeQTest.php
+++ b/test/PHPMailer/EncodeQTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test encoding a string using Q encoding functionality.
+ */
+final class EncodeQTest extends TestCase
+{
+
+    /**
+     * Encoding and charset tests.
+     */
+    public function testEncodings()
+    {
+        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
+        self::assertSame(
+            '=A1Hola!_Se=F1or!',
+            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'text'),
+            'Q Encoding (text) failed'
+        );
+        self::assertSame(
+            '=A1Hola!_Se=F1or!',
+            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'comment'),
+            'Q Encoding (comment) failed'
+        );
+        self::assertSame(
+            '=A1Hola!_Se=F1or!',
+            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'phrase'),
+            'Q Encoding (phrase) failed'
+        );
+        $this->Mail->CharSet = 'UTF-8';
+        self::assertSame(
+            '=C2=A1Hola!_Se=C3=B1or!',
+            $this->Mail->encodeQ("\xc2\xa1Hola! Se\xc3\xb1or!", 'text'),
+            'Q Encoding (text) failed'
+        );
+        // Strings containing '=' are a special case.
+        self::assertSame(
+            'Nov=C3=A1=3D',
+            $this->Mail->encodeQ("Nov\xc3\xa1=", 'text'),
+            'Q Encoding (text) failed 2'
+        );
+    }
+}

--- a/test/PHPMailer/EncodeQTest.php
+++ b/test/PHPMailer/EncodeQTest.php
@@ -60,15 +60,20 @@ final class EncodeQTest extends TestCase
                 'expected' => '=A1Hola!_Se=F1or!',
                 'position' => 'text',
             ],
+            'Encode for TEXT (uppercase); char encoding default (iso88591)' => [
+                'input'    => "\xa1Hola! Se\xf1or!",
+                'expected' => '=A1Hola!_Se=F1or!',
+                'position' => 'TEXT',
+            ],
             'Encode for comment; char encoding default (iso88591)' => [
                 'input'    => "\xa1Hola! Se\xf1or!",
                 'expected' => '=A1Hola!_Se=F1or!',
                 'position' => 'comment',
             ],
-            'Encode for phrase; char encoding default (iso88591)' => [
+            'Encode for Phrase (mixed case); char encoding default (iso88591)' => [
                 'input'    => "\xa1Hola! Se\xf1or!",
                 'expected' => '=A1Hola!_Se=F1or!',
-                'position' => 'phrase',
+                'position' => 'Phrase',
             ],
             'Encode for text; char encoding explicit: utf-8' => [
                 'input'    => "\xc2\xa1Hola! Se\xc3\xb1or!",
@@ -80,6 +85,23 @@ final class EncodeQTest extends TestCase
                 'input'    => "Nov\xc3\xa1=",
                 'expected' => 'Nov=C3=A1=3D',
                 'position' => 'text',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+            ],
+            'Encode for text; char encoding default (iso88591); string containing new lines' => [
+                'input'    => "\xa1Hola!\r\nSe\xf1or!\r\n",
+                'expected' => '=A1Hola!Se=F1or!',
+                'position' => 'text',
+            ],
+            'Encode for text; char encoding explicit: utf-8; phrase vs text regex (text)' => [
+                'input'    => "Hello?\xbdWorld\x5e\xa9",
+                'expected' => 'Hello=3F=BDWorld^=A9',
+                'position' => 'text',
+                'charset'  => PHPMailer::CHARSET_UTF8,
+            ],
+            'Encode for phrase; char encoding explicit: utf-8;  phrase vs text regex (phrase)' => [
+                'input'    => "Hello?\xbdWorld\x5e\xa9",
+                'expected' => 'Hello=3F=BDWorld=5E=A9',
+                'position' => 'phrase',
                 'charset'  => PHPMailer::CHARSET_UTF8,
             ],
         ];

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -862,41 +862,6 @@ EOT;
     }
 
     /**
-     * Encoding and charset tests.
-     */
-    public function testEncodings()
-    {
-        $this->Mail->CharSet = PHPMailer::CHARSET_ISO88591;
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'text'),
-            'Q Encoding (text) failed'
-        );
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'comment'),
-            'Q Encoding (comment) failed'
-        );
-        self::assertSame(
-            '=A1Hola!_Se=F1or!',
-            $this->Mail->encodeQ("\xa1Hola! Se\xf1or!", 'phrase'),
-            'Q Encoding (phrase) failed'
-        );
-        $this->Mail->CharSet = 'UTF-8';
-        self::assertSame(
-            '=C2=A1Hola!_Se=C3=B1or!',
-            $this->Mail->encodeQ("\xc2\xa1Hola! Se\xc3\xb1or!", 'text'),
-            'Q Encoding (text) failed'
-        );
-        //Strings containing '=' are a special case
-        self::assertSame(
-            'Nov=C3=A1=3D',
-            $this->Mail->encodeQ("Nov\xc3\xa1=", 'text'),
-            'Q Encoding (text) failed 2'
-        );
-    }
-
-    /**
      * Expect exceptions on bad encoding
      */
     public function testAddAttachmentEncodingException()


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434, #2435

## Commit details

###  Tests/reorganize: move encodeQ tests to own file

### EncodeQTest: reorganize to use data providers

* Maintains (largely) the same test code and exactly the same test cases.
* Makes it easier to add additional test cases in the future.

### EncodeQTest: add additional test cases

... which should be handled correctly based on the code in the method under test.

### EncodeQTest: add @covers tag 