### PR TITLE
PHPMailer::parseAddresses(): bug fix [1] - extension availability not checked (consistently)

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1237,7 +1237,7 @@ class PHPMailer
                     $name = trim($name);
                     if (static::validateAddress($email)) {
                         //If this name is encoded, decode it
-                        if (preg_match('/^=\?.*\?=$/', $name)) {
+                        if (extension_loaded('mbstring') && preg_match('/^=\?.*\?=$/', $name)) {
                             $name = mb_decode_mimeheader($name);
                         }
                         $addresses[] = [

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1205,7 +1205,8 @@ class PHPMailer
                     //Decode the name part if it's present and encoded
                     if (
                         property_exists($address, 'personal') &&
-                        extension_loaded('mbstring') &&
+                        //Check for a Mbstring constant rather than using extension_loaded, which is sometimes disabled
+                        defined('MB_CASE_UPPER') &&
                         preg_match('/^=\?.*\?=$/', $address->personal)
                     ) {
                         $address->personal = mb_decode_mimeheader($address->personal);
@@ -1236,8 +1237,9 @@ class PHPMailer
                     $email = trim(str_replace('>', '', $email));
                     $name = trim($name);
                     if (static::validateAddress($email)) {
+                        //Check for a Mbstring constant rather than using extension_loaded, which is sometimes disabled
                         //If this name is encoded, decode it
-                        if (extension_loaded('mbstring') && preg_match('/^=\?.*\?=$/', $name)) {
+                        if (defined('MB_CASE_UPPER') && preg_match('/^=\?.*\?=$/', $name)) {
                             $name = mb_decode_mimeheader($name);
                         }
                         $addresses[] = [

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -36,12 +36,7 @@ final class ParseAddressesTest extends TestCase
     {
         $parsed = PHPMailer::parseAddresses($addrstr, false);
 
-        self::assertIsArray($parsed, 'parseAddresses() did not return an array');
-        self::assertSame(
-            $expected,
-            $parsed,
-            'The return value from parseAddresses() did not match the expected output'
-        );
+        $this->verifyExpectations($parsed, $expected);
     }
 
     /**
@@ -57,14 +52,26 @@ final class ParseAddressesTest extends TestCase
      */
     public function testAddressSplittingImap($addrstr, $expected, $expectedImap = [])
     {
-        $parsed = PHPMailer::parseAddresses($addrstr, true);
-
-        self::assertIsArray($parsed, 'parseAddresses() did not return an array');
-
+        $parsed   = PHPMailer::parseAddresses($addrstr, true);
         $expected = empty($expectedImap) ? $expected : $expectedImap;
+
+        $this->verifyExpectations($parsed, $expected);
+    }
+
+    /**
+     * Verify the expectations.
+     *
+     * Abstracted out as the same verification needs to be done for every test, just with different data.
+     *
+     * @param string $actual   The actual function output.
+     * @param array  $expected The expected function output.
+     */
+    protected function verifyExpectations($actual, $expected)
+    {
+        self::assertIsArray($actual, 'parseAddresses() did not return an array');
         self::assertSame(
             $expected,
-            $parsed,
+            $actual,
             'The return value from parseAddresses() did not match the expected output'
         );
     }

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -27,6 +27,8 @@ final class ParseAddressesTest extends TestCase
     /**
      * Test RFC822 address splitting using the PHPMailer native implementation.
      *
+     * @requires extension mbstring
+     *
      * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr  The address list string.
@@ -42,9 +44,10 @@ final class ParseAddressesTest extends TestCase
     /**
      * Test RFC822 address splitting using the IMAP implementation.
      *
-     * @dataProvider dataAddressSplitting
-     *
      * @requires extension imap
+     * @requires extension mbstring
+     *
+     * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr      The address list string.
      * @param array  $expected     The expected function output.

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -25,7 +25,8 @@ final class ParseAddressesTest extends TestCase
 {
 
     /**
-     * Test RFC822 address splitting using the PHPMailer native implementation.
+     * Test RFC822 address splitting using the PHPMailer native implementation
+     * with the Mbstring extension available.
      *
      * @requires extension mbstring
      *
@@ -36,29 +37,94 @@ final class ParseAddressesTest extends TestCase
      */
     public function testAddressSplittingNative($addrstr, $expected)
     {
-        $parsed = PHPMailer::parseAddresses($addrstr, false);
+        $parsed         = PHPMailer::parseAddresses($addrstr, false);
+        $expectedOutput = $expected['default'];
+        if (empty($expected['native+mbstring']) === false) {
+            $expectedOutput = $expected['native+mbstring'];
+        } elseif (empty($expected['native']) === false) {
+            $expectedOutput = $expected['native'];
+        }
 
-        $this->verifyExpectations($parsed, $expected);
+        $this->verifyExpectations($parsed, $expectedOutput);
     }
 
     /**
-     * Test RFC822 address splitting using the IMAP implementation.
+     * Test RFC822 address splitting using the IMAP implementation
+     * with the Mbstring extension available.
      *
      * @requires extension imap
      * @requires extension mbstring
      *
      * @dataProvider dataAddressSplitting
      *
-     * @param string $addrstr      The address list string.
-     * @param array  $expected     The expected function output.
-     * @param array  $expectedImap Optional. The expected function output via IMAP if different.
+     * @param string $addrstr  The address list string.
+     * @param array  $expected The expected function output.
      */
-    public function testAddressSplittingImap($addrstr, $expected, $expectedImap = [])
+    public function testAddressSplittingImap($addrstr, $expected)
     {
-        $parsed   = PHPMailer::parseAddresses($addrstr, true);
-        $expected = empty($expectedImap) ? $expected : $expectedImap;
+        $parsed         = PHPMailer::parseAddresses($addrstr, true);
+        $expectedOutput = $expected['default'];
+        if (empty($expected['imap+mbstring']) === false) {
+            $expectedOutput = $expected['imap+mbstring'];
+        } elseif (empty($expected['imap']) === false) {
+            $expectedOutput = $expected['imap'];
+        }
 
-        $this->verifyExpectations($parsed, $expected);
+        $this->verifyExpectations($parsed, $expectedOutput);
+    }
+
+    /**
+     * Test RFC822 address splitting using the PHPMailer native implementation
+     * without the Mbstring extension.
+     *
+     * @dataProvider dataAddressSplitting
+     *
+     * @param string $addrstr  The address list string.
+     * @param array  $expected The expected function output.
+     */
+    public function testAddressSplittingNativeNoMbstring($addrstr, $expected)
+    {
+        if (extension_loaded('mbstring')) {
+            $this->markTestSkipped('Test requires MbString *not* to be available');
+        }
+
+        $parsed         = PHPMailer::parseAddresses($addrstr, false);
+        $expectedOutput = $expected['default'];
+        if (empty($expected['native--mbstring']) === false) {
+            $expectedOutput = $expected['native--mbstring'];
+        } elseif (empty($expected['native']) === false) {
+            $expectedOutput = $expected['native'];
+        }
+
+        $this->verifyExpectations($parsed, $expectedOutput);
+    }
+
+    /**
+     * Test RFC822 address splitting using the IMAP implementation
+     * without the Mbstring extension.
+     *
+     * @requires extension imap
+     *
+     * @dataProvider dataAddressSplitting
+     *
+     * @param string $addrstr  The address list string.
+     * @param array  $expected The expected function output.
+     */
+    public function testAddressSplittingImapNoMbstring($addrstr, $expected)
+    {
+        if (extension_loaded('mbstring')) {
+            $this->markTestSkipped('Test requires MbString *not* to be available');
+        }
+
+        $parsed         = PHPMailer::parseAddresses($addrstr, true);
+        $expectedOutput = $expected['default'];
+        if (empty($expected['imap--mbstring']) === false) {
+            $expectedOutput = $expected['imap--mbstring'];
+        } elseif (empty($expected['imap']) === false) {
+            $expectedOutput = $expected['imap'];
+        }
+
+        $this->verifyExpectations($parsed, $expectedOutput);
     }
 
     /**
@@ -82,7 +148,15 @@ final class ParseAddressesTest extends TestCase
     /**
      * Data provider.
      *
-     * @return array
+     * @return array The array is expected to have an `addrstr` and an `expected` key.
+     *               The `expected` key should - as a minimum - have a `default` key.
+     *               Optionally, the following extra keys are supported:
+     *               - `native`           Expected output from the native implementation with or without Mbstring.
+     *               - `native+mbstring`  Expected output from the native implementation with Mbstring.
+     *               - `native--mbstring` Expected output from the native implementation without Mbstring.
+     *               - `imap`             Expected output from the IMAP implementation with or without Mbstring.
+     *               - `imap+mbstring`    Expected output from the IMAP implementation with Mbstring.
+     *               - `imap--mbstring`   Expected output from the IMAP implementation without Mbstring.
      */
     public function dataAddressSplitting()
     {
@@ -91,29 +165,37 @@ final class ParseAddressesTest extends TestCase
             'Valid address: single address without name' => [
                 'addrstr'  => 'joe@example.com',
                 'expected' => [
-                    ['name' => '', 'address' => 'joe@example.com'],
+                    'default' => [
+                        ['name' => '', 'address' => 'joe@example.com'],
+                    ],
                 ],
             ],
             'Valid address: single address with name' => [
                 'addrstr'  => 'Joe User <joe@example.com>',
                 'expected' => [
-                    ['name' => 'Joe User', 'address' => 'joe@example.com'],
+                    'default' => [
+                        ['name' => 'Joe User', 'address' => 'joe@example.com'],
+                    ],
                 ],
             ],
             'Valid address: single address, quotes within name' => [
                 'addrstr'  => 'Tim "The Book" O\'Reilly <foo@example.com>',
                 'expected' => [
-                    ['name' => 'Tim "The Book" O\'Reilly', 'address' => 'foo@example.com'],
-                ],
-                'expectedImap' => [
-                    ['name' => 'Tim The Book O\'Reilly', 'address' => 'foo@example.com'],
+                    'default' => [
+                        ['name' => 'Tim "The Book" O\'Reilly', 'address' => 'foo@example.com'],
+                    ],
+                    'imap' => [
+                        ['name' => 'Tim The Book O\'Reilly', 'address' => 'foo@example.com'],
+                    ],
                 ],
             ],
             'Valid address: two addresses with names' => [
                 'addrstr'  => 'Joe User <joe@example.com>, Jill User <jill@example.net>',
                 'expected' => [
-                    ['name' => 'Joe User', 'address' => 'joe@example.com'],
-                    ['name' => 'Jill User', 'address' => 'jill@example.net'],
+                    'default' => [
+                        ['name' => 'Joe User', 'address' => 'joe@example.com'],
+                        ['name' => 'Jill User', 'address' => 'jill@example.net'],
+                    ],
                 ],
             ],
             'Valid address: two addresses with names, one without' => [
@@ -121,9 +203,11 @@ final class ParseAddressesTest extends TestCase
                     . 'Jill User <jill@example.net>,'
                     . 'frank@example.com,',
                 'expected' => [
-                    ['name' => 'Joe User', 'address' => 'joe@example.com'],
-                    ['name' => 'Jill User', 'address' => 'jill@example.net'],
-                    ['name' => '', 'address' => 'frank@example.com'],
+                    'default' => [
+                        ['name' => 'Joe User', 'address' => 'joe@example.com'],
+                        ['name' => 'Jill User', 'address' => 'jill@example.net'],
+                        ['name' => '', 'address' => 'frank@example.com'],
+                    ],
                 ],
             ],
             'Valid address: multiple address, various formats, including one utf8-encoded name' => [
@@ -131,25 +215,71 @@ final class ParseAddressesTest extends TestCase
                     ' "John O\'Groats" <johnog@example.net>,' .
                     ' =?utf-8?B?0J3QsNC30LLQsNC90LjQtSDRgtC10YHRgtCw?= <encoded@example.org>',
                 'expected' => [
-                    [
-                        'name'    => '',
-                        'address' => 'joe@example.com',
+                    'default' => [
+                        [
+                            'name'    => '',
+                            'address' => 'joe@example.com',
+                        ],
+                        [
+                            'name'    => '',
+                            'address' => 'me@example.com',
+                        ],
+                        [
+                            'name'    => 'Joe Doe',
+                            'address' => 'doe@example.com',
+                        ],
+                        [
+                            'name'    => "John O'Groats",
+                            'address' => 'johnog@example.net',
+                        ],
+                        [
+                            'name'    => 'Название теста',
+                            'address' => 'encoded@example.org',
+                        ],
                     ],
-                    [
-                        'name'    => '',
-                        'address' => 'me@example.com',
+                    'native--mbstring' => [
+                        [
+                            'name'    => '',
+                            'address' => 'joe@example.com',
+                        ],
+                        [
+                            'name'    => '',
+                            'address' => 'me@example.com',
+                        ],
+                        [
+                            'name'    => 'Joe Doe',
+                            'address' => 'doe@example.com',
+                        ],
+                        [
+                            'name'    => "John O'Groats",
+                            'address' => 'johnog@example.net',
+                        ],
+                        [
+                            'name'    => '=?utf-8?B?0J3QsNC30LLQsNC90LjQtSDRgtC10YHRgtCw?=',
+                            'address' => 'encoded@example.org',
+                        ],
                     ],
-                    [
-                        'name'    => 'Joe Doe',
-                        'address' => 'doe@example.com',
-                    ],
-                    [
-                        'name'    => "John O'Groats",
-                        'address' => 'johnog@example.net',
-                    ],
-                    [
-                        'name'    => 'Название теста',
-                        'address' => 'encoded@example.org',
+                    'imap--mbstring' => [
+                        [
+                            'name'    => '',
+                            'address' => 'joe@example.com',
+                        ],
+                        [
+                            'name'    => '',
+                            'address' => 'me@example.com',
+                        ],
+                        [
+                            'name'    => 'Joe Doe',
+                            'address' => 'doe@example.com',
+                        ],
+                        [
+                            'name'    => "John O'Groats",
+                            'address' => 'johnog@example.net',
+                        ],
+                        [
+                            'name'    => '=?utf-8?B?0J3QsNC30LLQsNC90LjQtSDRgtC10YHRgtCw?=',
+                            'address' => 'encoded@example.org',
+                        ],
                     ],
                 ],
             ],
@@ -157,15 +287,21 @@ final class ParseAddressesTest extends TestCase
             // Test cases with invalid addresses.
             'Invalid address: single address, incomplete email' => [
                 'addrstr'  => 'Jill User <doug@>',
-                'expected' => [],
+                'expected' => [
+                    'default' => [],
+                ],
             ],
             'Invalid address: single address, invalid characters in email' => [
                 'addrstr'  => 'Joe User <{^c\@**Dog^}@cartoon.com>',
-                'expected' => [],
+                'expected' => [
+                    'default' => [],
+                ],
             ],
             'Invalid address: multiple addresses, invalid periods' => [
                 'addrstr'  => 'Joe User <joe@example.com.>, Jill User <jill.@example.net>',
-                'expected' => [],
+                'expected' => [
+                    'default' => [],
+                ],
             ],
         ];
     }

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -116,7 +116,7 @@ final class ParseAddressesTest extends TestCase
                     ['name' => '', 'address' => 'frank@example.com'],
                 ],
             ],
-            'Valid address: multiple address, various formats, including one utf8-encoded address' => [
+            'Valid address: multiple address, various formats, including one utf8-encoded name' => [
                 'addrstr'  => 'joe@example.com, <me@example.com>, Joe Doe <doe@example.com>,' .
                     ' "John O\'Groats" <johnog@example.net>,' .
                     ' =?utf-8?B?0J3QsNC30LLQsNC90LjQtSDRgtC10YHRgtCw?= <encoded@example.org>',


### PR DESCRIPTION
### ParseAddressesTest: minor correction to test case description

### ParseAddressesTest: split off expectation verification

### PHPMailer::parseAddresses(): bug fix [1] - extension availability not checked

Follow up to #2266

#### Bug fix

In both "arms" (imap vs native implementation) of the `PHPMailer::parseAddresses()` method, the `mb_decode_mimeheader()` function is used to decode a (utf-8) encoded name.

In the IMAP "arm", a check was in place for the Mbstring extension being available before using it. This check was missing from the "native implementation" "arm".

#### Existing Tests

This also means that both currently existing tests have a requirement for the MbString extension being available. This was previously not made explicit in the tests.
Fixed now.

### ParseAddressesTest: add additional test for when Mbstring is not available

What with the previous commit adding a requirement for the `Mbstring` extension to the existing tests, it becomes clear that the "Mbstring extension not available" code path was not covered by the tests.

This commit fixes that by:
* Adding two new test methods which explicitly expect the Mbstring extension to **not** be available.
* Changing the data provider "expected(Imap)" keys.
    The `expected` key in the array will now be an array of arrays.
    A `default` key can be used for when the output across configurations will be the same.
    Any differences across configurations can be provided in separate sub-keys of the `expected` array, using the `native+mbstring`, `imap+mbstring`, `native--mbstring` and/or `imap--mbstring` keys, which match the four test methods which are now in place.
    Additionally, an `native` and/or `imap` key can be used for setting the output expectations for the two native implementation or the two IMAP implementation tests, if the Mbstring extension makes no difference.

### 🆕  PHPMailer::parseAddresses(): replace use of `extension_loaded()`

The `extension_loaded()` PHP function is sometimes disabled by shared hosts as a form of "security by obscurity".
This would lead to a fatal "Function not available" error.

With that in mind, replacing the `extension_loaded()` checks in the `PHPMailer::parseAddresses()` function with a check for the `MB_CASE_UPPER` constant being defined. This _should_ be reliable enough to determine whether the Mbstring extension is available, though has its own drawbacks as when the extension is not available, the constant _could_ be polyfilled by userland code (and sometimes is).

The `MB_CASE_UPPER` constant was chosen as it is one of the few Mbstring constants which is actually available cross-version in PHP 5.5-current.

Refs:
* https://www.php.net/manual/en/mbstring.constants.php
* https://php-legacy-docs.zend.com/manual/php5/en/mbstring.constants