### PR TITLE
Tests: move error recording test to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -738,22 +738,6 @@ EOT;
     }
 
     /**
-     * Test error handling.
-     */
-    public function testError()
-    {
-        $this->Mail->Subject .= ': Error handling test - this should be sent ok';
-        $this->buildBody();
-        $this->Mail->clearAllRecipients(); //No addresses should cause an error
-        self::assertTrue($this->Mail->isError() == false, 'Error found');
-        self::assertTrue($this->Mail->send() == false, 'send succeeded');
-        self::assertTrue($this->Mail->isError(), 'No error found');
-        self::assertSame('You must provide at least one recipient email address.', $this->Mail->ErrorInfo);
-        $this->Mail->addAddress($_REQUEST['mail_to']);
-        self::assertTrue($this->Mail->send(), 'send failed');
-    }
-
-    /**
      * Test addressing.
      */
     public function testAddressing()

--- a/test/PHPMailer/SetErrorTest.php
+++ b/test/PHPMailer/SetErrorTest.php
@@ -13,6 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
+use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
 /**
@@ -37,5 +38,115 @@ final class SetErrorTest extends TestCase
             $this->Mail->ErrorInfo,
             'Error info not correctly set'
         );
+    }
+
+    /**
+     * Test simple, non-STMP, error registration, where only one of the two SMTP conditions is met.
+     */
+    public function testSetErrorNonSmtpWithMailerSmtp()
+    {
+        $this->Mail->Mailer = 'smtp';
+
+        $this->testSetErrorNonSMTP();
+    }
+
+    /**
+     * Test simple, non-STMP, error registration, where the other one of the two SMTP conditions is met.
+     */
+    public function testSetErrorNonSmtpWithSmtpInstanceSet()
+    {
+        $stub = $this->getMockBuilder(SMTP::class)->getMock();
+        $this->Mail->setSMTPInstance($stub);
+
+        $this->testSetErrorNonSMTP();
+    }
+
+    /**
+     * Test error registration with SMTP enabled and instantiated.
+     *
+     * @dataProvider dataSetErrorSmtp
+     *
+     * @param array  $mockReturn The value the `SMTP::getError()` method mock should return.
+     * @param string $expected   The error message which is expected to be registered.
+     */
+    public function testSetErrorSmtp($mockReturn, $expected)
+    {
+        $stub = $this->getMockBuilder(SMTP::class)->getMock();
+        $stub->method('getError')
+             ->willReturn($mockReturn);
+
+        $this->Mail->Mailer = 'smtp';
+        $this->Mail->setSMTPInstance($stub);
+
+        // "Abuse" the `PHPMailer::set()` method to register an error.
+        self::assertFalse($this->Mail->set('nonexistentproperty', 'value'));
+
+        self::assertTrue($this->Mail->isError(), 'Error count not incremented');
+        self::assertSame($expected, $this->Mail->ErrorInfo, 'Error info not correctly set');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetErrorSmtp()
+    {
+        return [
+            'No SMTP error' => [
+                'mockReturn' => [
+                    'error'        => '',
+                    'detail'       => '',
+                    'smtp_code'    => '',
+                    'smtp_code_ex' => '',
+                ],
+                'expected' => 'Cannot set or reset variable: nonexistentproperty',
+            ],
+            'SMTP error, no details' => [
+                'mockReturn' => [
+                    'error'        => 'Fake error',
+                    'detail'       => '',
+                    'smtp_code'    => '',
+                    'smtp_code_ex' => '',
+                ],
+                'expected' => 'Cannot set or reset variable: nonexistentpropertySMTP server error: Fake error',
+            ],
+            'SMTP error, full details' => [
+                'mockReturn' => [
+                    'error'        => 'Fake error',
+                    'detail'       => 'Fake detail',
+                    'smtp_code'    => 'Fake code',
+                    'smtp_code_ex' => 'Fake code ex',
+                ],
+                'expected' => 'Cannot set or reset variable: nonexistentpropertySMTP server error: '
+                    . 'Fake error Detail: Fake detail SMTP code: Fake code Additional SMTP info: Fake code ex',
+            ],
+        ];
+    }
+
+    /**
+     * Verify that only the last error registered via `setError()` is available.
+     */
+    public function testErrorInfoOnlyContainsLastError()
+    {
+        // "Abuse" the `PHPMailer::set()` method to register a few errors.
+        self::assertFalse($this->Mail->set('property1', 'value'));
+        self::assertFalse($this->Mail->set('property2', 'value'));
+        self::assertFalse($this->Mail->set('property3', 'value'));
+
+        self::assertTrue($this->Mail->isError(), 'Error count not incremented');
+        self::assertSame(
+            'Cannot set or reset variable: property3',
+            $this->Mail->ErrorInfo,
+            'Error info not correctly set'
+        );
+    }
+
+    /**
+     * Verify that when no errors have been registered, `isError()` returns false.
+     */
+    public function testIsErrorWithoutError()
+    {
+        self::assertFalse($this->Mail->isError(), 'Error count not 0');
     }
 }

--- a/test/PHPMailer/SetErrorTest.php
+++ b/test/PHPMailer/SetErrorTest.php
@@ -13,27 +13,29 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\TestCase;
 
 /**
  * Test error registration functionality.
  */
-final class SetErrorTest extends SendTestCase
+final class SetErrorTest extends TestCase
 {
 
     /**
-     * Test error handling.
+     * Test simple, non-STMP, error registration.
      */
-    public function testError()
+    public function testSetErrorNonSmtp()
     {
-        $this->Mail->Subject .= ': Error handling test - this should be sent ok';
-        $this->buildBody();
-        $this->Mail->clearAllRecipients(); //No addresses should cause an error
-        self::assertTrue($this->Mail->isError() == false, 'Error found');
-        self::assertTrue($this->Mail->send() == false, 'send succeeded');
-        self::assertTrue($this->Mail->isError(), 'No error found');
-        self::assertSame('You must provide at least one recipient email address.', $this->Mail->ErrorInfo);
-        $this->Mail->addAddress($_REQUEST['mail_to']);
-        self::assertTrue($this->Mail->send(), 'send failed');
+        self::assertFalse($this->Mail->isError(), 'Errors found after class initialization');
+
+        // "Abuse" the `PHPMailer::set()` method to register an error.
+        self::assertFalse($this->Mail->set('nonexistentproperty', 'value'));
+
+        self::assertTrue($this->Mail->isError(), 'Error count not incremented');
+        self::assertSame(
+            'Cannot set or reset variable: nonexistentproperty',
+            $this->Mail->ErrorInfo,
+            'Error info not correctly set'
+        );
     }
 }

--- a/test/PHPMailer/SetErrorTest.php
+++ b/test/PHPMailer/SetErrorTest.php
@@ -18,6 +18,9 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test error registration functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::isError
+ * @covers \PHPMailer\PHPMailer\PHPMailer::setError
  */
 final class SetErrorTest extends TestCase
 {

--- a/test/PHPMailer/SetErrorTest.php
+++ b/test/PHPMailer/SetErrorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test error registration functionality.
+ */
+final class SetErrorTest extends SendTestCase
+{
+
+    /**
+     * Test error handling.
+     */
+    public function testError()
+    {
+        $this->Mail->Subject .= ': Error handling test - this should be sent ok';
+        $this->buildBody();
+        $this->Mail->clearAllRecipients(); //No addresses should cause an error
+        self::assertTrue($this->Mail->isError() == false, 'Error found');
+        self::assertTrue($this->Mail->send() == false, 'send succeeded');
+        self::assertTrue($this->Mail->isError(), 'No error found');
+        self::assertSame('You must provide at least one recipient email address.', $this->Mail->ErrorInfo);
+        $this->Mail->addAddress($_REQUEST['mail_to']);
+        self::assertTrue($this->Mail->send(), 'send failed');
+    }
+}


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434, #2435, #2439

## Commit details

### Tests/reorganize: move error recording test to own file

### SetErrorTest: replace the original test

... by a much simpler test which effectively tests the same thing, i.e.:
* No errors to start with.
* Trigger an error.
* Verify that `PHPMailer::isError()` returns `true`.
* Verify that the error message is as expected.

### SetErrorTest: add additional tests for the PHPMailer::setError() and `PHPMailer::isError()` methods

So far, these methods were only tested in the most perfunctory manner.

The additional tests this commit introduces, test all aspects of the methods as well as documents the current behaviour of the methods.

👉🏻 Take note of the "text merging"/readability issues for the SMTP error messages. There may be room for improvement there.

### SetErrorTest: add `@covers` tags 