### PR TITLE
Tests: move setFrom tests to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -755,29 +755,9 @@ EOT;
         self::assertFalse($this->Mail->addBCC('a@example.com'), 'BCC duplicate addressing failed (2)');
         self::assertTrue($this->Mail->addReplyTo('a@example.com'), 'Replyto Addressing failed');
         self::assertFalse($this->Mail->addReplyTo('a@example..com'), 'Invalid Replyto address accepted');
-        self::assertTrue($this->Mail->setFrom('a@example.com', 'some name'), 'setFrom failed');
-        self::assertFalse($this->Mail->setFrom('a@example.com.', 'some name'), 'setFrom accepted invalid address');
-        $this->Mail->Sender = '';
-        $this->Mail->setFrom('a@example.com', 'some name', true);
-        self::assertSame('a@example.com', $this->Mail->Sender, 'setFrom failed to set sender');
-        $this->Mail->Sender = '';
-        $this->Mail->setFrom('a@example.com', 'some name', false);
-        self::assertSame('', $this->Mail->Sender, 'setFrom should not have set sender');
         $this->Mail->clearCCs();
         $this->Mail->clearBCCs();
         $this->Mail->clearReplyTos();
-    }
-
-    /**
-     * Test addressing.
-     */
-    public function testAddressing2()
-    {
-        $this->buildBody();
-        $this->Mail->setFrom('bob@example.com', '"Bob\'s Burgers" (Bob\'s "Burgers")', true);
-        $this->Mail->isSMTP();
-        $this->Mail->Subject .= ': quotes in from name';
-        self::assertTrue($this->Mail->send(), 'send failed');
     }
 
     /**

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -48,6 +48,20 @@ final class SetFromTest extends TestCase
     public function dataSetFromSuccess()
     {
         return [
+            'Email, no name' => [
+                'expected' => [
+                    'From'     => 'a@example.com',
+                    'FromName' => '',
+                ],
+                'address'  => 'a@example.com',
+            ],
+            'Email, no name; whitespace padding around email' => [
+                'expected' => [
+                    'From'     => 'whitespacepadding@example.com',
+                    'FromName' => '',
+                ],
+                'address'  => " \t  whitespacepadding@example.com   \n",
+            ],
             'Email + name' => [
                 'expected' => [
                     'From'     => 'a@example.com',
@@ -63,6 +77,22 @@ final class SetFromTest extends TestCase
                 ],
                 'address'  => 'bob@example.com',
                 'name'     => '"Bob\'s Burgers" (Bob\'s "Burgers")',
+            ],
+            'Email + name; line breaks in name' => [
+                'expected' => [
+                    'From'     => 'removebreaks@example.com',
+                    'FromName' => 'somename',
+                ],
+                'address'  => 'removebreaks@example.com',
+                'name'     => "\r\nsome\r\nname\r\n",
+            ],
+            'Email + name; whitespace padding around name' => [
+                'expected' => [
+                    'From'     => 'a@example.com',
+                    'FromName' => 'some name',
+                ],
+                'address'  => 'a@example.com',
+                'name'     => "\t\tsome name    \r\n",
             ],
         ];
     }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -13,6 +13,8 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\Test\TestCase;
 
 /**
@@ -124,19 +126,56 @@ final class SetFromTest extends TestCase
 
     /**
      * Test unsuccesfully setting the From, FromName and Sender properties.
+     *
+     * @dataProvider dataSetFromFail
+     *
+     * @param string $address Email address input to pass to the function.
+     * @param string $name    Optional. Name input to pass to the function.
      */
-    public function testSetFromFail()
+    public function testSetFromFail($address, $name = '')
     {
         // Get the original, default values from the class.
         $expectedFrom     = $this->Mail->From;
         $expectedFromName = $this->Mail->FromName;
 
-        $result = $this->Mail->setFrom('a@example.com.', 'some name');
+        $result = $this->Mail->setFrom($address, $name);
         self::assertFalse($result, 'setFrom did not fail');
         self::assertTrue($this->Mail->isError(), 'Error count not incremented');
 
         self::assertSame($expectedFrom, $this->Mail->From, 'From has been overruled');
         self::assertSame($expectedFromName, $this->Mail->FromName, 'From name has been overruled');
         self::assertSame('', $this->Mail->Sender, 'Sender has been overruled');
+    }
+
+    /**
+     * Test that setting an invalid email address results in an exception.
+     *
+     * @dataProvider dataSetFromFail
+     *
+     * @param string $address Email address input to pass to the function.
+     * @param string $name    Optional. Name input to pass to the function.
+     */
+    public function testInvalidAddressException($address, $name = '')
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid address:  (From):');
+
+        $mail = new PHPMailer(true);
+        $mail->setFrom($address, $name);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetFromFail()
+    {
+        return [
+            'Invalid email address' => [
+                'address' => 'a@example.com.',
+                'name'    => 'some name',
+            ],
+        ];
     }
 }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -19,6 +19,8 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test setting the "from" address.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::setFrom
  */
 final class SetFromTest extends TestCase
 {

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -26,25 +26,54 @@ final class SetFromTest extends TestCase
      */
     public function testAddressing()
     {
-        self::assertTrue($this->Mail->setFrom('a@example.com', 'some name'), 'setFrom failed');
-        $this->Mail->Sender = '';
-        $this->Mail->setFrom('a@example.com', 'some name', true);
-        self::assertSame('a@example.com', $this->Mail->Sender, 'setFrom failed to set sender');
-        $this->Mail->Sender = '';
         $this->Mail->setFrom('a@example.com', 'some name', false);
         self::assertSame('', $this->Mail->Sender, 'setFrom should not have set sender');
     }
 
     /**
-     * Test addressing.
+     * Test succesfully setting the From, FromName and Sender properties.
+     *
+     * @dataProvider dataSetFromSuccess
+     *
+     * @param string $expected Expected funtion output.
+     * @param string $address  Email address input to pass to the function.
+     * @param string $name     Optional. Name input to pass to the function.
      */
-    public function testAddressing2()
+    public function testSetFromSuccess($expected, $address, $name = '')
     {
-        $this->buildBody();
-        $this->Mail->setFrom('bob@example.com', '"Bob\'s Burgers" (Bob\'s "Burgers")', true);
-        $this->Mail->isSMTP();
-        $this->Mail->Subject .= ': quotes in from name';
-        self::assertTrue($this->Mail->send(), 'send failed');
+        $result = $this->Mail->setFrom($address, $name);
+        self::assertTrue($result, 'setFrom failed');
+
+        self::assertSame($expected['From'], $this->Mail->From, 'From has not been set');
+        self::assertSame($expected['FromName'], $this->Mail->FromName, 'From name has not been set');
+        self::assertSame($expected['From'], $this->Mail->Sender, 'Sender has not been set');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetFromSuccess()
+    {
+        return [
+            'Email + name' => [
+                'expected' => [
+                    'From'     => 'a@example.com',
+                    'FromName' => 'some name',
+                ],
+                'address'  => 'a@example.com',
+                'name'     => 'some name',
+            ],
+            'Email + name; quotes in the name' => [
+                'expected' => [
+                    'From'     => 'bob@example.com',
+                    'FromName' => '"Bob\'s Burgers" (Bob\'s "Burgers")',
+                ],
+                'address'  => 'bob@example.com',
+                'name'     => '"Bob\'s Burgers" (Bob\'s "Burgers")',
+            ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -27,7 +27,6 @@ final class SetFromTest extends TestCase
     public function testAddressing()
     {
         self::assertTrue($this->Mail->setFrom('a@example.com', 'some name'), 'setFrom failed');
-        self::assertFalse($this->Mail->setFrom('a@example.com.', 'some name'), 'setFrom accepted invalid address');
         $this->Mail->Sender = '';
         $this->Mail->setFrom('a@example.com', 'some name', true);
         self::assertSame('a@example.com', $this->Mail->Sender, 'setFrom failed to set sender');
@@ -46,5 +45,13 @@ final class SetFromTest extends TestCase
         $this->Mail->isSMTP();
         $this->Mail->Subject .= ': quotes in from name';
         self::assertTrue($this->Mail->send(), 'send failed');
+    }
+
+    /**
+     * Test unsuccesfully setting the From, FromName and Sender properties.
+     */
+    public function testSetFromFail()
+    {
+        self::assertFalse($this->Mail->setFrom('a@example.com.', 'some name'), 'setFrom accepted invalid address');
     }
 }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -109,6 +109,20 @@ final class SetFromTest extends TestCase
     }
 
     /**
+     * Test setting the From address, but not overruling an existing, non-empty Sender value.
+     */
+    public function testSetFromDoesNotOverruleExistingSender()
+    {
+        $sender             = 'donotoverrule@example.com';
+        $this->Mail->Sender = $sender;
+
+        $result = $this->Mail->setFrom('overruled@example.com');
+
+        self::assertTrue($result, 'setFrom failed');
+        self::assertSame($sender, $this->Mail->Sender, 'Sender has been overruled');
+    }
+
+    /**
      * Test unsuccesfully setting the From, FromName and Sender properties.
      */
     public function testSetFromFail()

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -184,4 +184,18 @@ final class SetFromTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * Test unsuccesfully setting the From, FromName and Sender properties when an email address
+     * containing an 8bit character is passed and either the MbString or the Intl extension are
+     * not available.
+     */
+    public function testSetFromFailsOn8BitCharInDomainWithoutOptionalExtensions()
+    {
+        if (extension_loaded('mbstring') && function_exists('idn_to_ascii')) {
+            $this->markTestSkipped('Test requires MbString and/or Intl *not* to be available');
+        }
+
+        $this->testSetFromFail("8bit@ex\x80mple.com");
+    }
 }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -127,6 +127,16 @@ final class SetFromTest extends TestCase
      */
     public function testSetFromFail()
     {
-        self::assertFalse($this->Mail->setFrom('a@example.com.', 'some name'), 'setFrom accepted invalid address');
+        // Get the original, default values from the class.
+        $expectedFrom     = $this->Mail->From;
+        $expectedFromName = $this->Mail->FromName;
+
+        $result = $this->Mail->setFrom('a@example.com.', 'some name');
+        self::assertFalse($result, 'setFrom did not fail');
+        self::assertTrue($this->Mail->isError(), 'Error count not incremented');
+
+        self::assertSame($expectedFrom, $this->Mail->From, 'From has been overruled');
+        self::assertSame($expectedFromName, $this->Mail->FromName, 'From name has been overruled');
+        self::assertSame('', $this->Mail->Sender, 'Sender has been overruled');
     }
 }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test setting the "from" address.
+ */
+final class SetFromTest extends TestCase
+{
+
+    /**
+     * Test addressing.
+     */
+    public function testAddressing()
+    {
+        self::assertTrue($this->Mail->setFrom('a@example.com', 'some name'), 'setFrom failed');
+        self::assertFalse($this->Mail->setFrom('a@example.com.', 'some name'), 'setFrom accepted invalid address');
+        $this->Mail->Sender = '';
+        $this->Mail->setFrom('a@example.com', 'some name', true);
+        self::assertSame('a@example.com', $this->Mail->Sender, 'setFrom failed to set sender');
+        $this->Mail->Sender = '';
+        $this->Mail->setFrom('a@example.com', 'some name', false);
+        self::assertSame('', $this->Mail->Sender, 'setFrom should not have set sender');
+    }
+
+    /**
+     * Test addressing.
+     */
+    public function testAddressing2()
+    {
+        $this->buildBody();
+        $this->Mail->setFrom('bob@example.com', '"Bob\'s Burgers" (Bob\'s "Burgers")', true);
+        $this->Mail->isSMTP();
+        $this->Mail->Subject .= ': quotes in from name';
+        self::assertTrue($this->Mail->send(), 'send failed');
+    }
+}

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -176,6 +176,12 @@ final class SetFromTest extends TestCase
                 'address' => 'a@example.com.',
                 'name'    => 'some name',
             ],
+            'Not an email address: missing @ sign' => [
+                'address' => 'example.com',
+            ],
+            'Not an email address: nothing after the @ sign' => [
+                'address' => 'example@',
+            ],
         ];
     }
 }

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -22,15 +22,6 @@ final class SetFromTest extends TestCase
 {
 
     /**
-     * Test addressing.
-     */
-    public function testAddressing()
-    {
-        $this->Mail->setFrom('a@example.com', 'some name', false);
-        self::assertSame('', $this->Mail->Sender, 'setFrom should not have set sender');
-    }
-
-    /**
      * Test succesfully setting the From, FromName and Sender properties.
      *
      * @dataProvider dataSetFromSuccess
@@ -74,6 +65,17 @@ final class SetFromTest extends TestCase
                 'name'     => '"Bob\'s Burgers" (Bob\'s "Burgers")',
             ],
         ];
+    }
+
+    /**
+     * Test setting the From address, but not overruling the Sender value when the $auto parameter is set to false.
+     */
+    public function testSetFromDoesNotOverruleSenderWithAutoFalse()
+    {
+        $result = $this->Mail->setFrom('overruled@example.com', 'some name', false);
+
+        self::assertTrue($result, 'setFrom failed');
+        self::assertSame('', $this->Mail->Sender, 'Sender has been overruled');
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434, #2435, #2439, #2443

## Commit details

### Tests/reorganize: move setFrom tests to own file

### SetFromTest: split off failure test

This commit moves the "invalid email address" test case to a separate test method.

### SetFromTest: reorganize success tests to use data providers

* Merges the two "success" tests from the `testAddressing()` and the `testAddressing2()` methods into one `testSetFromSuccess()` method.
* Adds additional assertions to more comprehensively verify that the method did what was expected, i.e. set the `From`, `FromName` and `Sender` properties.
* Maintains the same test cases.
* Makes it easier to add additional test cases in the future.

### SetFromTest: replaces the last of the testAddressing() method

... with a dedicated test to verify that the `Sender` is not overruled when the `$auto` parameter is set to `false`.

### SetFromTest::testSetFromSuccess(): add additional test cases

... which should be handled correctly based on the code in the method under test.

### SetFromTest: add new test for not overruling existing Sender

Based on the code in the method, any existing, previously set `Sender` should not be overruled, even when the `$auto` parameter is set to `true`.

This method tests that specific situation.

### SetFromTest: improve the testSetFromFail() test

Make the failure test more comprehensive by verifying that when the method fails, the values for the `From`, `FromName` and `Sender` properties, _really_ haven't changed.

### SetFromTest: add extra failure test

... to test that passing an invalid email address in combination with an instance of the `PHPMailer` class which was instantiated with `$exceptions = true` results in an exception.

Includes reworking the `testSetFromFail()` method to a data provider and letting both the `testSetFromFail()` and the new `testInvalidAddressException()` method use the same data provider.

### SetFromTest::testSetFromFail(): add additional test cases

... which should be handled correctly based on the code in the method under test.

### SetFromTest: add extra test for passing an unacceptable email address

### SetFromTest: add @covers tag 