### PR TITLE
Tests: move property setting tests to own file

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1057,10 +1057,6 @@ EOT;
         $this->Mail->setLanguage('fr');
         $this->Mail->Sender = '';
         $this->Mail->createHeader();
-        self::assertFalse($this->Mail->set('x', 'y'), 'Invalid property set succeeded');
-        self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
-        self::assertTrue($this->Mail->set('AllowEmpty', null), 'Null property set failed');
-        self::assertTrue($this->Mail->set('AllowEmpty', false), 'Valid property set of null property failed');
     }
 
     public function testBadSMTP()

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -22,11 +22,31 @@ final class SetTest extends TestCase
 {
 
     /**
-     * Miscellaneous calls to improve test coverage and some small tests.
+     * Test setting the value of a class property.
+     *
+     * @dataProvider dataSetValidProperty
+     *
+     * @param string $name  The property name to set
+     * @param mixed  $value The value to set the property to
      */
-    public function testMiscellaneous()
+    public function testSetValidProperty($name, $value)
     {
-        self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
+        self::assertTrue($this->Mail->set($name, $value), 'Valid property set failed');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetValidProperty()
+    {
+        return [
+            'Valid: property exists, public' => [
+                'name'  => 'Timeout',
+                'value' => '11',
+            ],
+        ];
     }
 
     /**

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -46,6 +46,11 @@ final class SetTest extends TestCase
                 'name'  => 'Timeout',
                 'value' => '11',
             ],
+            'Valid: property exists, protected' => [
+                'name'  => 'MIMEBody',
+                'value' => 'Some text',
+            ],
+            // Note: no test for private property as the PHPMailer class doesn't have any.
         ];
     }
 

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -17,6 +17,8 @@ use PHPMailer\Test\TestCase;
 
 /**
  * Test property setting functionality.
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::set
  */
 final class SetTest extends TestCase
 {

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -26,9 +26,23 @@ final class SetTest extends TestCase
      */
     public function testMiscellaneous()
     {
-        self::assertFalse($this->Mail->set('x', 'y'), 'Invalid property set succeeded');
         self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
         self::assertTrue($this->Mail->set('AllowEmpty', null), 'Null property set failed');
         self::assertTrue($this->Mail->set('AllowEmpty', false), 'Valid property set of null property failed');
+    }
+
+    /**
+     * Test setting the value of a class property which doesn't exist.
+     */
+    public function testSetInvalidProperty()
+    {
+        self::assertFalse($this->Mail->set('x', 'y'), 'Invalid property set succeeded');
+
+        // Verify that an error has been registered.
+        self::assertSame(
+            'Cannot set or reset variable: x',
+            $this->Mail->ErrorInfo,
+            'Error info not correctly registered'
+        );
     }
 }

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -27,6 +27,13 @@ final class SetTest extends TestCase
     public function testMiscellaneous()
     {
         self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
+    }
+
+    /**
+     * Test setting a property to `null` and then resetting it to a non-null value.
+     */
+    public function testTogglingPropertyValueAwayFromNull()
+    {
         self::assertTrue($this->Mail->set('AllowEmpty', null), 'Null property set failed');
         self::assertTrue($this->Mail->set('AllowEmpty', false), 'Valid property set of null property failed');
     }

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test property setting functionality.
+ */
+final class SetTest extends TestCase
+{
+
+    /**
+     * Miscellaneous calls to improve test coverage and some small tests.
+     */
+    public function testMiscellaneous()
+    {
+        self::assertFalse($this->Mail->set('x', 'y'), 'Invalid property set succeeded');
+        self::assertTrue($this->Mail->set('Timeout', 11), 'Valid property set failed');
+        self::assertTrue($this->Mail->set('AllowEmpty', null), 'Null property set failed');
+        self::assertTrue($this->Mail->set('AllowEmpty', false), 'Valid property set of null property failed');
+    }
+}


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434, #2435, #2439, #2443, #2444

## Commit details

### Tests/reorganize: move property setting tests to own file

### SetTest: split off failure test

This commit moves the "failed to set the property" test case to a separate test method.

### SetTest: split off value toggling test

This commit moves the "set a property to null and then back" test to a separate test method.

Note: based on the code in the method, this test doesn't really add any value, but I also see no reason to remove it.

### SetTest: reorganize success test to use a data provider

* Renames the method to a more descriptive name.
* Maintains the same test case.
* Makes it easier to add additional test cases in the future.

### SetTest::testSetValidProperty(): add additional test case

This commit:
* Adds one extra test case.
* Documents why there is no test case for a `private` property.

### SetTest: add @covers tag 