### PR TITLE
Tests: move (get|set|clear)ReplyTo tests to own file

### DIFF
--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -81,16 +81,10 @@ final class MailTransportTest extends SendTestCase
         $this->setAddress('testmailsend@example.com', 'totest');
         $this->setAddress('cctestmailsend@example.com', 'cctest', $sType = 'cc');
         $this->setAddress('bcctestmailsend@example.com', 'bcctest', $sType = 'bcc');
-        $this->setAddress('replytotestmailsend@example.com', 'replytotest', $sType = 'ReplyTo');
 
         self::assertContains('testmailsend@example.com', $this->Mail->getToAddresses()[0], 'To address not found');
         self::assertContains('cctestmailsend@example.com', $this->Mail->getCcAddresses()[0], 'CC address not found');
         self::assertContains('bcctestmailsend@example.com', $this->Mail->getBccAddresses()[0], 'BCC address not found');
-        self::assertContains(
-            'replytotestmailsend@example.com',
-            $this->Mail->getReplyToAddresses()['replytotestmailsend@example.com'],
-            'Replyto address not found'
-        );
 
         self::assertTrue(
             $this->Mail->getAllRecipientAddresses()['testmailsend@example.com'],

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -32,7 +32,6 @@ final class PHPMailerTest extends SendTestCase
         $this->Mail->Body = 'Here is the main body.  There should be ' .
             'a reply to address in this message.';
         $this->Mail->Subject .= ': Low Priority';
-        $this->Mail->addReplyTo('nobody@nobody.com', 'Nobody (Unit Test)');
 
         $this->buildBody();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
@@ -753,11 +752,8 @@ EOT;
         self::assertTrue($this->Mail->addBCC('c@example.com'), 'BCC addressing failed');
         self::assertFalse($this->Mail->addBCC('c@example.com'), 'BCC duplicate addressing failed');
         self::assertFalse($this->Mail->addBCC('a@example.com'), 'BCC duplicate addressing failed (2)');
-        self::assertTrue($this->Mail->addReplyTo('a@example.com'), 'Replyto Addressing failed');
-        self::assertFalse($this->Mail->addReplyTo('a@example..com'), 'Invalid Replyto address accepted');
         $this->Mail->clearCCs();
         $this->Mail->clearBCCs();
-        $this->Mail->clearReplyTos();
     }
 
     /**
@@ -1109,7 +1105,6 @@ EOT;
         }
 
         $this->Mail->clearAllRecipients();
-        $this->Mail->clearReplyTos();
 
         //This file is UTF-8 encoded. Create a domain encoded in "iso-8859-1".
         $letter = html_entity_decode('&ccedil;', ENT_COMPAT, PHPMailer::CHARSET_ISO88591);
@@ -1117,13 +1112,11 @@ EOT;
         $this->Mail->addAddress('test' . $domain);
         $this->Mail->addCC('test+cc' . $domain);
         $this->Mail->addBCC('test+bcc' . $domain);
-        $this->Mail->addReplyTo('test+replyto' . $domain);
 
         //Queued addresses are not returned by get*Addresses() before send() call.
         self::assertEmpty($this->Mail->getToAddresses(), 'Bad "to" recipients');
         self::assertEmpty($this->Mail->getCcAddresses(), 'Bad "cc" recipients');
         self::assertEmpty($this->Mail->getBccAddresses(), 'Bad "bcc" recipients');
-        self::assertEmpty($this->Mail->getReplyToAddresses(), 'Bad "reply-to" recipients');
 
         //Clear queued BCC recipient.
         $this->Mail->clearBCCs();
@@ -1144,11 +1137,6 @@ EOT;
             'Bad "cc" recipients'
         );
         self::assertEmpty($this->Mail->getBccAddresses(), 'Bad "bcc" recipients');
-        self::assertSame(
-            ['test+replyto' . $domain => ['test+replyto' . $domain, '']],
-            $this->Mail->getReplyToAddresses(),
-            'Bad "reply-to" addresses'
-        );
     }
 
     /**
@@ -1161,7 +1149,6 @@ EOT;
         }
 
         $this->Mail->clearAllRecipients();
-        $this->Mail->clearReplyTos();
 
         $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
 
@@ -1173,14 +1160,6 @@ EOT;
         self::assertFalse($this->Mail->addAddress('test@xn--franois-xxa.ch'));
         self::assertFalse($this->Mail->addAddress('test@XN--FRANOIS-XXA.CH'));
 
-        self::assertTrue($this->Mail->addReplyTo('test+replyto@françois.ch'));
-        self::assertFalse($this->Mail->addReplyTo('test+replyto@françois.ch'));
-        self::assertTrue($this->Mail->addReplyTo('test+replyto@FRANÇOIS.CH'));
-        self::assertFalse($this->Mail->addReplyTo('test+replyto@FRANÇOIS.CH'));
-        self::assertTrue($this->Mail->addReplyTo('test+replyto@xn--franois-xxa.ch'));
-        self::assertFalse($this->Mail->addReplyTo('test+replyto@xn--franois-xxa.ch'));
-        self::assertFalse($this->Mail->addReplyTo('test+replyto@XN--FRANOIS-XXA.CH'));
-
         $this->buildBody();
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
 
@@ -1189,11 +1168,6 @@ EOT;
             1,
             $this->Mail->getToAddresses(),
             'Bad count of "to" recipients'
-        );
-        self::assertCount(
-            1,
-            $this->Mail->getReplyToAddresses(),
-            'Bad count of "reply-to" addresses'
         );
     }
 
@@ -1245,16 +1219,6 @@ EOT;
 
         include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
         $this->assertTrue($this->Mail->addAddress('test@françois.ch'));
-    }
-
-    public function testGivenIdnAddress_addReplyTo_returns_true()
-    {
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
-            $this->markTestSkipped('/test/fakefunctions.php file not found');
-        }
-
-        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
-        $this->assertTrue($this->Mail->addReplyTo('test@françois.ch'));
     }
 
     public function testErroneousAddress_addAddress_returns_false()

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -48,13 +48,12 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
 
     /**
      * Tests CharSet and Unicode -> ASCII conversions for addresses with IDN.
+     *
+     * @requires extension mbstring
+     * @requires function idn_to_ascii
      */
     public function testConvertEncoding()
     {
-        if (!PHPMailer::idnSupported()) {
-            self::markTestSkipped('intl and/or mbstring extensions are not available');
-        }
-
         $this->Mail->clearReplyTos();
 
         //This file is UTF-8 encoded. Create a domain encoded in "iso-8859-1".
@@ -79,13 +78,12 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
 
     /**
      * Tests removal of duplicate recipients and reply-tos.
+     *
+     * @requires extension mbstring
+     * @requires function idn_to_ascii
      */
     public function testDuplicateIDNRemoved()
     {
-        if (!PHPMailer::idnSupported()) {
-            self::markTestSkipped('intl and/or mbstring extensions are not available');
-        }
-
         $this->Mail->clearReplyTos();
 
         $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -400,13 +400,19 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
         );
     }
 
-    public function testGivenIdnAddress_addReplyTo_returns_true()
+    /**
+     * Test unsuccesfully adding an Reply-to address when an email address containing
+     * an 8bit character is passed and either the MbString or the Intl extension are
+     * not available.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::addAnAddress
+     */
+    public function testAddReplyToFailsOn8BitCharInDomainWithoutOptionalExtensions()
     {
-        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
-            $this->markTestSkipped('/test/fakefunctions.php file not found');
+        if (extension_loaded('mbstring') && function_exists('idn_to_ascii')) {
+            $this->markTestSkipped('Test requires MbString and/or Intl *not* to be available');
         }
 
-        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
-        $this->assertTrue($this->Mail->addReplyTo('test@françois.ch'));
+        self::assertFalse($this->Mail->addReplyTo('test@françois.ch'));
     }
 }

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -32,16 +32,26 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      *
      * @dataProvider dataAddReplyToValidAddressNonIdn
      *
-     * @param string $address The email address to set.
-     * @param string $name    Optional. The name to set.
+     * @param string $address  The email address to set.
+     * @param string $name     Optional. The name to set.
+     * @param string $expected Optional. The email address and name as they are expected to be set.
+     *                         Only needs to be passed if different than the original inputs.
      */
-    public function testAddReplyToValidAddressNonIdn($address, $name = null)
+    public function testAddReplyToValidAddressNonIdn($address, $name = null, $expected = null)
     {
         if (isset($name)) {
             $result = $this->Mail->addReplyTo($address, $name);
         } else {
             $result = $this->Mail->addReplyTo($address);
             $name   = '';
+        }
+
+        if (isset($expected) === false) {
+            $expected = [
+                'key'     => $address,
+                'address' => $address,
+                'name'    => $name,
+            ];
         }
 
         // Test the setting is successful.
@@ -52,24 +62,25 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
         self::assertIsArray($retrieved, 'ReplyTo property is not an array');
         self::assertCount(1, $retrieved, 'ReplyTo property does not contain exactly one address');
 
+        $key = $expected['key'];
         self::assertArrayHasKey(
-            $address,
+            $key,
             $retrieved,
             'ReplyTo property does not contain an entry with this address as the key'
         );
         self::assertCount(
             2,
-            $retrieved[$address],
+            $retrieved[$key],
             'ReplyTo array for this address does not contain exactly two array items'
         );
         self::assertSame(
-            $address,
-            $retrieved[$address][0],
+            $expected['address'],
+            $retrieved[$key][0],
             'ReplyTo array for this address does not contain added address'
         );
         self::assertSame(
-            $name,
-            $retrieved[$address][1],
+            $expected['name'],
+            $retrieved[$key][1],
             'ReplyTo array for this address does not contain added name'
         );
     }
@@ -85,9 +96,27 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
             'Valid address' => [
                 'address' => 'a@example.com',
             ],
+            'Valid address with surrounding whitespace and mixed case' => [
+                'address' => " \tMiXeD@Example.Com  \r\n",
+                'name'    => null,
+                'expected' => [
+                    'key'     => 'mixed@example.com',
+                    'address' => 'MiXeD@Example.Com',
+                    'name'    => '',
+                ],
+            ],
             'Valid address with name' => [
                 'address' => 'a@example.com',
                 'name'    => 'ReplyTo name',
+            ],
+            'Valid address with name; name with whitespace and line breaks' => [
+                'address'  => 'a@example.com',
+                'name'     => "\t\t  ReplyTo\r\nname  ",
+                'expected' => [
+                    'key'     => 'a@example.com',
+                    'address' => 'a@example.com',
+                    'name'    => 'ReplyToname',
+                ],
             ],
         ];
     }

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -14,12 +14,12 @@
 namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\Test\SendTestCase;
+use PHPMailer\Test\PreSendTestCase;
 
 /**
  * Test reply-to address setting, getting and clearing functionality.
  */
-final class ReplyToGetSetClearTest extends SendTestCase
+final class ReplyToGetSetClearTest extends PreSendTestCase
 {
 
     /**
@@ -33,7 +33,7 @@ final class ReplyToGetSetClearTest extends SendTestCase
         $this->Mail->addReplyTo('nobody@nobody.com', 'Nobody (Unit Test)');
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
     }
 
     /**
@@ -66,7 +66,7 @@ final class ReplyToGetSetClearTest extends SendTestCase
         self::assertEmpty($this->Mail->getReplyToAddresses(), 'Bad "reply-to" recipients');
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
 
         //Addresses with IDN are returned by get*Addresses() after send() call.
         $domain = $this->Mail->punyencodeAddress($domain);
@@ -99,7 +99,7 @@ final class ReplyToGetSetClearTest extends SendTestCase
         self::assertFalse($this->Mail->addReplyTo('test+replyto@XN--FRANOIS-XXA.CH'));
 
         $this->buildBody();
-        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+        self::assertTrue($this->Mail->preSend(), $this->Mail->ErrorInfo);
 
         //There should be only one "Reply-To" address.
         self::assertCount(

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -219,6 +219,14 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
         $LE = PHPMailer::getLE();
 
         return [
+            'Single address' => [
+                'addresses' => [
+                    [
+                        'address' => 'nobody@nobody.com',
+                    ],
+                ],
+                'expected'  => $LE . 'Reply-To: nobody@nobody.com' . $LE,
+            ],
             'Single address + name' => [
                 'addresses' => [
                     [
@@ -227,6 +235,23 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
                     ],
                 ],
                 'expected'  => $LE . 'Reply-To: "Nobody (Unit Test)" <nobody@nobody.com>' . $LE,
+            ],
+            'Multiple addresses, including no name and mixed case email' => [
+                'addresses' => [
+                    [
+                        'address' => 'nobody@nobody.com',
+                        'name'    => 'Nobody (Unit Test)',
+                    ],
+                    [
+                        'address' => 'Somebody@SomeBody.com',
+                        'name'    => 'Somebody (Unit Test)',
+                    ],
+                    [
+                        'address' => 'noname@noname.com',
+                    ],
+                ],
+                'expected'  => $LE . 'Reply-To: "Nobody (Unit Test)" <nobody@nobody.com>,'
+                    . ' "Somebody (Unit Test)" <Somebody@SomeBody.com>, noname@noname.com' . $LE,
             ],
         ];
     }

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -415,4 +415,38 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
 
         self::assertFalse($this->Mail->addReplyTo('test@françois.ch'));
     }
+
+    /**
+     * Test successfully clearing out both the added as well as the queued Reply-to addresses.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::clearReplyTos
+     *
+     * @requires extension mbstring
+     * @requires function idn_to_ascii
+     */
+    public function testClearReplyTos()
+    {
+        self::assertTrue($this->Mail->addReplyTo('example@example.com'), 'Address not added');
+        self::assertTrue($this->Mail->addReplyTo('test@françois.ch'), 'IDN Address not queued');
+
+        // Verify there is something to clear.
+        $retrieved = $this->Mail->getReplyToAddresses();
+        self::assertIsArray($retrieved, 'ReplyTo property is not an array (pre-clear)');
+        self::assertCount(1, $retrieved, 'ReplyTo property does not contain exactly one address');
+
+        $queue = $this->getPropertyValue($this->Mail, 'ReplyToQueue');
+        self::assertIsArray($queue, 'Queue is not an array (pre-clear)');
+        self::assertCount(1, $queue, 'Queue does not contain exactly one entry');
+
+        $this->Mail->clearReplyTos();
+
+        // Verify the clearing was successful.
+        $retrieved = $this->Mail->getReplyToAddresses();
+        self::assertIsArray($retrieved, 'ReplyTo property is not an array (post-clear)');
+        self::assertCount(0, $retrieved, 'ReplyTo property still contains an address');
+
+        $queue = $this->getPropertyValue($this->Mail, 'ReplyToQueue');
+        self::assertIsArray($queue, 'Queue is not an array (post-clear)');
+        self::assertCount(0, $queue, 'Queue still contains an entry');
+    }
 }

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\SendTestCase;
+
+/**
+ * Test reply-to address setting, getting and clearing functionality.
+ */
+final class ReplyToGetSetClearTest extends SendTestCase
+{
+
+    /**
+     * Test low priority.
+     */
+    public function testLowPriority()
+    {
+        $this->Mail->Body = 'Here is the main body.  There should be ' .
+            'a reply to address in this message.';
+        $this->Mail->Subject .= ': Low Priority';
+        $this->Mail->addReplyTo('nobody@nobody.com', 'Nobody (Unit Test)');
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Test addressing.
+     */
+    public function testAddressing()
+    {
+        self::assertTrue($this->Mail->addReplyTo('a@example.com'), 'Replyto Addressing failed');
+        self::assertFalse($this->Mail->addReplyTo('a@example..com'), 'Invalid Replyto address accepted');
+        $this->Mail->clearReplyTos();
+    }
+
+    /**
+     * Tests CharSet and Unicode -> ASCII conversions for addresses with IDN.
+     */
+    public function testConvertEncoding()
+    {
+        if (!PHPMailer::idnSupported()) {
+            self::markTestSkipped('intl and/or mbstring extensions are not available');
+        }
+
+        $this->Mail->clearReplyTos();
+
+        //This file is UTF-8 encoded. Create a domain encoded in "iso-8859-1".
+        $letter = html_entity_decode('&ccedil;', ENT_COMPAT, PHPMailer::CHARSET_ISO88591);
+        $domain = '@' . 'fran' . $letter . 'ois.ch';
+        $this->Mail->addReplyTo('test+replyto' . $domain);
+
+        //Queued addresses are not returned by get*Addresses() before send() call.
+        self::assertEmpty($this->Mail->getReplyToAddresses(), 'Bad "reply-to" recipients');
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+
+        //Addresses with IDN are returned by get*Addresses() after send() call.
+        $domain = $this->Mail->punyencodeAddress($domain);
+        self::assertSame(
+            ['test+replyto' . $domain => ['test+replyto' . $domain, '']],
+            $this->Mail->getReplyToAddresses(),
+            'Bad "reply-to" addresses'
+        );
+    }
+
+    /**
+     * Tests removal of duplicate recipients and reply-tos.
+     */
+    public function testDuplicateIDNRemoved()
+    {
+        if (!PHPMailer::idnSupported()) {
+            self::markTestSkipped('intl and/or mbstring extensions are not available');
+        }
+
+        $this->Mail->clearReplyTos();
+
+        $this->Mail->CharSet = PHPMailer::CHARSET_UTF8;
+
+        self::assertTrue($this->Mail->addReplyTo('test+replyto@françois.ch'));
+        self::assertFalse($this->Mail->addReplyTo('test+replyto@françois.ch'));
+        self::assertTrue($this->Mail->addReplyTo('test+replyto@FRANÇOIS.CH'));
+        self::assertFalse($this->Mail->addReplyTo('test+replyto@FRANÇOIS.CH'));
+        self::assertTrue($this->Mail->addReplyTo('test+replyto@xn--franois-xxa.ch'));
+        self::assertFalse($this->Mail->addReplyTo('test+replyto@xn--franois-xxa.ch'));
+        self::assertFalse($this->Mail->addReplyTo('test+replyto@XN--FRANOIS-XXA.CH'));
+
+        $this->buildBody();
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+
+        //There should be only one "Reply-To" address.
+        self::assertCount(
+            1,
+            $this->Mail->getReplyToAddresses(),
+            'Bad count of "reply-to" addresses'
+        );
+    }
+
+    public function testGivenIdnAddress_addReplyTo_returns_true()
+    {
+        if (file_exists(\PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php') === false) {
+            $this->markTestSkipped('/test/fakefunctions.php file not found');
+        }
+
+        include \PHPMAILER_INCLUDE_DIR . '/test/fakefunctions.php';
+        $this->assertTrue($this->Mail->addReplyTo('test@françois.ch'));
+    }
+}

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -152,6 +152,7 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
     {
         return [
             'Invalid domain' => ['a@example..com'],
+            'Missing @ sign' => ['example.com'],
         ];
     }
 

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -13,6 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
+use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\Test\PreSendTestCase;
 
@@ -141,6 +142,25 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
         $retrieved = $this->Mail->getReplyToAddresses();
         self::assertIsArray($retrieved, 'ReplyTo property is not an array');
         self::assertCount(0, $retrieved, 'ReplyTo property is not empty');
+    }
+
+    /**
+     * Test receiving an excepting when adding an invalid non-IDN reply-to address.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::addOrEnqueueAnAddress
+     * @covers \PHPMailer\PHPMailer\PHPMailer::addAnAddress
+     *
+     * @dataProvider dataAddReplyToInvalidAddressNonIdn
+     *
+     * @param string $address The email address to set.
+     */
+    public function testAddReplyToInvalidAddressNonIdnException($address)
+    {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid address:  (Reply-To): ' . $address);
+
+        $mail = new PHPMailer(true);
+        $mail->addReplyTo($address);
     }
 
     /**


### PR DESCRIPTION
This is a next PR in a series of PRs to improve the test suite and make it easier to maintain.
The principle of these changes was proposed to and discussed with the maintainer prior to work being started on it.

I'm splitting this up into several PRs to 1) allow for easier review and 2) allow the repo to benefit from the changes as quickly as possible. (the complete series is still a WIP).

Previous PRs in this series: #2372, #2376, #2377, #2378, #2379, #2380, #2381, #2382, #2383, #2384, #2385, #2386, #2387, #2389, #2392, #2395, #2400, #2401, #2404, #2408, #2410, #2414, #2421, #2422, #2424, #2425, #2427, #2434, #2435, #2439, #2443, #2444, #2445

## Commit details

### Tests/reorganize: move (get|set|clear)ReplyTo tests to own file

Note: this doesn't move the complete tests from the original test file, just select parts of the test methods.

### ReplyToGetSetClearTest: switch to preSend()

The actual "dequeueing" and adding of `ReplyTo` addresses with IDNs happens within `preSend()`, so this test doesn't actually need to call `send()`.

### ReplyToGetSetClearTest: replace testSkipping with @requires

### ReplyToGetSetClearTest: test the setting of reply-to address in more depth

This commit:
* Splits the primary tests previously contained in the `testAddressing()` method into two distinct test methods, each using a data provider to allow for adding additional test cases more easily.
* Enhances the tests by not only testing the return value of the `addReplyTo()` method, but also verifying that the `ReplyTo property has been set correctly and contains the expected information.

Includes adding `@covers` tags for these specific methods.

### ReplyToGetSetClearTest::testAddReplyToValidAddressNonIdn(): add additional test cases

This commit:
* Adds two extra test cases.
* Adds handling to allow the "expected" registered values (and key) being different from the original input values.

### ReplyToGetSetClearTest::testAddReplyToInvalidAddressNonIdn(): add additional test case

... which should be handled correctly based on the code.

### ReplyToGetSetClearTest: add extra setting failure test

... to test that passing an invalid email address in combination with an instance of the `PHPMailer` class which was instantiated with `$exceptions = true` results in an exception.

Includes adding `@covers` tags for this specific method.

### ReplyToGetSetClearTest: test the reply-to message header gets set correctly

This commit:
* Renames the `testLowPriority()` method to `testReplyToInMessageHeader()`.
    This test method was originally basically testing two things: the priority and the reply to header being set. For this class, it now just focusses on the reply to header, so letting the name reflect that.
* Enhances the test by actually testing that the reply-to header is correctly found in the fully composed message.
* Breaks out the test case to a data provider to allow for adding additional test cases more easily.

### ReplyToGetSetClearTest::testReplyToInMessageHeader(): add additional test cases

... to test that the header gets set correctly when multiple reply-to addresses have been set, as well as when a reply-to address has been set without a name.

### ReplyToGetSetClearTest: improve the conversion and enqueuing test

This commit:
* Renames the `testConvertEncoding()` method to `testEnqueueAndAddIdnAddress()`.
* Removes the call to `clearReplyTos()` at the start of the function as it is redundant. Each test gets a fresh instance of the PHPMailer class.
* Adds a number of additional assertions to the method to test the enqueuing in more depth.

Includes adding `@covers` tags for the test.

### ReplyToGetSetClearTest: improve the test with duplicate IDN addresses

This commit:
* Renames the `testDuplicateIDNRemoved()` method to `testNoDuplicateReplyToAddresses()`.
* Removes the call to `clearReplyTos()` at the start of the function as it is redundant. Each test gets a fresh instance of the PHPMailer class.
* Adds a number of additional assertions to the method to test the enqueuing and duplication removal in more depth.
* Ensures that all assertions are accompanied by a "failure" message so it can more easily be determined which assertion failed (in case of failure).

Includes adding `@covers` tags for the test.

### ReplyToGetSetClearTest: improve "extensions not available" test

The "fakefunctions" are all nice and dandy to get past the `idnSupported()` check, but if either of these functions is not _really_ available, the actual behaviour of the `PHPMailer::addReplyTo()` function is to _fail_ (on the address validation call in `PHPMailer::addAnAddress()`) and return `false`.

In other words, this test was nonsensical as it tested for something which can, and should, never happen.

With this in mind, the test has been rewritten to reflect the *real* behaviour when either Mbstring or the `idn_to_ascii` function is not available.

### ReplyToGetSetClearTest: add new test to verify clearing of reply-tos

### MailTransportTest: remove reply-to addressing testing

As noted in #2380, the addressing tests do not belong in the mail transport tests and as the `ReplyToGetSetClearTest` now covers this extensively (for the `addReplyTo()` part), the assertions can be removed from the `MailTransportTest`.

