### PR TITLE
 PHPMailer::setLanguage(): various fixes + add tests for localization

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2251,19 +2251,32 @@ class PHPMailer
         //Validate $langcode
         $foundlang = true;
         $langcode  = strtolower($langcode);
-        if (!preg_match('/^[a-z]{2}(?:_[a-z]{2})?$/', $langcode) && $langcode !== 'en') {
+        if (!preg_match('/^(?P<lang>[a-z]{2})(?P<country>_[a-z]{2})?$/', $langcode, $matches) && $langcode !== 'en') {
             $foundlang = false;
             $langcode = 'en';
         }
 
-        $lang_file = $lang_path . 'phpmailer.lang-' . $langcode . '.php';
         //There is no English translation file
         if ('en' !== $langcode) {
-            //Make sure language file path is readable
-            if (!static::fileIsAccessible($lang_file)) {
+            $langcodes = [];
+            if (!empty($matches['country'])) {
+                $langcodes[] = $matches['lang'] . $matches['country'];
+            }
+            $langcodes[] = $matches['lang'];
+
+            //Try and find a readable language file for the requested language.
+            $foundFile = false;
+            foreach ($langcodes as $code) {
+                $lang_file = $lang_path . 'phpmailer.lang-' . $code . '.php';
+                if (static::fileIsAccessible($lang_file)) {
+                    $foundFile = true;
+                    break;
+                }
+            }
+
+            if ($foundFile === false) {
                 $foundlang = false;
             } else {
-                //$foundlang = include $lang_file;
                 $lines = file($lang_file);
                 foreach ($lines as $line) {
                     //Translation file lines look like this:

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2189,6 +2189,8 @@ class PHPMailer
      * The default language is English.
      *
      * @param string $langcode  ISO 639-1 2-character language code (e.g. French is "fr")
+     *                          Optionally, the language code can be enhanced with a 4-character
+     *                          script annotation and/or a 2-character country annotation.
      * @param string $lang_path Path to the language file directory, with trailing separator (slash).D
      *                          Do not set this from user input!
      *
@@ -2251,7 +2253,10 @@ class PHPMailer
         //Validate $langcode
         $foundlang = true;
         $langcode  = strtolower($langcode);
-        if (!preg_match('/^(?P<lang>[a-z]{2})(?P<country>_[a-z]{2})?$/', $langcode, $matches) && $langcode !== 'en') {
+        if (
+            !preg_match('/^(?P<lang>[a-z]{2})(?P<script>_[a-z]{4})?(?P<country>_[a-z]{2})?$/', $langcode, $matches)
+            && $langcode !== 'en'
+        ) {
             $foundlang = false;
             $langcode = 'en';
         }
@@ -2259,8 +2264,14 @@ class PHPMailer
         //There is no English translation file
         if ('en' !== $langcode) {
             $langcodes = [];
+            if (!empty($matches['script']) && !empty($matches['country'])) {
+                $langcodes[] = $matches['lang'] . $matches['script'] . $matches['country'];
+            }
             if (!empty($matches['country'])) {
                 $langcodes[] = $matches['lang'] . $matches['country'];
+            }
+            if (!empty($matches['script'])) {
+                $langcodes[] = $matches['lang'] . $matches['script'];
             }
             $langcodes[] = $matches['lang'];
 

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2186,14 +2186,13 @@ class PHPMailer
 
     /**
      * Set the language for error messages.
-     * Returns false if it cannot load the language file.
      * The default language is English.
      *
      * @param string $langcode  ISO 639-1 2-character language code (e.g. French is "fr")
      * @param string $lang_path Path to the language file directory, with trailing separator (slash).D
      *                          Do not set this from user input!
      *
-     * @return bool
+     * @return bool Returns true if the requested language was loaded, false otherwise.
      */
     public function setLanguage($langcode = 'en', $lang_path = '')
     {
@@ -2248,11 +2247,14 @@ class PHPMailer
             //Calculate an absolute path so it can work if CWD is not here
             $lang_path = dirname(__DIR__) . DIRECTORY_SEPARATOR . 'language' . DIRECTORY_SEPARATOR;
         }
+
         //Validate $langcode
-        if (!preg_match('/^[a-z]{2}(?:_[a-zA-Z]{2})?$/', $langcode)) {
+        $foundlang = true;
+        if (!preg_match('/^[a-z]{2}(?:_[a-zA-Z]{2})?$/', $langcode) && $langcode !== 'en') {
+            $foundlang = false;
             $langcode = 'en';
         }
-        $foundlang = true;
+
         $lang_file = $lang_path . 'phpmailer.lang-' . $langcode . '.php';
         //There is no English translation file
         if ('en' !== $langcode) {

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2250,7 +2250,8 @@ class PHPMailer
 
         //Validate $langcode
         $foundlang = true;
-        if (!preg_match('/^[a-z]{2}(?:_[a-zA-Z]{2})?$/', $langcode) && $langcode !== 'en') {
+        $langcode  = strtolower($langcode);
+        if (!preg_match('/^[a-z]{2}(?:_[a-z]{2})?$/', $langcode) && $langcode !== 'en') {
             $foundlang = false;
             $langcode = 'en';
         }

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-fr.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-fr.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test overruling an existing translation
+ * file with a custom one by passing in a `$langPath` parameter.
+ */
+
+$PHPMAILER_LANG['empty_message'] = "Custom path test success (fr)";

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-nl.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-nl.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test overruling an existing translation
+ * file with a custom one by passing in a `$langPath` parameter.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'Custom path test success (nl)';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xa_scri_cc.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xa_scri_cc.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XA Lang-script-country file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xb_scri.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xb_scri.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XB Lang-script file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xc_cc.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xc_cc.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XC Lang-country file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xd_cc.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xd_cc.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XD Lang-country file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xd_scri.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xd_scri.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XD Lang-script file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xe.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xe.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test the fall-back logic.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'XE Lang file found';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-xx.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-xx.php
@@ -1,0 +1,9 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest`.
+ */
+
+$PHPMAILER_LANG['empty_message'] = 'This file should not be loaded as the path is passed incorrectly';

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-yy.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-yy.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test that arbitrary code in translation files is disregarded.
+ */
+
+$composer = file_get_contents(__DIR__ . '/../../../composer.json');
+
+echo $composer;
+
+$PHPMAILER_LANG['extension_missing'] = 'Confirming that test fixture was loaded correctly (yy).';
+$PHPMAILER_LANG['empty_message']     = $composer;
+$PHPMAILER_LANG['encoding']          = `ls -l`;
+$PHPMAILER_LANG['execute']           = exec('some harmful command');
+$PHPMAILER_LANG['signing']           = "Double quoted but not interpolated $composer";

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-zz.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-zz.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test that language strings not
+ * set via a fixed, known group of array index keys are disregarded.
+ */
+
+$PHPMAILER_LANG['extension_missing'] = 'Confirming that test fixture was loaded correctly (zz).';
+
+// Keys not in the original array.
+$PHPMAILER_LANG['unknown']           = 'Unknown text.';
+$PHPMAILER_LANG['invalid']           = 'Invalid text.';
+
+// Keys which exist in the original array, but use the wrong letter case or space instead of underscore.
+$PHPMAILER_LANG['Authenticate']      = 'Overruled text, index not same case';
+$PHPMAILER_LANG['CONNECT_HOST']      = 'Overruled text, index not same case';
+$PHPMAILER_LANG['Data_Not_Accepted'] = 'Overruled text, index not same case';
+$PHPMAILER_LANG['empty message']     = 'Overruled text, index not same case';

--- a/test/PHPMailer/LocalizationTest.php
+++ b/test/PHPMailer/LocalizationTest.php
@@ -1,0 +1,481 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use ReflectionMethod;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test localized error message functionality.
+ *
+ * {@internal In a number of tests unassigned language codes are being used
+ * on purpose so as not to conflict with translations which will potentially be
+ * added in the future.
+ * If at any point in the future, these code would be _assigned_, the tests should
+ * be updated to use some other, as yet unassigned language code.}
+ *
+ * @covers \PHPMailer\PHPMailer\PHPMailer::getTranslations
+ * @covers \PHPMailer\PHPMailer\PHPMailer::lang
+ * @covers \PHPMailer\PHPMailer\PHPMailer::setLanguage
+ */
+final class LocalizationTest extends TestCase
+{
+
+    /**
+     * Test setting the preferred language for error messages.
+     *
+     * @dataProvider dataSetLanguageSuccess
+     *
+     * @param string $phrase   The "empty_message" phrase in the expected language for verification.
+     * @param string $langCode Optional. Language code.
+     * @param string $langPath Optional. Path to the language file directory.
+     */
+    public function testSetLanguageSuccess($phrase, $langCode = null, $langPath = null)
+    {
+        if (isset($langCode, $langPath)) {
+            $result = $this->Mail->setLanguage($langCode, $langPath);
+        } elseif (isset($langCode)) {
+            $result = $this->Mail->setLanguage($langCode);
+        } else {
+            $result = $this->Mail->setLanguage();
+        }
+
+        $lang = $this->Mail->getTranslations();
+
+        self::assertTrue(
+            $result,
+            'Setting the language failed. Translations set to: ' . var_export($lang, true)
+        );
+
+        self::assertIsArray($lang, 'Translations is not an array');
+        self::assertArrayHasKey('empty_message', $lang, 'The "empty_message" key is unavailable');
+        self::assertSame($phrase, $lang['empty_message'], 'The "empty_message" translation is not as expected');
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetLanguageSuccess()
+    {
+        $customPath = dirname(__DIR__) . '/Fixtures/LocalizationTest/';
+
+        return [
+            'Default language (en)' => [
+                'phrase'   => 'Message body empty',
+            ],
+            'Renamed language (dk => da)' => [
+                'phrase'   => 'Meddelelsen er uden indhold',
+                'langCode' => 'dk',
+            ],
+            'Available language: "nl"' => [
+                'phrase'   => 'Berichttekst is leeg',
+                'langCode' => 'nl',
+            ],
+            'Available language: "NL" (uppercase)' => [
+                'phrase'   => 'Berichttekst is leeg',
+                'langCode' => 'NL',
+            ],
+            'Available language: "pt_br"' => [
+                'phrase'   => 'Mensagem vazia',
+                'langCode' => 'pt_br',
+            ],
+            'Available language: "Zh_Cn" (mixed case)' => [
+                'phrase'   => '邮件正文为空。',
+                'langCode' => 'Zh_Cn',
+            ],
+            'Available language: "sr_latn"' => [
+                'phrase'   => 'Sadržaj poruke je prazan.',
+                'langCode' => 'sr_latn',
+            ],
+            'Custom path: available language with code in "lang-script-country" format' => [
+                'phrase'   => 'XA Lang-script-country file found',
+                'langCode' => 'xa_scri_cc',
+                'langPath' => $customPath,
+            ],
+            'Custom path: available language: "nl" (single quoted translation text)' => [
+                'phrase'   => 'Custom path test success (nl)',
+                'langCode' => 'nl',
+                'langPath' => $customPath,
+            ],
+            'Custom path: available language: "fr" (double quoted translation text)' => [
+                'phrase'   => 'Custom path test success (fr)',
+                'langCode' => 'fr',
+                'langPath' => $customPath,
+            ],
+        ];
+    }
+
+    /**
+     * Test the fall-back logic for when a more specific language code is passed, for which a translation
+     * doesn't exist, while a translation for a related ("parent") language code does exist.
+     *
+     * {@internal This test re-uses the logic of the success test, but having it as a separate test
+     * allows for the test to report under its own name, making the test results more descriptive.}
+     *
+     * @dataProvider dataSetLanguageSuccessFallBackLogic
+     *
+     * @param string $phrase   The "empty_message" phrase in the expected language for verification.
+     * @param string $langCode Optional. Language code.
+     * @param string $langPath Optional. Path to the language file directory.
+     */
+    public function testSetLanguageSuccessFallBackLogic($phrase, $langCode = null, $langPath = null)
+    {
+        $this->testSetLanguageSuccess($phrase, $langCode, $langPath);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetLanguageSuccessFallBackLogic()
+    {
+        $customPath = dirname(__DIR__) . '/Fixtures/LocalizationTest/';
+
+        return [
+            'Request: "lang-script-country" (not available), receive "lang-script"' => [
+                'phrase'   => 'XB Lang-script file found',
+                'langCode' => 'xb_scri_cc',
+                'langPath' => $customPath,
+            ],
+            'Request: "lang-script-country" (not available), receive "lang-country"' => [
+                'phrase'   => 'XC Lang-country file found',
+                'langCode' => 'xc_scri_cc',
+                'langPath' => $customPath,
+            ],
+            'Request: "lang-script-country" (not available), receive "lang-country" (prefer country over script)' => [
+                'phrase'   => 'XD Lang-country file found',
+                'langCode' => 'xd_scri_cc',
+                'langPath' => $customPath,
+            ],
+            'Request: "lang-script-country" (not available), receive "lang" (no country or script available)' => [
+                'phrase'   => 'XE Lang file found',
+                'langCode' => 'xe_scri_cc',
+                'langPath' => $customPath,
+            ],
+
+            'Request: "lang-script" (not available), receive "lang" even when "lang_country" exists' => [
+                'phrase'   => '郵件內容為空',
+                'langCode' => 'zh_Hant',
+            ],
+            'Request: "lang-script" (not available), receive "lang" (no country or script available)' => [
+                'phrase'   => 'Corps du message vide.',
+                'langCode' => 'fr_latn',
+            ],
+
+            'Request: "lang-country" (not available), receive "lang" even when "lang_script" exists' => [
+                'phrase'   => 'Садржај поруке је празан.',
+                'langCode' => 'sr_rs',
+            ],
+            'Request: "lang-country" (not available), receive "lang" (no country or script available)' => [
+                'phrase'   => 'Berichttekst is leeg',
+                'langCode' => 'nl_NL',
+            ],
+        ];
+    }
+
+    /**
+     * Test that setting the preferred language for error messages fails when the language file
+     * could not be found/is inaccessible.
+     *
+     * @dataProvider dataSetLanguageFail
+     *
+     * @param string $langCode Optional. Language code.
+     * @param string $langPath Optional. Path to the language file directory.
+     */
+    public function testSetLanguageFail($langCode = null, $langPath = null)
+    {
+        if (isset($langCode, $langPath)) {
+            $result = $this->Mail->setLanguage($langCode, $langPath);
+        } elseif (isset($langCode)) {
+            $result = $this->Mail->setLanguage($langCode);
+        } else {
+            $result = $this->Mail->setLanguage();
+        }
+
+        $lang = $this->Mail->getTranslations();
+
+        self::assertFalse(
+            $result,
+            'Setting the language did not fail. Translations set to: ' . var_export($lang, true)
+        );
+
+        // Verify that the translations have still be set (in English).
+        self::assertIsArray($lang, 'Translations is not an array');
+        self::assertArrayHasKey('empty_message', $lang, 'The "empty_message" key is unavailable');
+        self::assertSame(
+            'Message body empty',
+            $lang['empty_message'],
+            'The "empty_message" translation is not as expected'
+        );
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataSetLanguageFail()
+    {
+        $customPath = dirname(__DIR__) . '/Fixtures/LocalizationTest/';
+
+        return [
+            'Unavailable language (Quechuan), fall back to default (en)' => [
+                'langCode' => 'qu',
+            ],
+            'Unavailable Language-country code (is_IS), unavailable lang code (is), fall back to default (en)' => [
+                'langCode' => 'is_IS',
+            ],
+            'Unavailable Language-script code (pa_Arab), unavailable lang code (pa), fall back to default (en)' => [
+                'langCode' => 'pa_Arab',
+            ],
+            'Invalid lang-country-script order (sr_rs_latin), fall back to default (en)' => [
+                'phrase'   => 'Садржај поруке је празан.',
+                'langCode' => 'sr_rs_latin',
+            ],
+            'Available language-country code, but using dash (pt-br): fall back to default (en)' => [
+                'langCode' => 'pt-br',
+            ],
+            /*
+             * Note: The first two letters of this three letter language code should match an existing
+             * language file for this test to test this properly.
+             */
+            'Invalid language code (ISO 639-2 "hrv"): fallback to default (en)' => [
+                'phrase'   => 'Message body empty',
+                'langCode' => 'hrv',
+            ],
+            'Custom path: unavailable language (Quechuan)' => [
+                'langCode' => 'qu',
+                'langPath' => $customPath,
+            ],
+            'Custom path: not a local/permitted path' => [
+                'langCode' => 'xx', // Unassigned lang code.
+                'langPath' => 'http://example.com/files/',
+            ],
+            'Custom path: path traversal' => [
+                'langCode' => 'xx', // Unassigned lang code.
+                'langPath' => './../../composer.json?',
+            ],
+            'Custom path: missing trailing slash, file exists but should not be loaded' => [
+                'langCode' => 'xx', // Unassigned lang code.
+                'langPath' => dirname(__DIR__) . '/Fixtures/LocalizationTest',
+            ],
+        ];
+    }
+
+    /**
+     * Test that arbitrary code in a language file does not get executed.
+     */
+    public function testSetLanguageDoesNotExecuteCodeInLangFile()
+    {
+        $result = $this->Mail->setLanguage(
+            'yy', // Unassigned lang code.
+            dirname(__DIR__) . '/Fixtures/LocalizationTest/'
+        );
+        $lang   = $this->Mail->getTranslations();
+
+        self::assertTrue($result, 'Setting the language failed. Translations set to: ' . var_export($lang, true));
+        self::assertIsArray($lang, 'Translations is not an array');
+
+        // Verify that the fixture file was loaded.
+        self::assertArrayHasKey('extension_missing', $lang, 'The "extension_missing" translation key was not found');
+        self::assertSame(
+            'Confirming that test fixture was loaded correctly (yy).',
+            $lang['extension_missing'],
+            'The "extension_missing" translation is not as expected'
+        );
+
+        // Verify that arbitrary code in a translation file does not get processed.
+        self::assertArrayHasKey('empty_message', $lang, 'The "empty_message" translation key was not found');
+        self::assertSame(
+            'Message body empty',
+            $lang['empty_message'],
+            'The "empty_message" translation is not as expected'
+        );
+
+        self::assertArrayHasKey('encoding', $lang, 'The "encoding" translation key was not found');
+        self::assertSame(
+            'Unknown encoding: ',
+            $lang['encoding'],
+            'The "encoding" translation is not as expected'
+        );
+
+        self::assertArrayHasKey('execute', $lang, 'The "execute" translation key was not found');
+        self::assertSame(
+            'Could not execute: ',
+            $lang['execute'],
+            'The "execute" translation is not as expected'
+        );
+
+        self::assertArrayHasKey('signing', $lang, 'The "signing" translation key was not found');
+        self::assertSame(
+            'Double quoted but not interpolated $composer',
+            $lang['signing'],
+            'The "signing" translation is not as expected'
+        );
+    }
+
+    /**
+     * Test that text strings passed in from a language file for arbitrary keys do not get processed.
+     */
+    public function testSetLanguageOnlyProcessesKnownKeys()
+    {
+        $result = $this->Mail->setLanguage(
+            'zz', // Unassigned lang code.
+            dirname(__DIR__) . '/Fixtures/LocalizationTest/'
+        );
+        $lang   = $this->Mail->getTranslations();
+
+        self::assertTrue($result, 'Setting the language failed. Translations set to: ' . var_export($lang, true));
+        self::assertIsArray($lang, 'Translations is not an array');
+
+        // Verify that the fixture file was loaded.
+        self::assertArrayHasKey('extension_missing', $lang, 'The "extension_missing" translation key was not found');
+        self::assertSame(
+            'Confirming that test fixture was loaded correctly (zz).',
+            $lang['extension_missing'],
+            'The "extension_missing" translation is not as expected'
+        );
+
+        // Verify that unknown translation keys do not get processed.
+        self::assertArrayNotHasKey('unknown', $lang, 'The "unknown" key was found');
+        self::assertNotContains(
+            'Unknown text.',
+            $lang,
+            'The text for the "unknown" key was found in the array'
+        );
+
+        self::assertArrayNotHasKey('invalid', $lang, 'The "invalid" key was found');
+        self::assertNotContains(
+            'Invalid text.',
+            $lang,
+            'The text for the "invalid" key was found in the array'
+        );
+
+        // Verify that known translation keys which do not match the expected case do not get processed.
+        self::assertNotContains(
+            'Overruled text, index not same case',
+            $lang,
+            'Non-exact key matches were processed anyway'
+        );
+    }
+
+    /**
+     * Test retrieving the applicable language strings.
+     *
+     * @dataProvider dataGetTranslations
+     *
+     * @param string $langCode Optional. The language to set.
+     */
+    public function testGetTranslations($langCode = null)
+    {
+        if (isset($langCode)) {
+            $this->Mail->setLanguage($langCode);
+        }
+
+        $result = $this->Mail->getTranslations();
+        self::assertIsArray($result);
+        self::assertNotCount(0, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataGetTranslations()
+    {
+        return [
+            'No explicit language set' => [
+               'langCode' => null,
+            ],
+            'Language explicitly set' => [
+               'langCode' => 'es',
+            ],
+        ];
+    }
+
+    /**
+     * Test retrieving a - potentially localized - text string.
+     *
+     * @dataProvider dataLang
+     *
+     * @param string $input    Text string identifier key.
+     * @param string $expected Expected function return value.
+     * @param string $langCode Optional. The language to retrieve the text in.
+     */
+    public function testLang($input, $expected, $langCode = null)
+    {
+        if (isset($langCode)) {
+            $this->Mail->setLanguage($langCode);
+        }
+
+        $reflMethod = new ReflectionMethod($this->Mail, 'lang');
+        $reflMethod->setAccessible(true);
+        $result = $reflMethod->invoke($this->Mail, $input);
+        $reflMethod->setAccessible(false);
+
+        self::assertSame($expected, $result);
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataLang()
+    {
+        return [
+            'Key: "invalid_address", default language (en)' => [
+               'input'    => 'invalid_address',
+               'expected' => 'Invalid address: ',
+            ],
+            'Key: "provide_address", explicit language: en' => [
+               'input'    => 'provide_address',
+               'expected' => 'You must provide at least one recipient email address.',
+               'langCode' => 'en',
+            ],
+            'Key: "encoding", explicit language: nl' => [
+               'input'    => 'encoding',
+               'expected' => 'Onbekende codering: ',
+               'langCode' => 'nl',
+            ],
+            'Key: "mailer_not_supported", explicit language: ja' => [
+               'input'    => 'mailer_not_supported',
+               'expected' => ' メーラーがサポートされていません。',
+               'langCode' => 'ja',
+            ],
+            'Key: "smtp_connect_failed", default language (en)' => [
+               'input'    => 'smtp_connect_failed',
+               'expected' => 'SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting',
+            ],
+            'Key: "smtp_connect_failed", explicit language: es' => [
+               'input'    => 'smtp_connect_failed',
+               'expected' => 'SMTP Connect() falló. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting',
+               'langCode' => 'es',
+            ],
+            'Non-existent key returns key, default language (en)' => [
+               'input'    => 'notasupportedkey',
+               'expected' => 'notasupportedkey',
+            ],
+            'Non-existent key returns key, explicit language: es' => [
+               'input'    => 'notasupportedkey',
+               'expected' => 'notasupportedkey',
+               'langCode' => 'es',
+            ],
+        ];
+    }
+}

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1050,7 +1050,6 @@ EOT;
         $this->Mail->isMail();
         $this->Mail->isSendmail();
         $this->Mail->isQmail();
-        $this->Mail->setLanguage('fr');
         $this->Mail->Sender = '';
         $this->Mail->createHeader();
     }


### PR DESCRIPTION
Fixes #2418 (and could only be pulled no after #2449 was merged as otherwise the tests would fail on PHP 5.5)

## Commit details

### PHPMailer::setLanguage(): make return value consistent

The return value of the method was inconsistent as it could return `true` even when the requested language was not loaded/set.

Previously, the method would:
* Return `false` when a `$langcode` was matched against the regex, but the file couldn't be loaded.
* Return `true` in all other cases, including when a `$langcode` other than `'en'` was passed, but it didn't match the regex, which meant that effectively the requested language was ignored and English was loaded anyway, but the function would still return `true`.

This has now been changed to:
* Return `true` when the requested language was loaded, whether `'en'` or another language.
* Return `false` when the requested language wasn't loaded and the language defaulted to English.

Related to #2418 (https://github.com/PHPMailer/PHPMailer/issues/2418#issuecomment-876265100)

### PHPMailer::setLanguage(): match language codes case-insensitively

For "language code - country code" locale notations, it is common for the "country code" part to be provided in uppercase, like `pt_BR`.

The method currently did not allow for that correctly. The regex check would accept the language code, but then fail to find the file on *nix based systems as the file names are all in lowercase and non-Windows file systems are generally case-sensitive. Which means that in effect, the method, ended up falling back to the default language (English).

The change in this commit makes the handling of the provided `$langcode` case-tolerant.

Note: the language code used in the file names for the language files is still expected to always be lowercase, including for language files in custom paths!

Related to #2418 - observation 1

### PHPMailer::setLanguage(): fix "lang_country" codes do not fall back to "lang"

When the  `$langCode` is passed as "language code - country code" and no translation is found for the specified country variant, the localization would automatically fall back to English, even when there was a viable translation available in the "parent" language, i.e. just based on the _language code_.

This commit changes the logic in the `PHPMailer::setLanguage()` method for when a "lang-country" code is passed.
It will now try and find a "lang-country" file first, if not found, it will try to find a file for just the "lang" and only if that could also not be found, it will fall back to English.

Related to #2418 - observation 2

Includes using named subpatterns in the regex to make the regex self-documenting.

Includes removing a commented out line of code which is superseded anyway.

### PHPMailer::setLanguage(): allow for "lang(_script)?(_country)?" codes

Language codes which were "language-script" based were not accepted by the regex used, which meant that the `sr_latn` script could never be loaded.

After discussion in #2418, it was decided to support "script" in a language code and to support it like so:
```
2-character language code [_] optional 4-character script code [_] optional 2-character country code
```

This combines the annotation forms of the following known standards:
* https://unicode-org.github.io/cldr-staging/charts/37/summary/root.html
* https://docs.oracle.com/cd/E23824_01/html/E26033/glset.html
* http://www.loc.gov/standards/iso639-2/php/code_list.php

This means that all of the below codes will now pass the language code validation:
```
sr
sr_latn
sr_rs
sr_latn_rs
```

But not:
```
sr_rs_latn
```

This commit applies the above change and also adjusts the "language code fall back" logic to take language codes with a script code into account.
Note: if the requested full "language-script-country" code is not available, "language-country" will take precedence over "language-script" for the fallback logic to find the appropriate translation file.

Related to #2418 - observation 4

### Tests: introduce dedicated tests for text localization

So far, the methods related to text localization - `PHPMailer::setLanguage()`, `PHPMailer::getTranslations()` and `PHPMailer::lang()` - did not have dedicated tests.

The test file this commit introduces, tests all aspects of these methods, including the changes introduced in response to #2418 and #2419, as well as documents the current behaviour of the methods for specific, outlier situations.

### PHPMailerTest: remove setLanguage() test

... which wasn't actually testing anything at all.

