### PR TITLE
Fixed check for proper email format rather than just an @ character

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1078,7 +1078,7 @@ class PHPMailer
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         // Validate the proper email address format
-        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        if (!filter_var($address, FILTER_VALIDATE_EMAIL)) {
           $error_message = sprintf(
               '%s (%s): %s',
               $this->lang('invalid_address'),

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1079,7 +1079,6 @@ class PHPMailer
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
         // Validate the proper email address format
         if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
-          //At-sign is missing.
           $error_message = sprintf(
               '%s (%s): %s',
               $this->lang('invalid_address'),

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1077,22 +1077,22 @@ class PHPMailer
     {
         $address = trim($address);
         $name = trim(preg_replace('/[\r\n]+/', '', $name)); //Strip breaks and trim
-        $pos = strrpos($address, '@');
-        if (false === $pos) {
-            //At-sign is missing.
-            $error_message = sprintf(
-                '%s (%s): %s',
-                $this->lang('invalid_address'),
-                $kind,
-                $address
-            );
-            $this->setError($error_message);
-            $this->edebug($error_message);
-            if ($this->exceptions) {
-                throw new Exception($error_message);
-            }
+        // Validate the proper email address format
+        if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+          //At-sign is missing.
+          $error_message = sprintf(
+              '%s (%s): %s',
+              $this->lang('invalid_address'),
+              $kind,
+              $address
+          );
+          $this->setError($error_message);
+          $this->edebug($error_message);
+          if ($this->exceptions) {
+              throw new Exception($error_message);
+          }
 
-            return false;
+          return false;
         }
         $params = [$kind, $address, $name];
         //Enqueue addresses with IDN until we know the PHPMailer::$CharSet.


### PR DESCRIPTION
The email address is not properly validated here.  The code only checks for the existence of an "@", but this functionality can be abused.  This allows adding an "?attach=<filepath>" suffix to the email address which can be used to include files on the operating system (e.g. ~/.ssh/id_rsa).  As a result, sensitive information can be included in these emails and sent to an attacker.  While the applications including PHPMailer should be doing input validation on their side of things, there's also no reason why we shouldn't be doing a more comprehensive check for a proper email address in PHPMailer, since we have the ability to do so.

Quick read about the vulnerability is available here:
https://www.zdnet.com/article/some-email-clients-are-vulnerable-to-attacks-via-mailto-links/

Full original paper reporting this vulnerability is available here:
https://www.nds.ruhr-uni-bochum.de/media/nds/veroeffentlichungen/2020/08/15/mailto-paper.pdf