### PR TITLE
PHP 5.4 compatibility

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1697,7 +1697,8 @@ class PHPMailer
         //Sendmail docs: http://www.sendmail.org/~ca/email/man/sendmail.html
         //Qmail docs: http://www.qmail.org/man/man8/qmail-inject.html
         //Example problem: https://www.drupal.org/node/1057954
-        if (empty($this->Sender) && !empty(ini_get('sendmail_from'))) {
+        $ini_get_sendmail_from = ini_get('sendmail_from'); // Workaround for PHP 5.4, otherweise Fatal error: Can't use function return value in write context
+        if (empty($this->Sender) && !empty($ini_get_sendmail_from)) {
             //PHP config has a sender address we can use
             $this->Sender = ini_get('sendmail_from');
         }
@@ -1879,7 +1880,8 @@ class PHPMailer
         //Qmail docs: http://www.qmail.org/man/man8/qmail-inject.html
         //Example problem: https://www.drupal.org/node/1057954
         //CVE-2016-10033, CVE-2016-10045: Don't pass -f if characters will be escaped.
-        if (empty($this->Sender) && !empty(ini_get('sendmail_from'))) {
+        $ini_get_sendmail_from = ini_get('sendmail_from'); // Workaround for PHP 5.4, otherweise Fatal error: Can't use function return value in write context
+        if (empty($this->Sender) && !empty($ini_get_sendmail_from)) {
             //PHP config has a sender address we can use
             $this->Sender = ini_get('sendmail_from');
         }


### PR DESCRIPTION
this merge request will fix the Fatal error: Can't use function return value in write context error, because php 5.4 don't support ini_get in an if condition.

Why i make this patch? CentOS7 ship PHP on the version 5.4 and still support this with security updates until 2024.