### PR TITLE
POP3 cleanup

### DIFF
--- a/src/POP3.php
+++ b/src/POP3.php
@@ -308,6 +308,7 @@ class POP3
     {
         if (!$this->connected) {
             $this->setError('Not connected to POP3 server');
+            return false;
         }
         if (empty($username)) {
             $username = $this->username;

--- a/src/POP3.php
+++ b/src/POP3.php
@@ -337,6 +337,15 @@ class POP3
     public function disconnect()
     {
         $this->sendString('QUIT');
+        
+        // RFC 1939 shows POP3 server sending a +OK response to the QUIT command.
+        // Try to get it.  Ignore any failures here.
+        try {
+            $this->getResponse();
+        } catch (Exception $e) {
+            //Do nothing
+        }
+
         //The QUIT command may cause the daemon to exit, which will kill our connection
         //So ignore errors here
         try {
@@ -344,6 +353,10 @@ class POP3
         } catch (Exception $e) {
             //Do nothing
         }
+
+        // Clean up attributes.
+        $this->connected = false;
+        $this->pop_conn  = false;
     }
 
     /**


### PR DESCRIPTION
This PR resolves #2487 and #2488 by adding the suggested code. If there's a response from the server to the `QUIT` command it will be captured, and the `connected` property will properly be `false` after a disconnect.