### PR TITLE
Provide additional error details after connection failures

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2143,7 +2143,8 @@ class PHPMailer
                     }
                     if ($tls) {
                         if (!$this->smtp->startTLS()) {
-                            throw new Exception($this->lang('connect_host'));
+                            $message = $this->getSmtpErrorMessage('connect_host');
+                            throw new Exception($message);
                         }
                         //We must resend EHLO after TLS negotiation
                         $this->smtp->hello($hello);
@@ -4108,6 +4109,26 @@ class PHPMailer
 
         //Return the key as a fallback
         return $key;
+    }
+
+    /**
+     * Build an error message starting with a generic one and adding details if possible.
+     *
+     * @param string $base_key
+     * @return string
+     */
+    private function getSmtpErrorMessage($base_key)
+    {
+        $message = $this->lang($base_key);
+        $error = $this->smtp->getError();
+        if (!empty($error['error'])) {
+            $message .= ' ' . $error['error'];
+            if (!empty($error['detail'])) {
+                $message .= ' ' . $error['detail'];
+            }
+        }
+
+        return $message;
     }
 
     /**

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2174,6 +2174,10 @@ class PHPMailer
         //As we've caught all exceptions, just report whatever the last one was
         if ($this->exceptions && null !== $lastexception) {
             throw $lastexception;
+        } elseif ($this->exceptions) {
+            // no exception was thrown, likely $this->smtp->connect() failed
+            $message = $this->getSmtpErrorMessage('connect_host');
+            throw new Exception($message);
         }
 
         return false;


### PR DESCRIPTION
This should go some way to resolving #1405. TLS connection errors are already being gathered by the SMTP class but these details are not being included in the exception thrown [when `$this->smtp->startTls()` fails](https://github.com/PHPMailer/PHPMailer/blob/master/src/PHPMailer.php#L2146). This PR adds those details.

Unless I'm missing something, it seems like an exception is never thrown when `$this->smtp->connect()` returns false and exceptions are enabled. I don't know if that's a deliberate decision, but this PR also throws an exception with these details in that case.

Now TLS failure exceptions will have a message like
```
SMTP Error: Could not connect to SMTP host. Connection failed. stream_socket_enable_crypto(): SSL operation failed with code 1. OpenSSL Error messages:
error:1416F086:SSL routines:tls_process_server_certificate:certificate verify failed
```
Or
```
SMTP Error: Could not connect to SMTP host. Connection failed. stream_socket_enable_crypto(): Peer certificate CN=`smtp.example.com' did not match expected CN=`mail.example.com'
```

This is a bit verbose, but parsing all possible error messages (esp. from all versions of PHP going back almost 10 years) into something readable seems like an unrealistic job. Certainly a subset could be translated into something more user-friendly, perhaps within the `SMTP::errorHandler()` method.
