### PR TITLE
Add smtp_transaction_id pattern for Mailjet

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -187,6 +187,7 @@ class SMTP
         'SendGrid' => '/[\d]{3} Ok: queued as (.*)/',
         'CampaignMonitor' => '/[\d]{3} 2.0.0 OK:([a-zA-Z\d]{48})/',
         'Haraka' => '/[\d]{3} Message Queued \((.*)\)/',
+        'Mailjet' => '/[\d]{3} OK queued as (.*)/',
     ];
 
     /**

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -23,6 +23,8 @@ use PHPMailer\Test\SendTestCase;
  */
 final class PHPMailerTest extends SendTestCase
 {
+    private $Smtp;
+
     /**
      * Test low priority.
      */


### PR DESCRIPTION
Responses from the Mailjet servers look like this:  
`250 OK queued as a08b7f37-ed61-423a-ba75-38ed2fd4b54c`