### PR TITLE
Do not call `call_user_func` on `error_log`

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -901,7 +901,7 @@ class PHPMailer
             return;
         }
         //Avoid clash with built-in function names
-        if (is_callable($this->Debugoutput) && !in_array($this->Debugoutput, ['error_log', 'html', 'echo'])) {
+        if (is_callable($this->Debugoutput) && !in_array($this->Debugoutput, ['html', 'echo'])) {
             call_user_func($this->Debugoutput, $str, $this->SMTPDebug);
 
             return;


### PR DESCRIPTION
Do not call `call_user_function` when `Debugoutput` is set to `error_log`  
as it raises PHP warning when `SMTPDebug` is set to `SMTP::DEBUG_SERVER`.

Closes #2581