### PR TITLE
Composer: update version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,10 @@
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "doctrine/annotations": "^1.2",
         "php-parallel-lint/php-console-highlighter": "^0.5.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3",
+        "php-parallel-lint/php-parallel-lint": "^1.3.1",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.6.0",
+        "squizlabs/php_codesniffer": "^3.6.2",
         "yoast/phpunit-polyfills": "^1.0.0"
     },
     "suggest": {

--- a/test/OAuth/OAuthTest.php
+++ b/test/OAuth/OAuthTest.php
@@ -22,7 +22,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class OAuthTest extends TestCase
 {
-
     /**
      * Test OAuth method.
      *

--- a/test/PHPMailer/AddEmbeddedImageTest.php
+++ b/test/PHPMailer/AddEmbeddedImageTest.php
@@ -27,7 +27,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class AddEmbeddedImageTest extends PreSendTestCase
 {
-
     /**
      * Test successfully adding an embedded image.
      */

--- a/test/PHPMailer/AddStringAttachmentTest.php
+++ b/test/PHPMailer/AddStringAttachmentTest.php
@@ -27,7 +27,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class AddStringAttachmentTest extends PreSendTestCase
 {
-
     /**
      * Test successfully adding a simple plain string attachment.
      */

--- a/test/PHPMailer/AddStringEmbeddedImageTest.php
+++ b/test/PHPMailer/AddStringEmbeddedImageTest.php
@@ -26,7 +26,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class AddStringEmbeddedImageTest extends PreSendTestCase
 {
-
     /**
      * Test successfully adding a stingified embedded image without a name.
      */

--- a/test/PHPMailer/AuthCRAMMD5Test.php
+++ b/test/PHPMailer/AuthCRAMMD5Test.php
@@ -20,7 +20,6 @@ use PHPMailer\Test\SendTestCase;
  */
 final class AuthCRAMMD5Test extends SendTestCase
 {
-
     /**
      * Test CRAM-MD5 authentication.
      * Needs a connection to a server that supports this auth mechanism, so commented out by default.

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -22,7 +22,6 @@ use PHPMailer\Test\TestCase;
  */
 final class CustomHeaderTest extends TestCase
 {
-
     /**
      * Tests setting and getting custom headers.
      *

--- a/test/PHPMailer/DKIMTest.php
+++ b/test/PHPMailer/DKIMTest.php
@@ -24,7 +24,6 @@ use PHPMailer\Test\SendTestCase;
  */
 final class DKIMTest extends SendTestCase
 {
-
     /**
      * Whether or not to initialize the PHPMailer object to throw exceptions.
      *

--- a/test/PHPMailer/EncodeQTest.php
+++ b/test/PHPMailer/EncodeQTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\TestCase;
  */
 final class EncodeQTest extends TestCase
 {
-
     /**
      * Test encoding a string using Q encoding.
      *

--- a/test/PHPMailer/EncodeStringTest.php
+++ b/test/PHPMailer/EncodeStringTest.php
@@ -22,7 +22,6 @@ use PHPMailer\Test\TestCase;
  */
 final class EncodeStringTest extends TestCase
 {
-
     /**
      * Encoding and charset tests.
      *

--- a/test/PHPMailer/FileIsAccessibleTest.php
+++ b/test/PHPMailer/FileIsAccessibleTest.php
@@ -28,7 +28,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class FileIsAccessibleTest extends TestCase
 {
-
     /**
      * Verify whether the "is a file accessible" check works correctly.
      *

--- a/test/PHPMailer/FilenameToTypeTest.php
+++ b/test/PHPMailer/FilenameToTypeTest.php
@@ -23,7 +23,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class FilenameToTypeTest extends TestCase
 {
-
     /**
      * Verify mapping a file name to a MIME type.
      *

--- a/test/PHPMailer/GenerateIdTest.php
+++ b/test/PHPMailer/GenerateIdTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class GenerateIdTest extends PreSendTestCase
 {
-
     /**
      * Test generating a unique ID.
      *

--- a/test/PHPMailer/GetLastMessageIDTest.php
+++ b/test/PHPMailer/GetLastMessageIDTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class GetLastMessageIDTest extends PreSendTestCase
 {
-
     /**
      * Test setting and retrieving an invalid message ID.
      *

--- a/test/PHPMailer/HasLineLongerThanMaxTest.php
+++ b/test/PHPMailer/HasLineLongerThanMaxTest.php
@@ -21,7 +21,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class HasLineLongerThanMaxTest extends PreSendTestCase
 {
-
     /**
      * Test constructing a multipart message that contains lines that are too long for RFC compliance.
      *

--- a/test/PHPMailer/Html2TextTest.php
+++ b/test/PHPMailer/Html2TextTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\TestCase;
  */
 final class Html2TextTest extends TestCase
 {
-
     /**
      * Test converting an arbitrary HTML string into plain text.
      *

--- a/test/PHPMailer/ICalTest.php
+++ b/test/PHPMailer/ICalTest.php
@@ -20,7 +20,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class ICalTest extends PreSendTestCase
 {
-
     /**
      * Test ICal method.
      *

--- a/test/PHPMailer/IsPermittedPathTest.php
+++ b/test/PHPMailer/IsPermittedPathTest.php
@@ -24,7 +24,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class IsPermittedPathTest extends TestCase
 {
-
     /**
      * Test whether the validation of whether a path is of a permitted type works correctly.
      *

--- a/test/PHPMailer/IsValidHostTest.php
+++ b/test/PHPMailer/IsValidHostTest.php
@@ -23,7 +23,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class IsValidHostTest extends TestCase
 {
-
     /**
      * Test host validation when a valid host is passed.
      *

--- a/test/PHPMailer/LocalizationTest.php
+++ b/test/PHPMailer/LocalizationTest.php
@@ -31,7 +31,6 @@ use PHPMailer\Test\TestCase;
  */
 final class LocalizationTest extends TestCase
 {
-
     /**
      * Test setting the preferred language for error messages.
      *

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -20,7 +20,6 @@ use PHPMailer\Test\SendTestCase;
  */
 final class MailTransportTest extends SendTestCase
 {
-
     /**
      * Test sending using SendMail.
      *

--- a/test/PHPMailer/MbPathinfoTest.php
+++ b/test/PHPMailer/MbPathinfoTest.php
@@ -23,7 +23,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class MbPathinfoTest extends TestCase
 {
-
     /**
      * Verify retrieving information about a file path when the $options parameter has been passed.
      *

--- a/test/PHPMailer/MimeTypesTest.php
+++ b/test/PHPMailer/MimeTypesTest.php
@@ -23,7 +23,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class MimeTypesTest extends TestCase
 {
-
     /**
      * Test mime type mapping.
      *

--- a/test/PHPMailer/NormalizeBreaksTest.php
+++ b/test/PHPMailer/NormalizeBreaksTest.php
@@ -24,7 +24,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class NormalizeBreaksTest extends TestCase
 {
-
     /**
      * Test line break normalization.
      *

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -28,7 +28,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class ParseAddressesTest extends TestCase
 {
-
     /**
      * Test RFC822 address splitting using the PHPMailer native implementation
      * with the Mbstring extension available.

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\TestCase;
  */
 final class PunyencodeAddressTest extends TestCase
 {
-
     /**
      * Test IDN to ASCII form/punycode conversion for an email address.
      *

--- a/test/PHPMailer/QuotedStringTest.php
+++ b/test/PHPMailer/QuotedStringTest.php
@@ -23,7 +23,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class QuotedStringTest extends TestCase
 {
-
     /**
      * Test quoting of a string depending on the content of the string.
      *

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -22,7 +22,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class ReplyToGetSetClearTest extends PreSendTestCase
 {
-
     /**
      * Test adding a non-IDN reply-to address.
      *

--- a/test/PHPMailer/SetErrorTest.php
+++ b/test/PHPMailer/SetErrorTest.php
@@ -24,7 +24,6 @@ use PHPMailer\Test\TestCase;
  */
 final class SetErrorTest extends TestCase
 {
-
     /**
      * Test simple, non-STMP, error registration.
      */

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -24,7 +24,6 @@ use PHPMailer\Test\TestCase;
  */
 final class SetFromTest extends TestCase
 {
-
     /**
      * Test succesfully setting the From, FromName and Sender properties.
      *

--- a/test/PHPMailer/SetTest.php
+++ b/test/PHPMailer/SetTest.php
@@ -22,7 +22,6 @@ use PHPMailer\Test\TestCase;
  */
 final class SetTest extends TestCase
 {
-
     /**
      * Test setting the value of a class property.
      *

--- a/test/PHPMailer/SetWordWrapTest.php
+++ b/test/PHPMailer/SetWordWrapTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\PreSendTestCase;
  */
 final class SetWordWrapTest extends PreSendTestCase
 {
-
     /**
      * Test word-wrapping a message.
      *

--- a/test/PHPMailer/Utf8CharBoundaryTest.php
+++ b/test/PHPMailer/Utf8CharBoundaryTest.php
@@ -24,7 +24,6 @@ use PHPMailer\Test\TestCase;
  */
 final class Utf8CharBoundaryTest extends TestCase
 {
-
     /**
      * Verify that the utf8CharBoundary() returns the correct last character boundary for encoded text.
      *

--- a/test/PHPMailer/ValidateAddressCustomValidatorTest.php
+++ b/test/PHPMailer/ValidateAddressCustomValidatorTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\TestCase;
  */
 final class ValidateAddressCustomValidatorTest extends TestCase
 {
-
     /**
      * Test injecting a one-off custom validator.
      */

--- a/test/PHPMailer/ValidateAddressTest.php
+++ b/test/PHPMailer/ValidateAddressTest.php
@@ -33,7 +33,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class ValidateAddressTest extends TestCase
 {
-
     /**
      * Run before this test class.
      */

--- a/test/PHPMailer/WrapTextTest.php
+++ b/test/PHPMailer/WrapTextTest.php
@@ -23,7 +23,6 @@ use PHPMailer\Test\TestCase;
  */
 final class WrapTextTest extends TestCase
 {
-
     /**
      * Test wrapping text.
      *

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -25,7 +25,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase;
  */
 final class PopBeforeSmtpTest extends TestCase
 {
-
     /**
      * PIDs of any processes we need to kill.
      *

--- a/test/PreSendTestCase.php
+++ b/test/PreSendTestCase.php
@@ -21,7 +21,6 @@ use PHPMailer\Test\TestCase;
  */
 abstract class PreSendTestCase extends TestCase
 {
-
     /**
      * Property names and their values for the test instance of the PHPMailer class.
      *

--- a/test/Security/DenialOfServiceVectorsTest.php
+++ b/test/Security/DenialOfServiceVectorsTest.php
@@ -22,7 +22,6 @@ use PHPMailer\Test\SendTestCase;
  */
 final class DenialOfServiceVectorsTest extends SendTestCase
 {
-
     /**
      * Test this denial of service attack.
      *

--- a/test/SendTestCase.php
+++ b/test/SendTestCase.php
@@ -20,7 +20,6 @@ use Exception;
  */
 abstract class SendTestCase extends PreSendTestCase
 {
-
     /**
      * Translation map for supported $REQUEST keys to the property name in the PHPMailer class.
      *

--- a/test/TestCase.php
+++ b/test/TestCase.php
@@ -24,7 +24,6 @@ use Yoast\PHPUnitPolyfills\TestCases\TestCase as PolyfillTestCase;
  */
 abstract class TestCase extends PolyfillTestCase
 {
-
     /**
      * Whether or not to initialize the PHPMailer object to throw exceptions.
      *


### PR DESCRIPTION
### Composer: update version constraints

Follow up on c1a63391084a9cb55bba53cb341049428aa3a1c0 which enabled PHP 8.1 support, let's make sure that the version constraints of (dev) dependencies are such that PHP 8.1 compatible versions will be installed.

Refs:
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases
* https://github.com/squizlabs/PHP_CodeSniffer/releases

### CS: minor cleanup

PHPCS 3.6.2 added a sniff for a PSR-12 rule which was previously not strictly checked: "No blank line after the opening brace of a class".

This fixes the newly flagged issues.