### PR TITLE
Bug fix for typo in property name (x2)

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1185,6 +1185,7 @@ class PHPMailer
      *
      * @param string $addrstr The address list string
      * @param bool   $useimap Whether to use the IMAP extension to parse the list
+     * @param string $charset The charset to use when decoding the address list string.
      *
      * @return array
      */
@@ -1742,7 +1743,7 @@ class PHPMailer
                 fwrite($mail, $header);
                 fwrite($mail, $body);
                 $result = pclose($mail);
-                $addrinfo = static::parseAddresses($toAddr, true, $this->charSet);
+                $addrinfo = static::parseAddresses($toAddr, true, $this->CharSet);
                 $this->doCallback(
                     ($result === 0),
                     [[$addrinfo['address'], $addrinfo['name']]],
@@ -1905,7 +1906,7 @@ class PHPMailer
         if ($this->SingleTo && count($toArr) > 1) {
             foreach ($toArr as $toAddr) {
                 $result = $this->mailPassthru($toAddr, $this->Subject, $body, $header, $params);
-                $addrinfo = static::parseAddresses($toAddr, true, $this->charSet);
+                $addrinfo = static::parseAddresses($toAddr, true, $this->CharSet);
                 $this->doCallback(
                     $result,
                     [[$addrinfo['address'], $addrinfo['name']]],


### PR DESCRIPTION
The `$CharSet` property name as declared in the class starts with a capital, while there were two places in the code where the property was referred to as `$this->charSet`, which is a non-existent property.

In PHP 8.2, this is regarded as access to a dynamic property and will generate deprecation notices.

In effect, this meant that the `PHPMailer::parseAddresses()` method would be called with `null` as the value for the `$charset` parameter.
This `null` value would then subsequently be passed on to the PHP native `mb_internal_encoding()` function, which now didn't get the correct encoding.

This may have led to mail sending failures due to the address encoding being incorrect. If there are any bug reports open for this, it may be a good idea to evaluate whether they could be related to this bug.

Found by @dseguy via Exakat.

Note: this issue was not flagged by the tests as the tests for the `PHPMailer::parseAddresses()` method, only test the method either with a valid value for encoding òr without the `$charset` parameter set, but not with an explicit `null` value..

As the `$charset` parameter for `PHPMailer::parseAddresses()` has a sensible default value and is not explicitly nullable, adding a test for this incorrect use of the method seems over the top.

I have, however, ensured that the non-nullability of the parameter is now documented for the method.

Refs:
* https://wiki.php.net/rfc/deprecate_dynamic_properties
* https://www.php.net/manual/en/function.mb-internal-encoding.php