### PR TITLE
GH Actions: version update for `codecov/codecov-action`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v2
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true


### PR DESCRIPTION
A while back the `codecov/codecov-action` released a new major.

As per the release notes:
> On February 1, 2022, the v1 uploader will be full sunset and no longer function. This is due to the deprecation of the underlying bash uploader. This version uses the new uploader.

Considering Feb 2022 is creeping closer every day, updating seems prudent.

> Multiple fields have not been transferred from the bash uploader or have been deprecated. Notably many of the `functionalities` and `gcov_` arguments have been removed.

This repo does not seem to be affected by this.

Refs:
* https://github.com/codecov/codecov-action/releases/tag/v2.0.0
* https://github.com/codecov/codecov-action/releases/tag/v2.0.1
* https://github.com/codecov/codecov-action/releases/tag/v2.0.2
* https://github.com/codecov/codecov-action/releases/tag/v2.0.3
* https://github.com/codecov/codecov-action/releases/tag/v2.1.0