### PR TITLE
GH Actions: version update for codecov action runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Send coverage report to Codecov
         if: ${{ success() && matrix.coverage == true }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           files: ./build/logs/clover.xml
           fail_ci_if_error: true


### PR DESCRIPTION
Yet another predefined action has had a major release.

This is, again, mostly just a change of the Node version used by the action itself (from Node 12 to Node 16).

Refs:
* https://github.com/codecov/codecov-action/releases