### PR TITLE
Composer script: show deprecations when linting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "test": "./vendor/bin/phpunit --no-coverage",
         "coverage": "./vendor/bin/phpunit",
         "lint": [
-            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . -e php,phps --exclude vendor --exclude .git --exclude build"
+            "@php ./vendor/php-parallel-lint/php-parallel-lint/parallel-lint . --show-deprecated -e php,phps --exclude vendor --exclude .git --exclude build"
         ]
     }
 }


### PR DESCRIPTION
While rare, there are some deprecations which PHP can show when a file is being linted.
By default these are ignored by PHP-Parallel-Lint.

Apparently though, there is an option to show them (wasn't documented until recently), so let's turn that option on.