### PR TITLE
Composer: update PHP Parallel Lint and Console Highlighter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
         "doctrine/annotations": "^1.2",
-        "php-parallel-lint/php-console-highlighter": "^0.5.0",
-        "php-parallel-lint/php-parallel-lint": "^1.3.1",
+        "php-parallel-lint/php-console-highlighter": "^1.0.0",
+        "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.6.2",


### PR DESCRIPTION
PHP Console Highlighter has released version `1.0.0` and PHP Parallel Lint version `1.3.2` is the first PHP Parallel Lint version which supports PHP Console Highlighter `1.0.0`.

As the minimum supported PHP version is still PHP 5.3 for both, we can safely update both dependency requirements.

Refs:
* https://github.com/php-parallel-lint/PHP-Console-Highlighter/releases/tag/v1.0.0
* https://github.com/php-parallel-lint/PHP-Parallel-Lint/releases/tag/v1.3.2