### PR TITLE
use arrow functions

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3932,9 +3932,7 @@ class PHPMailer
     {
         $this->RecipientsQueue = array_filter(
             $this->RecipientsQueue,
-            static function ($params) use ($kind) {
-                return $params[0] !== $kind;
-            }
+            static fn ($params) => $params[0] !== $kind
         );
     }
 


### PR DESCRIPTION
Anonymous functions with one-liner return statement must use arrow functions.