### PR TITLE
void return

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -889,7 +889,7 @@ class PHPMailer
      *
      * @param string $str
      */
-    protected function edebug($str)
+    protected function edebug($str): void
     {
         if ($this->SMTPDebug <= 0) {
             return;
@@ -944,7 +944,7 @@ class PHPMailer
      *
      * @param bool $isHtml True for HTML mode
      */
-    public function isHTML($isHtml = true)
+    public function isHTML($isHtml = true): void
     {
         if ($isHtml) {
             $this->ContentType = static::CONTENT_TYPE_TEXT_HTML;
@@ -956,7 +956,7 @@ class PHPMailer
     /**
      * Send messages using SMTP.
      */
-    public function isSMTP()
+    public function isSMTP(): void
     {
         $this->Mailer = 'smtp';
     }
@@ -964,7 +964,7 @@ class PHPMailer
     /**
      * Send messages using PHP's mail() function.
      */
-    public function isMail()
+    public function isMail(): void
     {
         $this->Mailer = 'mail';
     }
@@ -972,7 +972,7 @@ class PHPMailer
     /**
      * Send messages using $Sendmail.
      */
-    public function isSendmail()
+    public function isSendmail(): void
     {
         $ini_sendmail_path = ini_get('sendmail_path');
 
@@ -987,7 +987,7 @@ class PHPMailer
     /**
      * Send messages using qmail.
      */
-    public function isQmail()
+    public function isQmail(): void
     {
         $ini_sendmail_path = ini_get('sendmail_path');
 
@@ -2212,7 +2212,7 @@ class PHPMailer
     /**
      * Close the active SMTP session if one exists.
      */
-    public function smtpClose()
+    public function smtpClose(): void
     {
         if ((null !== $this->smtp) && $this->smtp->connected()) {
             $this->smtp->quit();
@@ -2560,7 +2560,7 @@ class PHPMailer
      * You should only do this to plain-text bodies as wrapping HTML tags may break them.
      * This is called automatically by createBody(), so you don't need to call it yourself.
      */
-    public function setWordWrap()
+    public function setWordWrap(): void
     {
         if ($this->WordWrap < 1) {
             return;
@@ -3108,7 +3108,7 @@ class PHPMailer
      * Set the message type.
      * PHPMailer only supports some preset message types, not arbitrary MIME structures.
      */
-    protected function setMessageType()
+    protected function setMessageType(): void
     {
         $type = [];
         if ($this->alternativeExists()) {
@@ -3928,7 +3928,7 @@ class PHPMailer
      *
      * @param string $kind 'to', 'cc', or 'bcc'
      */
-    public function clearQueuedAddresses($kind)
+    public function clearQueuedAddresses($kind): void
     {
         $this->RecipientsQueue = array_filter(
             $this->RecipientsQueue,
@@ -3941,7 +3941,7 @@ class PHPMailer
     /**
      * Clear all To recipients.
      */
-    public function clearAddresses()
+    public function clearAddresses(): void
     {
         foreach ($this->to as $to) {
             unset($this->all_recipients[strtolower($to[0])]);
@@ -3953,7 +3953,7 @@ class PHPMailer
     /**
      * Clear all CC recipients.
      */
-    public function clearCCs()
+    public function clearCCs(): void
     {
         foreach ($this->cc as $cc) {
             unset($this->all_recipients[strtolower($cc[0])]);
@@ -3965,7 +3965,7 @@ class PHPMailer
     /**
      * Clear all BCC recipients.
      */
-    public function clearBCCs()
+    public function clearBCCs(): void
     {
         foreach ($this->bcc as $bcc) {
             unset($this->all_recipients[strtolower($bcc[0])]);
@@ -3977,7 +3977,7 @@ class PHPMailer
     /**
      * Clear all ReplyTo recipients.
      */
-    public function clearReplyTos()
+    public function clearReplyTos(): void
     {
         $this->ReplyTo = [];
         $this->ReplyToQueue = [];
@@ -3986,7 +3986,7 @@ class PHPMailer
     /**
      * Clear all recipient types.
      */
-    public function clearAllRecipients()
+    public function clearAllRecipients(): void
     {
         $this->to = [];
         $this->cc = [];
@@ -3998,7 +3998,7 @@ class PHPMailer
     /**
      * Clear all filesystem, string, and binary attachments.
      */
-    public function clearAttachments()
+    public function clearAttachments(): void
     {
         $this->attachment = [];
     }
@@ -4006,7 +4006,7 @@ class PHPMailer
     /**
      * Clear all custom headers.
      */
-    public function clearCustomHeaders()
+    public function clearCustomHeaders(): void
     {
         $this->CustomHeader = [];
     }
@@ -4016,7 +4016,7 @@ class PHPMailer
      *
      * @param string $msg
      */
-    protected function setError($msg)
+    protected function setError($msg): void
     {
         ++$this->error_count;
         if ('smtp' === $this->Mailer && null !== $this->smtp) {
@@ -4653,7 +4653,7 @@ class PHPMailer
      *
      * @param string $le
      */
-    protected static function setLE($le)
+    protected static function setLE($le): void
     {
         static::$LE = $le;
     }
@@ -4666,7 +4666,7 @@ class PHPMailer
      * @param string $key_pass            Password for private key
      * @param string $extracerts_filename Optional path to chain certificate
      */
-    public function sign($cert_filename, $key_filename, $key_pass, $extracerts_filename = '')
+    public function sign($cert_filename, $key_filename, $key_pass, $extracerts_filename = ''): void
     {
         $this->sign_cert_file = $cert_filename;
         $this->sign_key_file = $key_filename;
@@ -5053,7 +5053,7 @@ class PHPMailer
      * @param string $from
      * @param array  $extra
      */
-    protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from, $extra)
+    protected function doCallback($isSent, $to, $cc, $bcc, $subject, $body, $from, $extra): void
     {
         if (!empty($this->action_function) && is_callable($this->action_function)) {
             call_user_func($this->action_function, $isSent, $to, $cc, $bcc, $subject, $body, $from, $extra);
@@ -5073,7 +5073,7 @@ class PHPMailer
     /**
      * Set an OAuthTokenProvider instance.
      */
-    public function setOAuth(OAuthTokenProvider $oauth)
+    public function setOAuth(OAuthTokenProvider $oauth): void
     {
         $this->oauth = $oauth;
     }

--- a/src/POP3.php
+++ b/src/POP3.php
@@ -335,7 +335,7 @@ class POP3
     /**
      * Disconnect from the POP3 server.
      */
-    public function disconnect()
+    public function disconnect(): void
     {
         $this->sendString('QUIT');
 
@@ -422,7 +422,7 @@ class POP3
      *
      * @param string $error
      */
-    protected function setError($error)
+    protected function setError($error): void
     {
         $this->errors[] = $error;
         if ($this->do_debug >= self::DEBUG_SERVER) {
@@ -452,7 +452,7 @@ class POP3
      * @param string $errfile
      * @param int    $errline
      */
-    protected function catchWarning($errno, $errstr, $errfile, $errline)
+    protected function catchWarning($errno, $errstr, $errfile, $errline): void
     {
         $this->setError(
             'Connecting to the POP3 server raised a PHP warning:' .

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -253,7 +253,7 @@ class SMTP
      * @see SMTP::$Debugoutput
      * @see SMTP::$do_debug
      */
-    protected function edebug($str, $level = 0)
+    protected function edebug($str, $level = 0): void
     {
         if ($level > $this->do_debug) {
             return;
@@ -680,7 +680,7 @@ class SMTP
      *
      * @see quit()
      */
-    public function close()
+    public function close(): void
     {
         $this->setError('');
         $this->server_caps = null;
@@ -844,7 +844,7 @@ class SMTP
      *
      * @param string $type `HELO` or `EHLO`
      */
-    protected function parseHelloFields($type)
+    protected function parseHelloFields($type): void
     {
         $this->server_caps = [];
         $lines = explode("\n", $this->helo_rply);
@@ -1299,7 +1299,7 @@ class SMTP
      *
      * @param bool $enabled
      */
-    public function setVerp($enabled = false)
+    public function setVerp($enabled = false): void
     {
         $this->do_verp = $enabled;
     }
@@ -1322,7 +1322,7 @@ class SMTP
      * @param string $smtp_code    An associated SMTP error code
      * @param string $smtp_code_ex Extended SMTP code
      */
-    protected function setError($message, $detail = '', $smtp_code = '', $smtp_code_ex = '')
+    protected function setError($message, $detail = '', $smtp_code = '', $smtp_code_ex = ''): void
     {
         $this->error = [
             'error' => $message,
@@ -1337,7 +1337,7 @@ class SMTP
      *
      * @param string|callable $method The name of the mechanism to use for debugging output, or a callable to handle it
      */
-    public function setDebugOutput($method = 'echo')
+    public function setDebugOutput($method = 'echo'): void
     {
         $this->Debugoutput = $method;
     }
@@ -1357,7 +1357,7 @@ class SMTP
      *
      * @param int $level
      */
-    public function setDebugLevel($level = 0)
+    public function setDebugLevel($level = 0): void
     {
         $this->do_debug = $level;
     }
@@ -1377,7 +1377,7 @@ class SMTP
      *
      * @param int $timeout The timeout duration in seconds
      */
-    public function setTimeout($timeout = 0)
+    public function setTimeout($timeout = 0): void
     {
         $this->Timeout = $timeout;
     }
@@ -1400,7 +1400,7 @@ class SMTP
      * @param string $errfile The file the error occurred in
      * @param int    $errline The line number the error occurred on
      */
-    protected function errorHandler($errno, $errmsg, $errfile = '', $errline = 0)
+    protected function errorHandler($errno, $errmsg, $errfile = '', $errline = 0): void
     {
         $notice = 'Connection failed.';
         $this->setError(


### PR DESCRIPTION
Add void return type to functions with missing or empty return statements, but priority is given to @return annotations.