### PR TITLE
Automatic text/csv detection

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4470,6 +4470,7 @@ class PHPMailer
             'ics' => 'text/calendar',
             'xml' => 'text/xml',
             'xsl' => 'text/xml',
+            'csv' => 'text/csv',
             'wmv' => 'video/x-ms-wmv',
             'mpeg' => 'video/mpeg',
             'mpe' => 'video/mpeg',


### PR DESCRIPTION
Per [RFC 7111](https://www.rfc-editor.org/rfc/rfc7111) the `text/csv` MIME type should be used for CSV files.

This just adds detection for the `csv` file extension to use this in the automatic type detection.