### PR TITLE
Bugfix invalid DKIM-signature with zero To-addresses

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1891,13 +1891,14 @@ class PHPMailer
         foreach ($this->to as $toaddr) {
             $toArr[] = $this->addrFormat($toaddr);
         }
-        $to = implode(', ', $toArr);
+        $to = trim(implode(', ', $toArr));
         
         //If there are no To-addresses (e.g. when sending only to BCC-addresses)
         //the following should be added to get a correct DKIM-signature.
         //Compare with $this->preSend()
-        if(trim($to) == '') { $to = 'undisclosed-recipients:;'; }
-
+        if ($to === '') {
+            $to = 'undisclosed-recipients:;';
+        }
 
         $params = null;
         //This sets the SMTP envelope sender which gets turned into a return-path header by the receiver

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1892,6 +1892,12 @@ class PHPMailer
             $toArr[] = $this->addrFormat($toaddr);
         }
         $to = implode(', ', $toArr);
+        
+        //If there are no To-addresses (e.g. when sending only to BCC-addresses)
+        //the following should be added to get a correct DKIM-signature.
+        //Compare with $this->preSend()
+        if(trim($to) == '') { $to = 'undisclosed-recipients:;'; }
+
 
         $params = null;
         //This sets the SMTP envelope sender which gets turned into a return-path header by the receiver

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1892,7 +1892,7 @@ class PHPMailer
             $toArr[] = $this->addrFormat($toaddr);
         }
         $to = trim(implode(', ', $toArr));
-        
+
         //If there are no To-addresses (e.g. when sending only to BCC-addresses)
         //the following should be added to get a correct DKIM-signature.
         //Compare with $this->preSend()


### PR DESCRIPTION
Resolves issue #2753 

When using PHP's `mail()` function, and when there are no To-addressees (e.g. only BCC), then the DKIM-signature was not correct. There was a discrepancy between how `mail()` was called (empty `$to`) versus the DKIM-signature (`'undisclosed-recipients:;'`).