### PR TITLE
Don't try to issue RSET on connection errors

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1671,7 +1671,7 @@ class PHPMailer
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
             }
         } catch (Exception $exc) {
-            if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true) {
+            if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true && $this->smtp->connected()) {
                 $this->smtp->reset();
             }
             $this->setError($exc->getMessage());


### PR DESCRIPTION
In case of errors, keep-alive SMTP connections are always reset, but when the error happened while establishing the connection, trying to reset the connection is pointless and just produces another error.