### PR TITLE
fix bug in addAttachment with folder's instead of filenames

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1863,7 +1863,7 @@ class PHPMailer
         if (!static::isPermittedPath($path)) {
             return false;
         }
-        $readable = file_exists($path);
+        $readable = is_file($path);
         //If not a UNC path (expected to start with \\), check read permission, see #2069
         if (strpos($path, '\\\\') !== 0) {
             $readable = $readable && is_readable($path);


### PR DESCRIPTION
fixes a bug when a path is passed into addAttachment. 

https://github.com/PHPMailer/PHPMailer/issues/2782
