### PR TITLE
fix bug error message supressed on close()

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -682,7 +682,6 @@ class SMTP
      */
     public function close()
     {
-        $this->setError('');
         $this->server_caps = null;
         $this->helo_rply = null;
         if (is_resource($this->smtp_conn)) {


### PR DESCRIPTION
fixes error message getting suppressed when the connection is closed.

https://github.com/PHPMailer/PHPMailer/issues/2626
https://github.com/PHPMailer/PHPMailer/issues/2570