### PR TITLE
GH Actions: use semver branch/tag references instead of commit references

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Build Docs
         uses: ./.github/actions/build-docs
       - name: Publish Docs to gh-pages
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages
           folder: docs

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -25,12 +25,12 @@ jobs:
     
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@a12a3943b4bdde767164f792f33f40b04645d846 # v3.0.0
+        uses: actions/checkout@v3
         with:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@e363bfca00e752f91de7b7d2a77340e2e523cb18 # v1.1.1
+        uses: ossf/scorecard-action@e363bfca00e752f91de7b7d2a77340e2e523cb18
         with:
           results_file: results.sarif
           results_format: sarif
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.0.0
+        uses: actions/upload-artifact@v3
         with:
           name: SARIF file
           path: results.sarif
@@ -57,6 +57,6 @@ jobs:
       
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e0e5ded33cabb451ae0a9768fc7b0410bad9ad44 # v1.0.26
+        uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
Most predefined action runners offer a long-running branch or a tag which gets moved every release to allow staying on the "latest" version of a certain major of their action, without having to update the workflow scripts on every release of the action runner.

This works well for action runners which follow semver.

I've reviewed the existing workflows and tweaked the versions used whenever possible to make optimal use of this.

* For the `ossf/scorecard-action` action runner, I have not been able to find a workable tag/branch to fix this on.
    Note: I have remove the "# v1.1.1" comment though as it doesn't get updated by Dependabot and was sorely out of date (you are currently on version `2.0.4`).

With the changes in this PR, Dependabot should become less noisy and will only send in PRs to update the action runner versions when a new major release has been tagged. (save for the one exceptions mentioned above)

I would recommend watching the following repos for new releases:
* https://github.com/actions/checkout
* https://github.com/actions/upload-artifact
* https://github.com/shivammathur/setup-php
* https://github.com/ramsey/composer-install
* https://github.com/nick-fields/retry
* https://github.com/codecov/codecov-action
* https://github.com/JamesIves/github-pages-deploy-action
* https://github.com/ossf/scorecard-action
* https://github.com/github/codeql-action

This will ensure you will get an email with the changelogs for those action runners on all releases, so you can still monitor for changes in the action runners you need to be aware of.

![image](https://user-images.githubusercontent.com/663378/194921427-38cf0d48-4603-493e-8a49-71a68d887cfd.png)

Closes #2794
Closes #2795
