### PR TITLE
Add line ending \n after POP3 quit command

### DIFF
--- a/src/POP3.php
+++ b/src/POP3.php
@@ -337,7 +337,7 @@ class POP3
      */
     public function disconnect()
     {
-        $this->sendString('QUIT');
+        $this->sendString('QUIT' . static::LE);
 
         // RFC 1939 shows POP3 server sending a +OK response to the QUIT command.
         // Try to get it.  Ignore any failures here.


### PR DESCRIPTION
This is required by some POP3 servers which will wait until a newline char which is delimiting all commands. Without it, the login works, but it waits for the full timeout.