### PR TITLE
Avoid POP3 client error message when TCP connection failed

### DIFF
--- a/src/POP3.php
+++ b/src/POP3.php
@@ -337,6 +337,11 @@ class POP3
      */
     public function disconnect()
     {
+        // If could not connect at all, no need to disconnect
+        if ($this->pop_conn === false) {
+            return;
+        }
+
         $this->sendString('QUIT' . static::LE);
 
         // RFC 1939 shows POP3 server sending a +OK response to the QUIT command.

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -42,7 +42,7 @@ final class PopBeforeSmtpTest extends TestCase
              * Set up default include path.
              * Default to the dir above the test dir, i.e. the project home dir.
              */
-            define('PHPMAILER_INCLUDE_DIR', dirname(__DIR__));
+            define('PHPMAILER_INCLUDE_DIR', dirname(dirname(__DIR__)));
         }
     }
 
@@ -54,6 +54,10 @@ final class PopBeforeSmtpTest extends TestCase
         if (DIRECTORY_SEPARATOR === '\\') {
             $this->markTestSkipped('This test needs a non-Windows OS to run');
         }
+
+        // Chdir to test directory as runfakepopserver.sh runs fakepopserver.sh
+        // from its working directory.
+        chdir(PHPMAILER_INCLUDE_DIR . "/test");
     }
 
     /**

--- a/test/POP3/PopBeforeSmtpTest.php
+++ b/test/POP3/PopBeforeSmtpTest.php
@@ -120,4 +120,16 @@ final class PopBeforeSmtpTest extends TestCase
         @shell_exec('kill -TERM ' . escapeshellarg($pid));
         sleep(2);
     }
+
+    /**
+     * Test case when POP3 server is unreachable.
+     */
+    public function testPopBeforeSmtpUnreachable()
+    {
+        // There is no POP3 server at all. Port is different again.
+        self::assertFalse(
+            POP3::popBeforeSmtp('localhost', 1102, 10, 'user', 'xxx'),
+            'POP before SMTP should have failed'
+        );
+    }
 }

--- a/test/fakepopserver.sh
+++ b/test/fakepopserver.sh
@@ -123,4 +123,4 @@ while [ ${BREAK} -eq 0 ] ; do
   fi
 done
 
-echo "+OK Bye!\r\n"
+echo -en "+OK Bye!\r\n"


### PR DESCRIPTION
The disconnect() method throws a TypeError when the TCP connection cannot be created. Error and trace:

fgets(): Argument #1 ($stream) must be of type resource, bool given

phpmailer/phpmailer/src/POP3.php(372): fgets()
phpmailer/phpmailer/src/POP3.php(345): PHPMailer\PHPMailer\POP3->getResponse() phpmailer/phpmailer/src/POP3.php(230): PHPMailer\PHPMailer\POP3->disconnect() PHPMailer\PHPMailer\POP3->authorise()

Reproduce with:

include __DIR__ . "/POP3.php";
\PHPMailer\PHPMailer\POP3::popBeforeSmtp('doesnotexist', 110);