### PR TITLE
Don't let RSET errors overwrite the original error

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1671,11 +1671,11 @@ class PHPMailer
                     return $this->mailSend($this->MIMEHeader, $this->MIMEBody);
             }
         } catch (Exception $exc) {
+            $this->setError($exc->getMessage());
+            $this->edebug($exc->getMessage());
             if ($this->Mailer === 'smtp' && $this->SMTPKeepAlive == true && $this->smtp->connected()) {
                 $this->smtp->reset();
             }
-            $this->setError($exc->getMessage());
-            $this->edebug($exc->getMessage());
             if ($this->exceptions) {
                 throw $exc;
             }


### PR DESCRIPTION
On keep-alive connections, we issue an RSET command in case of errors. But that RSET command may fail, which causes the error information from the original error to be replaced by the error information from the RSET error, which isn't helpful in diagnosing the actual cause. To avoid this problem, we need to extract the error information first, and only issue the RSET command afterwards.