### PR TITLE
added SMTP Transaction ID regex for ZoneMTA mailer

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -187,6 +187,7 @@ class SMTP
         'SendGrid' => '/[\d]{3} Ok: queued as (.*)/',
         'CampaignMonitor' => '/[\d]{3} 2.0.0 OK:([a-zA-Z\d]{48})/',
         'Haraka' => '/[\d]{3} Message Queued \((.*)\)/',
+        'ZoneMTA' => '/[\d]{3} Message queued as \((.*)\)/',
         'Mailjet' => '/[\d]{3} OK queued as (.*)/',
     ];
 


### PR DESCRIPTION
Simple change, just adding the regex so it can match the transaction id.  