### PR TITLE
Update for my previous ZoneMTA transaction id regex fixing the regex …

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -187,7 +187,7 @@ class SMTP
         'SendGrid' => '/[\d]{3} Ok: queued as (.*)/',
         'CampaignMonitor' => '/[\d]{3} 2.0.0 OK:([a-zA-Z\d]{48})/',
         'Haraka' => '/[\d]{3} Message Queued \((.*)\)/',
-        'ZoneMTA' => '/[\d]{3} Message queued as \((.*)\)/',
+        'ZoneMTA' => '/[\d]{3} Message queued as (.*)/',
         'Mailjet' => '/[\d]{3} OK queued as (.*)/',
     ];
 


### PR DESCRIPTION
…as the id does not have parenthesis surrounding it.

sorry about that.