### PR TITLE
Support instantiating from DSN string

### DIFF
--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -22,14 +22,16 @@
 namespace PHPMailer\PHPMailer;
 
 /**
- * Configure PHPMailer via DSN.
+ * Configure PHPMailer with DSN string.
  *
- * @author Oleg Voronkovich (voronkovich) <oleg-voronkovich@yandex.ru>
+ * @see https://en.wikipedia.org/wiki/Data_source_name
+ *
+ * @author Oleg Voronkovich <oleg-voronkovich@yandex.ru>
  */
 class DSNConfigurator
 {
     /**
-     * Configure PHPMailer via DSN.
+     * Configure PHPMailer instance with DSN string.
      *
      * @param PHPMailer $mailer PHPMailer instance
      * @param string    $dsn    DSN
@@ -46,13 +48,13 @@ class DSNConfigurator
     }
 
     /**
-     * Parse DSN.
+     * Parse DSN string.
      *
      * @param string $dsn DSN
      *
      * @throws Exception If DSN is mailformed
      *
-     * @return array configruration
+     * @return array Configruration
      */
     private function parseDSN($dsn)
     {
@@ -72,7 +74,7 @@ class DSNConfigurator
     }
 
     /**
-     * Apply config to mailer.
+     * Apply configuration to mailer.
      *
      * @param PHPMailer $mailer PHPMailer instance
      * @param array     $config Configuration

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -123,7 +123,7 @@ class DSNConfigurator
         $isSMTPS = 'smtps' === $config['scheme'];
 
         if ($isSMTPS) {
-            $mailer->SMTPSecure = 'tls';
+            $mailer->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
         }
 
         $mailer->Host = $config['host'];

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -77,7 +77,7 @@ class DSNConfigurator
      */
     private function parseDSN($dsn)
     {
-        $config = parse_url($dsn);
+        $config = $this->parseUrl($dsn);
 
         if (false === $config || !isset($config['scheme']) || !isset($config['host'])) {
             throw new Exception(
@@ -217,5 +217,26 @@ class DSNConfigurator
                     break;
             }
         }
+    }
+
+    /**
+     * Parse URL.
+     *
+     * @param string $url URL
+     *
+     * @return array Result
+     */
+    private function parseUrl($url)
+    {
+        if (\PHP_VERSION_ID >= 50600 || false === strpos($url, '?')) {
+            return parse_url($url);
+        }
+
+        $chunks = explode('?', $url);
+
+        $result = parse_url($chunks[0]);
+        $result['query'] = $chunks[1];
+
+        return $result;
     }
 }

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -81,7 +81,7 @@ class DSNConfigurator
 
         if (false === $config || !isset($config['scheme']) || !isset($config['host'])) {
             throw new Exception(
-                sprintf('Mailformed DSN: "%s".', $dsn)
+                sprintf('Malformed DSN: "%s".', $dsn)
             );
         }
 

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -102,7 +102,7 @@ class DSNConfigurator
                 throw new Exception(
                     sprintf(
                         'Invalid scheme: "%s". Allowed values: "mail", "sendmail", "qmail", "smtp", "smtps".',
-                        $config['scheme'],
+                        $config['scheme']
                     )
                 );
         }

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -226,7 +226,7 @@ class DSNConfigurator
      *
      * @return array Result
      */
-    private function parseUrl($url)
+    protected function parseUrl($url)
     {
         if (\PHP_VERSION_ID >= 50600 || false === strpos($url, '?')) {
             return parse_url($url);

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -40,6 +40,8 @@ class DSNConfigurator
     {
         $config = $this->parseDSN($dsn);
 
+        $this->applyConfig($mailer, $config);
+
         return $mailer;
     }
 
@@ -67,5 +69,43 @@ class DSNConfigurator
         }
 
         return $config;
+    }
+
+    /**
+     * Apply config to mailer.
+     *
+     * @param PHPMailer $mailer PHPMailer instance
+     * @param array     $config Configuration
+     *
+     * @throws Exception If scheme is invalid
+     *
+     * @return PHPMailer
+     */
+    private function applyConfig(PHPMailer $mailer, $config)
+    {
+        switch ($config['scheme']) {
+            case 'mail':
+                $mailer->isMail();
+                break;
+            case 'sendmail':
+                $mailer->isSendmail();
+                break;
+            case 'qmail':
+                $mailer->isQmail();
+                break;
+            case 'smtp':
+            case 'smtps':
+                $mailer->isSMTP();
+                break;
+            default:
+                throw new Exception(
+                    sprintf(
+                        'Invalid scheme: "%s". Allowed values: "mail", "sendmail", "qmail", "smtp", "smtps".',
+                        $config['scheme'],
+                    )
+                );
+        }
+
+        return $mailer;
     }
 }

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -96,6 +96,7 @@ class DSNConfigurator
             case 'smtp':
             case 'smtps':
                 $mailer->isSMTP();
+                $this->configureSMTP($mailer, $config);
                 break;
             default:
                 throw new Exception(
@@ -104,6 +105,43 @@ class DSNConfigurator
                         $config['scheme'],
                     )
                 );
+        }
+
+        return $mailer;
+    }
+
+    /**
+     * Configure SMTP.
+     *
+     * @param PHPMailer $mailer PHPMailer instance
+     * @param array     $config Configuration
+     *
+     * @return PHPMailer
+     */
+    private function configureSMTP($mailer, $config)
+    {
+        $isSMTPS = 'smtps' === $config['scheme'];
+
+        if ($isSMTPS) {
+            $mailer->SMTPSecure = 'tls';
+        }
+
+        $mailer->Host = $config['host'];
+
+        if (isset($config['port'])) {
+            $mailer->Port = $config['port'];
+        } elseif ($isSMTPS) {
+            $mailer->Port = SMTP::DEFAULT_SECURE_PORT;
+        }
+
+        $mailer->SMTPAuth = isset($config['user']) || isset($config['pass']);
+
+        if (isset($config['user'])) {
+            $mailer->Username = $config['user'];
+        }
+
+        if (isset($config['pass'])) {
+            $mailer->Password = $config['pass'];
         }
 
         return $mailer;

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -31,6 +31,25 @@ namespace PHPMailer\PHPMailer;
 class DSNConfigurator
 {
     /**
+     * Create new PHPMailer instance configured by DSN.
+     *
+     * @param string $dsn        DSN
+     * @param bool   $exceptions Should we throw external exceptions?
+     *
+     * @return PHPMailer
+     */
+    public static function mailer($dsn, $exceptions = null)
+    {
+        static $configurator = null;
+
+        if (null === $configurator) {
+            $configurator = new DSNConfigurator();
+        }
+
+        return $configurator->configure(new PHPMailer($exceptions), $dsn);
+    }
+
+    /**
      * Configure PHPMailer instance with DSN string.
      *
      * @param PHPMailer $mailer PHPMailer instance

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -78,8 +78,6 @@ class DSNConfigurator
      * @param array     $config Configuration
      *
      * @throws Exception If scheme is invalid
-     *
-     * @return PHPMailer
      */
     private function applyConfig(PHPMailer $mailer, $config)
     {
@@ -145,6 +143,14 @@ class DSNConfigurator
         }
     }
 
+    /**
+     * Configure options.
+     *
+     * @param PHPMailer $mailer  PHPMailer instance
+     * @param array     $options Options
+     *
+     * @throws Exception If option is unknown
+     */
     private function configureOptions(PHPMailer $mailer, $options)
     {
         $allowedOptions = get_object_vars($mailer);
@@ -165,7 +171,7 @@ class DSNConfigurator
                     sprintf(
                         'Unknown option: "%s". Allowed values: "%s"',
                         $key,
-                        implode('", "', $allowedOptions),
+                        implode('", "', $allowedOptions)
                     )
                 );
             }

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -191,7 +191,7 @@ class DSNConfigurator
                 case 'Priority':
                 case 'SMTPDebug':
                 case 'WordWrap':
-                    $mailer->$key = (integer) $value;
+                    $mailer->$key = (int) $value;
                     break;
                 default:
                     $mailer->$key = $value;

--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * PHPMailer - PHP email creation and transport class.
+ * PHP Version 5.5.
+ *
+ * @see https://github.com/PHPMailer/PHPMailer/ The PHPMailer GitHub project
+ *
+ * @author    Marcus Bointon (Synchro/coolbru) <phpmailer@synchromedia.co.uk>
+ * @author    Jim Jagielski (jimjag) <jimjag@gmail.com>
+ * @author    Andy Prevost (codeworxtech) <codeworxtech@users.sourceforge.net>
+ * @author    Brent R. Matzelle (original founder)
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2010 - 2012 Jim Jagielski
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ * @note      This program is distributed in the hope that it will be useful - WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+namespace PHPMailer\PHPMailer;
+
+/**
+ * Configure PHPMailer via DSN.
+ *
+ * @author Oleg Voronkovich (voronkovich) <oleg-voronkovich@yandex.ru>
+ */
+class DSNConfigurator
+{
+    /**
+     * Configure PHPMailer via DSN.
+     *
+     * @param PHPMailer $mailer PHPMailer instance
+     * @param string    $dsn    DSN
+     *
+     * @return PHPMailer
+     */
+    public function configure(PHPMailer $mailer, $dsn)
+    {
+        $config = $this->parseDSN($dsn);
+
+        return $mailer;
+    }
+
+    /**
+     * Parse DSN.
+     *
+     * @param string $dsn DSN
+     *
+     * @throws Exception If DSN is mailformed
+     *
+     * @return array configruration
+     */
+    private function parseDSN($dsn)
+    {
+        $config = parse_url($dsn);
+
+        if (false === $config || !isset($config['scheme']) || !isset($config['host'])) {
+            throw new Exception(
+                sprintf('Mailformed DSN: "%s".', $dsn)
+            );
+        }
+
+        if (isset($config['query'])) {
+            parse_str($config['query'], $config['query']);
+        }
+
+        return $config;
+    }
+}

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -833,6 +833,20 @@ class PHPMailer
     }
 
     /**
+     * Create new instance configured by DSN.
+     *
+     * @param string $dsn        DSN
+     * @param bool   $exceptions Should we throw external exceptions?
+     *
+     * @return PHPMailer
+     */
+    public static function fromDSN($dsn, $exceptions = null)
+    {
+        static $configurator = new DSNConfigurator();
+
+        return $configurator->configure(new PHPMailer($exceptions), $dsn);
+    }
+    /**
      * Destructor.
      */
     public function __destruct()
@@ -5122,20 +5136,5 @@ class PHPMailer
     public function setOAuth(OAuthTokenProvider $oauth)
     {
         $this->oauth = $oauth;
-    }
-
-    /**
-     * Create new instance configured by DSN.
-     *
-     * @param string $dsn        DSN
-     * @param bool   $exceptions Should we throw external exceptions?
-     *
-     * @return PHPMailer
-     */
-    public static function fromDSN($dsn, $exceptions = null)
-    {
-        static $configurator = new DSNConfigurator();
-
-        return $configurator->configure(new PHPMailer($exceptions), $dsn);
     }
 }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -842,7 +842,11 @@ class PHPMailer
      */
     public static function fromDSN($dsn, $exceptions = null)
     {
-        static $configurator = new DSNConfigurator();
+        static $configurator = null;
+
+        if (null === $configurator) {
+            $configurator = new DSNConfigurator();
+        }
 
         return $configurator->configure(new PHPMailer($exceptions), $dsn);
     }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -5123,4 +5123,19 @@ class PHPMailer
     {
         $this->oauth = $oauth;
     }
+
+    /**
+     * Create new instance configured by DSN.
+     *
+     * @param string $dsn        DSN
+     * @param bool   $exceptions Should we throw external exceptions?
+     *
+     * @return PHPMailer
+     */
+    public static function fromDSN($dsn, $exceptions = null)
+    {
+        static $configurator = new DSNConfigurator();
+
+        return $configurator->configure(new PHPMailer($exceptions), $dsn);
+    }
 }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -833,24 +833,6 @@ class PHPMailer
     }
 
     /**
-     * Create new instance configured by DSN.
-     *
-     * @param string $dsn        DSN
-     * @param bool   $exceptions Should we throw external exceptions?
-     *
-     * @return PHPMailer
-     */
-    public static function fromDSN($dsn, $exceptions = null)
-    {
-        static $configurator = null;
-
-        if (null === $configurator) {
-            $configurator = new DSNConfigurator();
-        }
-
-        return $configurator->configure(new PHPMailer($exceptions), $dsn);
-    }
-    /**
      * Destructor.
      */
     public function __destruct()

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -56,7 +56,7 @@ class SMTP
      *
      * @var int
      */
-    const DEFAULT_SECURE_PORT = 587;
+    const DEFAULT_SECURE_PORT = 465;
 
     /**
      * The maximum line length allowed by RFC 5321 section 4.5.3.1.6,

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -52,6 +52,13 @@ class SMTP
     const DEFAULT_PORT = 25;
 
     /**
+     * The SMTPs port to use if one is not specified.
+     *
+     * @var int
+     */
+    const DEFAULT_SECURE_PORT = 587;
+
+    /**
      * The maximum line length allowed by RFC 5321 section 4.5.3.1.6,
      * *excluding* a trailing CRLF break.
      *

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -19,8 +19,16 @@ use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
+/**
+ * Test configuring with DSN.
+ *
+ * @covers \PHPMailer\PHPMailer\DSNConfigurator
+ */
 final class DSNConfiguratorTest extends TestCase
 {
+    /**
+     * Test throwing exception if DSN is invalid.
+     */
     public function testInvalidDSN()
     {
         $configurator = new DSNConfigurator();
@@ -31,6 +39,9 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'localhost');
     }
 
+    /**
+     * Test throwing exception if DSN scheme is invalid.
+     */
     public function testInvalidScheme()
     {
         $configurator = new DSNConfigurator();
@@ -41,6 +52,9 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'ftp://localhost');
     }
 
+    /**
+     * Test cofiguring mail.
+     */
     public function testConfigureMail()
     {
         $configurator = new DSNConfigurator();
@@ -50,6 +64,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Mailer, 'mail');
     }
 
+    /**
+     * Test cofiguring sendmail.
+     */
     public function testConfigureSendmail()
     {
         $configurator = new DSNConfigurator();
@@ -59,6 +76,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Mailer, 'sendmail');
     }
 
+    /**
+     * Test cofiguring qmail.
+     */
     public function testConfigureQmail()
     {
         $configurator = new DSNConfigurator();
@@ -68,6 +88,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Mailer, 'qmail');
     }
 
+    /**
+     * Test cofiguring SMTP without authentication.
+     */
     public function testConfigureSmtpWithoutAuthentication()
     {
         $configurator = new DSNConfigurator();
@@ -79,6 +102,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertFalse($this->Mail->SMTPAuth);
     }
 
+    /**
+     * Test cofiguring SMTP with authentication.
+     */
     public function testConfigureSmtpWithAuthentication()
     {
         $configurator = new DSNConfigurator();
@@ -93,6 +119,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Password, 'pass');
     }
 
+    /**
+     * Test cofiguring SMTP without port.
+     */
     public function testConfigureSmtpWithoutPort()
     {
         $configurator = new DSNConfigurator();
@@ -104,6 +133,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_PORT);
     }
 
+    /**
+     * Test cofiguring SMTP with port.
+     */
     public function testConfigureSmtpWitPort()
     {
         $configurator = new DSNConfigurator();
@@ -115,6 +147,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Port, 2525);
     }
 
+    /**
+     * Test cofiguring SMTPs without port.
+     */
     public function testConfigureSmtpsWithoutPort()
     {
         $configurator = new DSNConfigurator();
@@ -132,6 +167,9 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Password, 'pass');
     }
 
+    /**
+     * Test cofiguring SMTPs with port.
+     */
     public function testConfigureWithUnknownOption()
     {
         $configurator = new DSNConfigurator();
@@ -142,6 +180,9 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'mail://locahost?UnknownOption=Value');
     }
 
+    /**
+     * Test cofiguring options with query sting.
+     */
     public function testConfigureWithOptions()
     {
         $configurator = new DSNConfigurator();

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -200,12 +200,10 @@ final class DSNConfiguratorTest extends TestCase
 
     /**
      * Test shortcut.
-     *
-     * @covers \PHPMailer\PHPMailer\PHPMailer::fromDSN
      */
     public function testShorcut()
     {
-        $mailer = PHPMailer::fromDSN('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
+        $mailer = DSNConfigurator::mailer('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
 
         self::assertEquals($mailer->Mailer, 'smtp');
         self::assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -28,4 +28,32 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'localhost');
     }
+
+    public function testInvalidScheme()
+    {
+        $configurator = new DSNConfigurator();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Invalid scheme: "ftp".');
+
+        $configurator->configure($this->Mail, 'ftp://localhost');
+    }
+
+    public function testConfigureSendmail()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'sendmail://localhost');
+
+        $this->assertEquals($this->Mail->Mailer, 'sendmail');
+    }
+
+    public function testConfigureSmtp()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'smtp://localhost');
+
+        $this->assertEquals($this->Mail->Mailer, 'smtp');
+    }
 }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -194,4 +194,27 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->AllowEmpty, true);
         $this->assertEquals($this->Mail->WordWrap, 78);
     }
+
+    /**
+     * Test shortcut.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::fromDSN
+     */
+    public function testShorcut()
+    {
+        $mailer = PHPMailer::fromDSN('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
+
+        $this->assertEquals($mailer->Mailer, 'smtp');
+        $this->assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+
+        $this->assertEquals($mailer->Host, 'smtp.gmail.com');
+        $this->assertEquals($mailer->Port, SMTP::DEFAULT_SECURE_PORT);
+
+        $this->assertTrue($mailer->SMTPAuth);
+        $this->assertEquals($mailer->Username, 'user@gmail.com');
+        $this->assertEquals($mailer->Password, 'secret');
+
+        $this->assertEquals($mailer->SMTPDebug, 3);
+        $this->assertEquals($mailer->Timeout, 1000);
+    }
 }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -15,6 +15,7 @@ namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\DSNConfigurator;
 use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
 final class DSNConfiguratorTest extends TestCase
@@ -48,12 +49,42 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Mailer, 'sendmail');
     }
 
-    public function testConfigureSmtp()
+    public function testConfigureSmtpWithoutAuthentication()
     {
         $configurator = new DSNConfigurator();
 
         $configurator->configure($this->Mail, 'smtp://localhost');
 
         $this->assertEquals($this->Mail->Mailer, 'smtp');
+        $this->assertEquals($this->Mail->Host, 'localhost');
+        $this->assertFalse($this->Mail->SMTPAuth);
+    }
+
+    public function testConfigureSmtpWithAuthentication()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'smtp://user:pass@remotehost');
+
+        $this->assertEquals($this->Mail->Mailer, 'smtp');
+        $this->assertTrue($this->Mail->SMTPAuth);
+        $this->assertEquals($this->Mail->Host, 'remotehost');
+        $this->assertEquals($this->Mail->Username, 'user');
+        $this->assertEquals($this->Mail->Password, 'pass');
+    }
+
+    public function testConfigureSmtpsWithoutPort()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'smtps://user:pass@remotehost');
+
+        $this->assertEquals($this->Mail->Mailer, 'smtp');
+        $this->assertEquals($this->Mail->SMTPSecure, 'tls');
+        $this->assertTrue($this->Mail->SMTPAuth);
+        $this->assertEquals($this->Mail->Host, 'remotehost');
+        $this->assertEquals($this->Mail->Username, 'user');
+        $this->assertEquals($this->Mail->Password, 'pass');
+        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
     }
 }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -61,7 +61,7 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'mail://localhost');
 
-        $this->assertEquals($this->Mail->Mailer, 'mail');
+        self::assertEquals($this->Mail->Mailer, 'mail');
     }
 
     /**
@@ -73,7 +73,7 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'sendmail://localhost');
 
-        $this->assertEquals($this->Mail->Mailer, 'sendmail');
+        self::assertEquals($this->Mail->Mailer, 'sendmail');
     }
 
     /**
@@ -85,7 +85,7 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'qmail://localhost');
 
-        $this->assertEquals($this->Mail->Mailer, 'qmail');
+        self::assertEquals($this->Mail->Mailer, 'qmail');
     }
 
     /**
@@ -97,9 +97,9 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'smtp://localhost');
 
-        $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->Host, 'localhost');
-        $this->assertFalse($this->Mail->SMTPAuth);
+        self::assertEquals($this->Mail->Mailer, 'smtp');
+        self::assertEquals($this->Mail->Host, 'localhost');
+        self::assertFalse($this->Mail->SMTPAuth);
     }
 
     /**
@@ -111,12 +111,12 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'smtp://user:pass@remotehost');
 
-        $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->Host, 'remotehost');
+        self::assertEquals($this->Mail->Mailer, 'smtp');
+        self::assertEquals($this->Mail->Host, 'remotehost');
 
-        $this->assertTrue($this->Mail->SMTPAuth);
-        $this->assertEquals($this->Mail->Username, 'user');
-        $this->assertEquals($this->Mail->Password, 'pass');
+        self::assertTrue($this->Mail->SMTPAuth);
+        self::assertEquals($this->Mail->Username, 'user');
+        self::assertEquals($this->Mail->Password, 'pass');
     }
 
     /**
@@ -128,9 +128,9 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'smtp://localhost');
 
-        $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->Host, 'localhost');
-        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_PORT);
+        self::assertEquals($this->Mail->Mailer, 'smtp');
+        self::assertEquals($this->Mail->Host, 'localhost');
+        self::assertEquals($this->Mail->Port, SMTP::DEFAULT_PORT);
     }
 
     /**
@@ -142,9 +142,9 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'smtp://localhost:2525');
 
-        $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->Host, 'localhost');
-        $this->assertEquals($this->Mail->Port, 2525);
+        self::assertEquals($this->Mail->Mailer, 'smtp');
+        self::assertEquals($this->Mail->Host, 'localhost');
+        self::assertEquals($this->Mail->Port, 2525);
     }
 
     /**
@@ -156,15 +156,15 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'smtps://user:pass@remotehost');
 
-        $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+        self::assertEquals($this->Mail->Mailer, 'smtp');
+        self::assertEquals($this->Mail->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
 
-        $this->assertEquals($this->Mail->Host, 'remotehost');
-        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
+        self::assertEquals($this->Mail->Host, 'remotehost');
+        self::assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
 
-        $this->assertTrue($this->Mail->SMTPAuth);
-        $this->assertEquals($this->Mail->Username, 'user');
-        $this->assertEquals($this->Mail->Password, 'pass');
+        self::assertTrue($this->Mail->SMTPAuth);
+        self::assertEquals($this->Mail->Username, 'user');
+        self::assertEquals($this->Mail->Password, 'pass');
     }
 
     /**
@@ -189,10 +189,10 @@ final class DSNConfiguratorTest extends TestCase
 
         $configurator->configure($this->Mail, 'sendmail://localhost?Sendmail=/usr/local/bin/sendmail&AllowEmpty=1&WordWrap=78');
 
-        $this->assertEquals($this->Mail->Mailer, 'sendmail');
-        $this->assertEquals($this->Mail->Sendmail, '/usr/local/bin/sendmail');
-        $this->assertEquals($this->Mail->AllowEmpty, true);
-        $this->assertEquals($this->Mail->WordWrap, 78);
+        self::assertEquals($this->Mail->Mailer, 'sendmail');
+        self::assertEquals($this->Mail->Sendmail, '/usr/local/bin/sendmail');
+        self::assertEquals($this->Mail->AllowEmpty, true);
+        self::assertEquals($this->Mail->WordWrap, 78);
     }
 
     /**
@@ -204,17 +204,17 @@ final class DSNConfiguratorTest extends TestCase
     {
         $mailer = PHPMailer::fromDSN('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
 
-        $this->assertEquals($mailer->Mailer, 'smtp');
-        $this->assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+        self::assertEquals($mailer->Mailer, 'smtp');
+        self::assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
 
-        $this->assertEquals($mailer->Host, 'smtp.gmail.com');
-        $this->assertEquals($mailer->Port, SMTP::DEFAULT_SECURE_PORT);
+        self::assertEquals($mailer->Host, 'smtp.gmail.com');
+        self::assertEquals($mailer->Port, SMTP::DEFAULT_SECURE_PORT);
 
-        $this->assertTrue($mailer->SMTPAuth);
-        $this->assertEquals($mailer->Username, 'user@gmail.com');
-        $this->assertEquals($mailer->Password, 'secret');
+        self::assertTrue($mailer->SMTPAuth);
+        self::assertEquals($mailer->Username, 'user@gmail.com');
+        self::assertEquals($mailer->Password, 'secret');
 
-        $this->assertEquals($mailer->SMTPDebug, 3);
-        $this->assertEquals($mailer->Timeout, 1000);
+        self::assertEquals($mailer->SMTPDebug, 3);
+        self::assertEquals($mailer->Timeout, 1000);
     }
 }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -201,7 +201,7 @@ final class DSNConfiguratorTest extends TestCase
     /**
      * Test shortcut.
      */
-    public function testShorcut()
+    public function testShortcut()
     {
         $mailer = DSNConfigurator::mailer('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
 

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   http://www.gnu.org/copyleft/lesser.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\DSNConfigurator;
+use PHPMailer\PHPMailer\Exception;
+use PHPMailer\Test\TestCase;
+
+final class DSNConfiguratorTest extends TestCase
+{
+    public function testInvalidDSN()
+    {
+        $configurator = new DSNConfigurator();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Mailformed DSN: "localhost".');
+
+        $configurator->configure($this->Mail, 'localhost');
+    }
+}

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -34,7 +34,7 @@ final class DSNConfiguratorTest extends TestCase
         $configurator = new DSNConfigurator();
 
         $this->expectException(Exception::class);
-        $this->expectExceptionMessage('Mailformed DSN: "localhost".');
+        $this->expectExceptionMessage('Malformed DSN: "localhost".');
 
         $configurator->configure($this->Mail, 'localhost');
     }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -131,4 +131,26 @@ final class DSNConfiguratorTest extends TestCase
         $this->assertEquals($this->Mail->Username, 'user');
         $this->assertEquals($this->Mail->Password, 'pass');
     }
+
+    public function testConfigureWithUnknownOption()
+    {
+        $configurator = new DSNConfigurator();
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Unknown option: "UnknownOption".');
+
+        $configurator->configure($this->Mail, 'mail://locahost?UnknownOption=Value');
+    }
+
+    public function testConfigureWithOptions()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'sendmail://localhost?Sendmail=/usr/local/bin/sendmail&AllowEmpty=1&WordWrap=78');
+
+        $this->assertEquals($this->Mail->Mailer, 'sendmail');
+        $this->assertEquals($this->Mail->Sendmail, '/usr/local/bin/sendmail');
+        $this->assertEquals($this->Mail->AllowEmpty, true);
+        $this->assertEquals($this->Mail->WordWrap, 78);
+    }
 }

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -187,7 +187,10 @@ final class DSNConfiguratorTest extends TestCase
     {
         $configurator = new DSNConfigurator();
 
-        $configurator->configure($this->Mail, 'sendmail://localhost?Sendmail=/usr/local/bin/sendmail&AllowEmpty=1&WordWrap=78');
+        $configurator->configure(
+            $this->Mail,
+            'sendmail://localhost?Sendmail=/usr/local/bin/sendmail&AllowEmpty=1&WordWrap=78'
+        );
 
         self::assertEquals($this->Mail->Mailer, 'sendmail');
         self::assertEquals($this->Mail->Sendmail, '/usr/local/bin/sendmail');

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -15,6 +15,7 @@ namespace PHPMailer\Test\PHPMailer;
 
 use PHPMailer\PHPMailer\DSNConfigurator;
 use PHPMailer\PHPMailer\Exception;
+use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\PHPMailer\SMTP;
 use PHPMailer\Test\TestCase;
 
@@ -40,6 +41,15 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'ftp://localhost');
     }
 
+    public function testConfigureMail()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'mail://localhost');
+
+        $this->assertEquals($this->Mail->Mailer, 'mail');
+    }
+
     public function testConfigureSendmail()
     {
         $configurator = new DSNConfigurator();
@@ -47,6 +57,15 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'sendmail://localhost');
 
         $this->assertEquals($this->Mail->Mailer, 'sendmail');
+    }
+
+    public function testConfigureQmail()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'qmail://localhost');
+
+        $this->assertEquals($this->Mail->Mailer, 'qmail');
     }
 
     public function testConfigureSmtpWithoutAuthentication()
@@ -67,10 +86,33 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'smtp://user:pass@remotehost');
 
         $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertTrue($this->Mail->SMTPAuth);
         $this->assertEquals($this->Mail->Host, 'remotehost');
+
+        $this->assertTrue($this->Mail->SMTPAuth);
         $this->assertEquals($this->Mail->Username, 'user');
         $this->assertEquals($this->Mail->Password, 'pass');
+    }
+
+    public function testConfigureSmtpWithoutPort()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'smtp://localhost');
+
+        $this->assertEquals($this->Mail->Mailer, 'smtp');
+        $this->assertEquals($this->Mail->Host, 'localhost');
+        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_PORT);
+    }
+
+    public function testConfigureSmtpWitPort()
+    {
+        $configurator = new DSNConfigurator();
+
+        $configurator->configure($this->Mail, 'smtp://localhost:2525');
+
+        $this->assertEquals($this->Mail->Mailer, 'smtp');
+        $this->assertEquals($this->Mail->Host, 'localhost');
+        $this->assertEquals($this->Mail->Port, 2525);
     }
 
     public function testConfigureSmtpsWithoutPort()
@@ -80,11 +122,13 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'smtps://user:pass@remotehost');
 
         $this->assertEquals($this->Mail->Mailer, 'smtp');
-        $this->assertEquals($this->Mail->SMTPSecure, 'tls');
-        $this->assertTrue($this->Mail->SMTPAuth);
+        $this->assertEquals($this->Mail->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+
         $this->assertEquals($this->Mail->Host, 'remotehost');
+        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
+
+        $this->assertTrue($this->Mail->SMTPAuth);
         $this->assertEquals($this->Mail->Username, 'user');
         $this->assertEquals($this->Mail->Password, 'pass');
-        $this->assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
     }
 }


### PR DESCRIPTION
This PR adds an ability to configure PHPMailer with [DSN](https://en.wikipedia.org/wiki/Data_source_name) string. For example:
```php
$mailer = DSNConfigurator::mailer('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
```
This feature is essential for developing [12-factor apps](https://12factor.net/config) which configured by environment variables:
```php
$mailer = DSNConfigurator::mailer(getenv('MAIL_URL'));
```
## Configuraton

Supported protocols:

- `mail`
- `sendmail`
- `qmail`
- `smtp`
- `smtps`

Additional configuration can be applied via [query string](https://en.wikipedia.org/wiki/Query_string):
```php
$mailer = DSNConfigurator::mailer('mail://localhost?XMailer=SuperMailer&FromName=CoolSite');
```
