### PR TITLE
Composer: update some CS related dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,13 @@
         "ext-hash": "*"
     },
     "require-dev": {
-        "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
+        "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
         "doctrine/annotations": "^1.2.6 || ^1.13.3",
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
         "roave/security-advisories": "dev-latest",
-        "squizlabs/php_codesniffer": "^3.7.1",
+        "squizlabs/php_codesniffer": "^3.7.2",
         "yoast/phpunit-polyfills": "^1.0.4"
     },
     "suggest": {


### PR DESCRIPTION
The Composer PHPCS plugin has released its 1.0.0 version. :tada:

As minors below a 1.0 are considered as majors by Composer, this needs an update to the `composer.json` file to get access to the new version. And as PHPCS has also released a new version, may as well update that as well.

Refs:
* https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0
* https://github.com/squizlabs/PHP_CodeSniffer/releases/tag/3.7.2