### PR TITLE
Prevent PHP8+ Error 8192 - strlen(): Passing null to parameter #1 ($s…

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4270,7 +4270,7 @@ class PHPMailer
     {
         preg_match_all('/(?<!-)(src|background)=["\'](.*)["\']/Ui', $message, $images);
         if (array_key_exists(2, $images)) {
-            if (strlen($basedir) > 1 && '/' !== substr($basedir, -1)) {
+            if ($basedir && strlen($basedir) > 1 && '/' !== substr($basedir, -1)) {
                 //Ensure $basedir has a trailing /
                 $basedir .= '/';
             }


### PR DESCRIPTION
…tring) of type string is deprecated