### PR TITLE
fix(SMTP): set SMTP Timelimit same as Timeout

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2114,6 +2114,7 @@ class PHPMailer
         }
 
         $this->smtp->setTimeout($this->Timeout);
+        $this->smtp->setTimelimit($this->Timeout);
         $this->smtp->setDebugLevel($this->SMTPDebug);
         $this->smtp->setDebugOutput($this->Debugoutput);
         $this->smtp->setVerp($this->do_verp);

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -1400,6 +1400,26 @@ class SMTP
     }
 
     /**
+     * Set SMTP timelimit.
+     *
+     * @param int $timelimit The timelimit duration in seconds
+     */
+    public function setTimelimit($timelimit = 0)
+    {
+        $this->Timelimit = $timelimit;
+    }
+
+    /**
+     * Get SMTP timelimit.
+     *
+     * @return int
+     */
+    public function getTimelimit()
+    {
+        return $this->Timelimit;
+    }
+
+    /**
      * Reports an error number and string.
      *
      * @param int    $errno   The error number returned by PHP

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -1384,7 +1384,7 @@ class SMTP
      *
      * @param int $timeout The timeout duration in seconds
      */
-    public function setTimeout($timeout = 0)
+    public function setTimeout($timeout)
     {
         $this->Timeout = $timeout;
     }
@@ -1404,7 +1404,7 @@ class SMTP
      *
      * @param int $timelimit The timelimit duration in seconds
      */
-    public function setTimelimit($timelimit = 0)
+    public function setTimelimit($timelimit)
     {
         $this->Timelimit = $timelimit;
     }


### PR DESCRIPTION
In case of having problems in the SMTP server after the connection, the Timeout set wasn't being applied. This PR set the Timelimit value with the same value as Timeout to fix it.