### PR TITLE
fix: null issue in trim method

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1571,7 +1571,10 @@ class PHPMailer
 
             //Validate From, Sender, and ConfirmReadingTo addresses
             foreach (['From', 'Sender', 'ConfirmReadingTo'] as $address_kind) {
-                $this->{$address_kind} = trim($this->{$address_kind} ?? '');
+                if($this->{$address_kind} === null) {
+                    $this->{$address_kind} = '';
+                }
+                $this->{$address_kind} = trim($this->{$address_kind});
                 if (empty($this->{$address_kind})) {
                     continue;
                 }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1571,7 +1571,7 @@ class PHPMailer
 
             //Validate From, Sender, and ConfirmReadingTo addresses
             foreach (['From', 'Sender', 'ConfirmReadingTo'] as $address_kind) {
-                $this->{$address_kind} = trim($this->{$address_kind});
+                $this->{$address_kind} = trim($this->{$address_kind} ?? '');
                 if (empty($this->{$address_kind})) {
                     continue;
                 }

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1571,8 +1571,9 @@ class PHPMailer
 
             //Validate From, Sender, and ConfirmReadingTo addresses
             foreach (['From', 'Sender', 'ConfirmReadingTo'] as $address_kind) {
-                if($this->{$address_kind} === null) {
+                if ($this->{$address_kind} === null) {
                     $this->{$address_kind} = '';
+                    continue;
                 }
                 $this->{$address_kind} = trim($this->{$address_kind});
                 if (empty($this->{$address_kind})) {


### PR DESCRIPTION
fixes : #2959

Passing null to parameter #1 ($string) of type string is deprecated