### PR TITLE
Add methods to update or clear custom headers by name.

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4059,6 +4059,30 @@ class PHPMailer
     }
 
     /**
+     * Clear a specific custom header.
+     */
+    public function clearCustomHeader($name)
+    {
+        foreach ($this->CustomHeader as $k => $pair) {
+            if ($pair[0] == $name) {
+                unset($this->CustomHeader[$k]);
+            }
+        }
+    }
+
+    /**
+     * Replace a custom header.
+     */
+    public function replaceCustomHeader($name, $value)
+    {
+        foreach ($this->CustomHeader as $k => $pair) {
+            if ($pair[0] == $name) {
+                $this->CustomHeader[$k] = [$name, $value];
+            }
+        }
+    }
+
+    /**
      * Add an error message to the error container.
      *
      * @param string $msg

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4077,9 +4077,18 @@ class PHPMailer
     {
         foreach ($this->CustomHeader as $k => $pair) {
             if ($pair[0] == $name) {
+                if (strpbrk($name . $value, "\r\n") !== false) {
+                    if ($this->exceptions) {
+                        throw new Exception($this->lang('invalid_header'));
+                    }
+
+                    return false;
+                }
                 $this->CustomHeader[$k] = [$name, $value];
             }
         }
+
+        return true;
     }
 
     /**

--- a/test/PHPMailer/CustomHeaderTest.php
+++ b/test/PHPMailer/CustomHeaderTest.php
@@ -191,6 +191,23 @@ final class CustomHeaderTest extends TestCase
     }
 
     /**
+     * Test removing previously set custom header.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::clearCustomHeader
+     */
+    public function testClearCustomHeader()
+    {
+        $this->Mail->addCustomHeader('foo', 'bar');
+        self::assertSame([['foo', 'bar']], $this->Mail->getCustomHeaders());
+
+        $this->Mail->clearCustomHeader('foo');
+
+        $cleared = $this->Mail->getCustomHeaders();
+        self::assertIsArray($cleared);
+        self::assertEmpty($cleared);
+    }
+
+    /**
      * Test removing previously set custom headers.
      *
      * @covers \PHPMailer\PHPMailer\PHPMailer::clearCustomHeaders
@@ -221,5 +238,23 @@ final class CustomHeaderTest extends TestCase
 
         $mail = new PHPMailer(true);
         $mail->addCustomHeader('SomeHeader', "Some\n Value");
+    }
+
+    /**
+     * Test replacing a previously set custom header.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::replaceCustomHeader
+     */
+    public function testReplaceCustomHeader()
+    {
+        $this->Mail->addCustomHeader('foo', 'bar');
+        $this->Mail->replaceCustomHeader('foo', 'baz');
+
+        // Test retrieving the custom header(s) and verify the updated value is seet.
+        self::assertSame(
+            [['foo', 'baz']],
+            $this->Mail->getCustomHeaders(),
+            'Custom header does not contain expected update'
+        );
     }
 }


### PR DESCRIPTION
When sending a personalized email blast, it is sometimes useful to just update the "to" address and the body (rather than re-creating the entire email object). It is also useful to update the custom "List-Unsubscribe" header since it can contain a URL that is specific to each recipient. Currently, PHPMailer only has a method to clear ALL custom headers. However, we might want to keep some custom headers and only clear a specific one.

This PR adds the ability to clear or update a specific custom header by name.

Example one: clear a custom header:

    $mail->clearCustomHeader('List-Unsubscribe');

Example two: update a custom header:

    $mail->replaceCustomHeader('List-Unsubscribe', '<https://yourdomain/unsubscribe/hash>');
