### PR TITLE
Update PHPMailerAutoload.php

### DIFF
--- a/PHPMailerAutoload.php
+++ b/PHPMailerAutoload.php
@@ -42,7 +42,7 @@ if (version_compare(PHP_VERSION, '5.1.2', '>=')) {
      * Fall back to traditional autoload for old PHP versions
      * @param string $classname The name of the class to load
      */
-    function __autoload($classname)
+    function spl_autoload_register($classname)
     {
         PHPMailerAutoload($classname);
     }


### PR DESCRIPTION
I have got an error:
Fatal error: __autoload() is no longer supported, use spl_autoload_register() instead in D:\xampp\htdocs\test\PHPMailer\PHPMailerAutoload.php on line 45

Then I edit line no 45:
function spl_autoload_register($classname)

Now my error is fixed. 
This reason for this error is
1. SPL autoloading was introduced in PHP 5.1.2
2.  __autoload() is no longer supported So just change the function name