### PR TITLE
Adds missing translations

### DIFF
--- a/language/phpmailer.lang-es.php
+++ b/language/phpmailer.lang-es.php
@@ -5,27 +5,32 @@
  * @package PHPMailer
  * @author Matt Sturdy <matt.sturdy@gmail.com>
  * @author Crystopher Glodzienski Cardoso <crystopher.glodzienski@gmail.com>
+ * @author Daniel Cruz <danicruz0415@gmail.com>
  */
 
 $PHPMAILER_LANG['authenticate']         = 'Error SMTP: Imposible autentificar.';
+$PHPMAILER_LANG['buggy_php']            = 'Tu versión de PHP está afectada por un bug que puede resultar en mensajes corruptos. Para arreglarlo, cambia a enviar usando SMTP, deshabilita la opción mail.add_x_header en tu php.ini, cambia a MacOS o Linux, o actualiza tu PHP a la versión 7.0.17+ o 7.1.3+.';
 $PHPMAILER_LANG['connect_host']         = 'Error SMTP: Imposible conectar al servidor SMTP.';
 $PHPMAILER_LANG['data_not_accepted']    = 'Error SMTP: Datos no aceptados.';
 $PHPMAILER_LANG['empty_message']        = 'El cuerpo del mensaje está vacío.';
 $PHPMAILER_LANG['encoding']             = 'Codificación desconocida: ';
 $PHPMAILER_LANG['execute']              = 'Imposible ejecutar: ';
+$PHPMAILER_LANG['extension_missing']    = 'Extensión faltante: ';
 $PHPMAILER_LANG['file_access']          = 'Imposible acceder al archivo: ';
 $PHPMAILER_LANG['file_open']            = 'Error de Archivo: Imposible abrir el archivo: ';
 $PHPMAILER_LANG['from_failed']          = 'La(s) siguiente(s) direcciones de remitente fallaron: ';
 $PHPMAILER_LANG['instantiate']          = 'Imposible crear una instancia de la función Mail.';
 $PHPMAILER_LANG['invalid_address']      = 'Imposible enviar: dirección de email inválido: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nombre o valor de encabezado no válido';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Hostentry inválido: ';
+$PHPMAILER_LANG['invalid_host']         = 'Host inválido: ';
 $PHPMAILER_LANG['mailer_not_supported'] = ' mailer no está soportado.';
 $PHPMAILER_LANG['provide_address']      = 'Debe proporcionar al menos una dirección de email de destino.';
 $PHPMAILER_LANG['recipients_failed']    = 'Error SMTP: Los siguientes destinos fallaron: ';
 $PHPMAILER_LANG['signing']              = 'Error al firmar: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falló.';
-$PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
-$PHPMAILER_LANG['variable_set']         = 'No se pudo configurar la variable: ';
-$PHPMAILER_LANG['extension_missing']    = 'Extensión faltante: ';
 $PHPMAILER_LANG['smtp_code']            = 'Código del servidor SMTP: ';
 $PHPMAILER_LANG['smtp_code_ex']         = 'Información adicional del servidor SMTP: ';
-$PHPMAILER_LANG['invalid_header']       = 'Nombre o valor de encabezado no válido';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP Connect() falló.';
+$PHPMAILER_LANG['smtp_detail']          = 'Detalle: ';
+$PHPMAILER_LANG['smtp_error']           = 'Error del servidor SMTP: ';
+$PHPMAILER_LANG['variable_set']         = 'No se pudo configurar la variable: ';


### PR DESCRIPTION
Adds missing translations:

- buggy_php
- invalid_hostentry
- invalid_host
- smtp_detail

Also I reordered some translations to match the original English definition and be more consistent. Elements reordered:
- extension_missing
- smtp_code
- smtp_code_ex
- invalid_header
I stay tuned for any feedback