### PR TITLE
Remove potential ending line break when using edebug() with LoggerInterface

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -280,6 +280,8 @@ class SMTP
         }
         //Is this a PSR-3 logger?
         if ($this->Debugoutput instanceof \Psr\Log\LoggerInterface) {
+            //Remove ending line breaks potentialy added by calls to SMTP::client_send()
+            $str = preg_replace('/[' . static::LE .']+$/', '', $str);
             $this->Debugoutput->debug($str);
 
             return;

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -281,7 +281,7 @@ class SMTP
         //Is this a PSR-3 logger?
         if ($this->Debugoutput instanceof \Psr\Log\LoggerInterface) {
             //Remove ending line breaks potentialy added by calls to SMTP::client_send()
-            $str = preg_replace('/[' . static::LE .']+$/', '', $str);
+            $str = preg_replace('/[\r\n]+$/', '', $str);
             $this->Debugoutput->debug($str);
 
             return;

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -281,7 +281,7 @@ class SMTP
         //Is this a PSR-3 logger?
         if ($this->Debugoutput instanceof \Psr\Log\LoggerInterface) {
             //Remove ending line breaks potentialy added by calls to SMTP::client_send()
-            $str = preg_replace('/[\r\n]+$/', '', $str);
+            $str = rtrim($str, "\n\r");
             $this->Debugoutput->debug($str);
 
             return;


### PR DESCRIPTION
This PR is for #3045.
