### PR TITLE
Additional operands for GoogleAPI for .json management

### DIFF
--- a/examples/sendoauth2.phps
+++ b/examples/sendoauth2.phps
@@ -70,7 +70,7 @@ try {
             'tenant'                      => 'long string',           // MSFT tenant GUID. Null for Gmail
 
             'hostedDomain'                => 'mydomain.com',          // Any Google (and optional). Null for MSFT
-            
+
             'projectID'                   => 'string',                // GoogleAPI only. Else null
             'serviceAccountName'          => 'string',                // GoogleAPI service account only. Else null
             'impersonate'                 => 'you@mydomain.com',      // Google API service account only. Else null

--- a/examples/sendoauth2.phps
+++ b/examples/sendoauth2.phps
@@ -70,10 +70,16 @@ try {
             'tenant'                      => 'long string',           // MSFT tenant GUID. Null for Gmail
 
             'hostedDomain'                => 'mydomain.com',          // Any Google (and optional). Null for MSFT
+            
             'projectID'                   => 'string',                // GoogleAPI only. Else null
             'serviceAccountName'          => 'string',                // GoogleAPI service account only. Else null
             'impersonate'                 => 'you@mydomain.com',      // Google API service account only. Else null
-                                                                      // (Google Wspace email adddress, not @gmail)
+                                                                      // default to 'mailSMTPAddress', must be
+                                                                      // a Google Wspace email adddress, not @gmail
+            'gmailXoauth2Credentials'     => 'your credentials.json', // File name - defaults to:
+                                                                      // gmail-xoauth2-credentials.json
+            'writeGmailCredentialsFile'   => 'yes' or 'no',           // Defaults to 'yes'; meaning the
+                                                                      // credentials json is dynamically created
          ]
     );
 


### PR DESCRIPTION
**V4.1.0** of the SendOauth2 wrapper introduces two new optional operands for the invocation of both the standard PHPMailer email application and for the complete replacement of a PHPMailer application by the wrapper SendOauth2A front-end. These operands allow the developer to specify a name for the .json credentials file and/or whether the wrapper should dynamically build this .json file or use an already-built one, created  either by Google (its standard download) or by the developer.