### PR TITLE
DKIMTest: two fixes for tests for when OpenSSL is disabled/unavailable

### DIFF
--- a/test/PHPMailer/DKIMTest.php
+++ b/test/PHPMailer/DKIMTest.php
@@ -241,21 +241,6 @@ final class DKIMTest extends SendTestCase
     }
 
     /**
-     * Verify behaviour of the DKIM_Sign method when Open SSL is not available.
-     *
-     * @covers \PHPMailer\PHPMailer\PHPMailer::DKIM_Sign
-     */
-    public function testDKIMSignOpenSSLNotAvailable()
-    {
-        if (extension_loaded('openssl')) {
-            $this->markTestSkipped('Test requires OpenSSL *not* to be available');
-        }
-
-        $signature = $this->Mail->DKIM_Sign('foo');
-        self::assertSame('', $signature);
-    }
-
-    /**
      * Verify behaviour of the DKIM_Sign method when Open SSL is not available and exceptions is enabled.
      *
      * @covers \PHPMailer\PHPMailer\PHPMailer::DKIM_Sign

--- a/test/PHPMailer/DKIMTest.php
+++ b/test/PHPMailer/DKIMTest.php
@@ -13,7 +13,7 @@
 
 namespace PHPMailer\Test\PHPMailer;
 
-use Exception;
+use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\PHPMailer;
 use PHPMailer\Test\SendTestCase;
 

--- a/test/PHPMailer/DKIMWithoutExceptionsTest.php
+++ b/test/PHPMailer/DKIMWithoutExceptionsTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * PHPMailer - PHP email transport unit tests.
+ * PHP version 5.5.
+ *
+ * @author    Marcus Bointon <phpmailer@synchromedia.co.uk>
+ * @author    Andy Prevost
+ * @copyright 2012 - 2020 Marcus Bointon
+ * @copyright 2004 - 2009 Andy Prevost
+ * @license   https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html GNU Lesser General Public License
+ */
+
+namespace PHPMailer\Test\PHPMailer;
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\Test\TestCase;
+
+/**
+ * Test DKIM signing functionality.
+ *
+ * @group dkim
+ */
+final class DKIMWithoutExceptionsTest extends TestCase
+{
+    /**
+     * Whether or not to initialize the PHPMailer object to throw exceptions.
+     *
+     * @var bool|null
+     */
+    const USE_EXCEPTIONS = false;
+
+    /**
+     * Verify behaviour of the DKIM_Sign method when Open SSL is not available and exceptions is disabled.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::DKIM_Sign
+     */
+    public function testDKIMSignOpenSSLNotAvailable()
+    {
+        if (extension_loaded('openssl')) {
+            $this->markTestSkipped('Test requires OpenSSL *not* to be available');
+        }
+
+        $signature = $this->Mail->DKIM_Sign('foo');
+        self::assertSame('', $signature);
+    }
+}


### PR DESCRIPTION
### DKIMTest: make exception expectation more specific

As things were, the `DKIMTest::testDKIMSignOpenSSLNotAvailableException()` test _could_ potentially pass even when another `Exception` than the `PHPMailer\PHPMailer\Exception` was being thrown, as _all_ exceptions extend the PHP native `Exception` class.
Now this risk is not that high, as there is also a check on the exception message, but still.

Making the exception expectation more specific (by changing the import `use` statement), should still make the test more stable.

### DKIMTest::testDKIMSignOpenSSLNotAvailable(): fix the test

As things were, the `DKIMTest::testDKIMSignOpenSSLNotAvailable()` could not pass as the `DKIMTest` class sets the `USE_EXCEPTIONS` class constant to `true`, which means the method would fail on an exception.

As this test is specifically about testing the behaviour when exceptions are _disabled_, the test needs to be in its own test class, which sets `USE_EXCEPTIONS` to `false`.

That should allow the test to run properly and to pass.