### PR TITLE
Replace Swiftmailer with Symfony Mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Formatting email correctly is surprisingly difficult. There are myriad overlappi
 The PHP `mail()` function usually sends via a local mail server, typically fronted by a `sendmail` binary on Linux, BSD, and macOS platforms, however, Windows usually doesn't include a local mail server; PHPMailer's integrated SMTP client allows email sending on all platforms without needing a local mail server. Be aware though, that the `mail()` function should be avoided when possible; it's both faster and [safer](https://exploitbox.io/paper/Pwning-PHP-Mail-Function-For-Fun-And-RCE.html) to use SMTP to localhost.
 
 *Please* don't be tempted to do it yourself – if you don't use PHPMailer, there are many other excellent libraries that
-you should look at before rolling your own. Try [SwiftMailer](https://swiftmailer.symfony.com/)
+you should look at before rolling your own. Try [Symfony Mailer](https://symfony.com/doc/current/mailer.html)
 , [Laminas/Mail](https://docs.laminas.dev/laminas-mail/), [ZetaComponents](https://github.com/zetacomponents/Mail), etc.
 
 ## License


### PR DESCRIPTION
As Swiftmailer is end of life (https://symfony.com/blog/the-end-of-swiftmailer), it is better to refer to its successor.