### PR TITLE
Fix the smtp error `ErrorInfo` msg: Troubleshooting url glued

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -4180,7 +4180,7 @@ class PHPMailer
         if ('smtp' === $this->Mailer && null !== $this->smtp) {
             $lasterror = $this->smtp->getError();
             if (!empty($lasterror['error'])) {
-                $msg .= $this->lang('smtp_error') . $lasterror['error'];
+                $msg .= ' ' . $this->lang('smtp_error') . $lasterror['error'];
                 if (!empty($lasterror['detail'])) {
                     $msg .= ' ' . $this->lang('smtp_detail') . $lasterror['detail'];
                 }


### PR DESCRIPTION
`SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/TroubleshootingSMTP server error: Failed to connect to server SMTP code: 111 Additional SMTP info: Connection refused`

Become

`SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting SMTP server error: Failed to connect to server SMTP code: 111 Additional SMTP info: Connection refused`