### PR TITLE
Wrong line endings on PHP8.3 (Linux) #3150 - Issue attempt

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1548,7 +1548,7 @@ class PHPMailer
             static::setLE(self::CRLF);
         } else {
             //Maintain backward compatibility with legacy Linux command line mailers
-            //Force PHP_EOL for all mail() calls on Linux
+            //Force PHP_EOL for all mail() calls on Linux - regardless of PHP versions -
             static::setLE(PHP_EOL);
         }
         //Check for buggy PHP versions that add a header with an incorrect line break

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1541,7 +1541,7 @@ class PHPMailer
     {
         if (
             'smtp' === $this->Mailer
-            || ('mail' === $this->Mailer && (\PHP_VERSION_ID >= 80000 || stripos(PHP_OS, 'WIN') === 0))
+            || ('mail' === $this->Mailer && stripos(PHP_OS, 'WIN') === 0)
         ) {
             //SMTP mandates RFC-compliant line endings
             //and it's also used with mail() on Windows

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1548,6 +1548,7 @@ class PHPMailer
             static::setLE(self::CRLF);
         } else {
             //Maintain backward compatibility with legacy Linux command line mailers
+            //Force PHP_EOL for all mail() calls on Linux
             static::setLE(PHP_EOL);
         }
         //Check for buggy PHP versions that add a header with an incorrect line break


### PR DESCRIPTION
#3150 

> The output we're seeing is similar to https://github.com/PHPMailer/PHPMailer/issues/2870, except we're using standard mail.
>The client receives emails with added newlines in the content part when sending emails with attachments (i.e. multipart).
>Forcing PHP_EOL fixes the issue.
>
>The [commit referenced in the blame](https://github.com/php/php-src/commit/6983ae751cd301886c966b84367fc7aaa1273b2d) >changed from "\n" to "\r\n". Current code is this:
>
>	char *line_sep = PG(mail_mixed_lf_and_crlf) ? "\n" : "\r\n";
>
>So depending on the setting, either will be used. The change was introduced in https://github.com/php/php-src/commit/>cc931af35ddc0a07c0a669eb4da9dc66e1f73af4, which seems to have landed in 8.2.4.
