### PR TITLE
XOAUTH : Added support for long token

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -634,9 +634,36 @@ class SMTP
                 }
                 $oauth = $OAuth->getOauth64();
 
-                //Start authentication
-                if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 ' . $oauth, 235)) {
-                    return false;
+                /*
+                 * The maximum length for an SMTP commands is 512 bytes, according to RFC 4954 (https://datatracker.ietf.org/doc/html/rfc4954).
+                 * (In truth this seems more complex than that, but 512 bytes seems to be the stricter limit)
+                 *
+                 * Therefor, the base64-encoded OAUTH token has a maximum length of 497 : 512 - 13 (AUTH XOAUTH2) - 2 (CRLF)
+                 * If the token is longer than that, the command and the token must be sent separately
+                 */
+                if (strlen($oauth) <= 497) {
+                    //Start authentication
+                    if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 ' . $oauth, 235)) {
+                        return false;
+                    }
+                } else {
+                    // Send the command and expect a code 334
+                    if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2', 334)) {
+                        return false;
+                    }
+
+                    // Send the token
+                    if (!$this->sendCommand('Oauth TOKEN', $oauth, [235, 334])) {
+                        return false;
+                    }
+
+                    // If the server answer with a code 334, send and empty line an wait for a code 235
+                    if (
+                        substr($this->last_reply, 0, 3) == 334
+                        && $this->sendCommand('AUTH End', '', 235)
+                    ) {
+                        return false;
+                    }
                 }
                 break;
             default:

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -633,31 +633,28 @@ class SMTP
                     return false;
                 }
                 $oauth = $OAuth->getOauth64();
-
                 /*
-                 * The maximum length for an SMTP commands is 512 bytes, according to RFC 4954 (https://datatracker.ietf.org/doc/html/rfc4954).
-                 * (In truth this seems more complex than that, but 512 bytes seems to be the stricter limit)
-                 *
-                 * Therefor, the base64-encoded OAUTH token has a maximum length of 497 : 512 - 13 (AUTH XOAUTH2) - 2 (CRLF)
-                 * If the token is longer than that, the command and the token must be sent separately
+                 * An SMTP command line can have a maximum length of 512 bytes, including the command name,
+                 * so the base64-encoded OAUTH token has a maximum length of 512 - 13 (AUTH XOAUTH2) - 2 (CRLF) = 497 bytes
+                 * If the token is longer than that, the command and the token must be sent separately as described in
+                 * https://www.rfc-editor.org/rfc/rfc4954#section-4
                  */
                 if (strlen($oauth) <= 497) {
-                    //Start authentication
+                    //Authenticate using a token in the initial-response part
                     if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 ' . $oauth, 235)) {
                         return false;
                     }
                 } else {
-                    // Send the command and expect a code 334
+                    //The token is too long, so we need to send it in two parts.
+                    //Send the auth command without a token and expect a 334
                     if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2', 334)) {
                         return false;
                     }
-
-                    // Send the token
-                    if (!$this->sendCommand('Oauth TOKEN', $oauth, [235, 334])) {
+                    //Send the token
+                    if (!$this->sendCommand('OAuth TOKEN', $oauth, [235, 334])) {
                         return false;
                     }
-
-                    // If the server answer with a code 334, send an empty line and wait for a code 235
+                    //If the server answers with 334, send an empty line and wait for a 235
                     if (
                         substr($this->last_reply, 0, 3) === '334'
                         && $this->sendCommand('AUTH End', '', 235)

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -635,7 +635,8 @@ class SMTP
                 $oauth = $OAuth->getOauth64();
                 /*
                  * An SMTP command line can have a maximum length of 512 bytes, including the command name,
-                 * so the base64-encoded OAUTH token has a maximum length of 512 - 13 (AUTH XOAUTH2) - 2 (CRLF) = 497 bytes
+                 * so the base64-encoded OAUTH token has a maximum length of:
+                 * 512 - 13 (AUTH XOAUTH2) - 2 (CRLF) = 497 bytes
                  * If the token is longer than that, the command and the token must be sent separately as described in
                  * https://www.rfc-editor.org/rfc/rfc4954#section-4
                  */

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -639,7 +639,13 @@ class SMTP
                  * If the token is longer than that, the command and the token must be sent separately as described in
                  * https://www.rfc-editor.org/rfc/rfc4954#section-4
                  */
-                if (strlen($oauth) <= 497) {
+                if ($oauth === '') {
+                    //Sending an empty auth token is legitimate, but it must be encoded as '='
+                    //to indicate it's not a 2-part command
+                    if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 =', 235)) {
+                        return false;
+                    }
+                } elseif (strlen($oauth) <= 497) {
                     //Authenticate using a token in the initial-response part
                     if (!$this->sendCommand('AUTH', 'AUTH XOAUTH2 ' . $oauth, 235)) {
                         return false;

--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -657,9 +657,9 @@ class SMTP
                         return false;
                     }
 
-                    // If the server answer with a code 334, send and empty line an wait for a code 235
+                    // If the server answer with a code 334, send an empty line and wait for a code 235
                     if (
-                        substr($this->last_reply, 0, 3) == 334
+                        substr($this->last_reply, 0, 3) === '334'
                         && $this->sendCommand('AUTH End', '', 235)
                     ) {
                         return false;


### PR DESCRIPTION
In reference to #3169, heres a patch for handling XOAUTH2 authentication with long base64-encoded tokens.

As a note, I haven't been able to test this fix with GMail or Outlook, only with a Dovecot server.