### PR TITLE
Change action_function to callable phpdoc type

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -563,7 +563,7 @@ class PHPMailer
      *   string  $extra         extra information of possible use
      *                          "smtp_transaction_id' => last smtp transaction id
      *
-     * @var string
+     * @var callable
      */
     public $action_function = '';
 


### PR DESCRIPTION
I made this change because we use a a object method array for the action_function which should work with the PHPMailer code.