### PR TITLE
PHP 8.5 | Tests: prevent deprecation notice for Reflection*::setAccessible()

### DIFF
--- a/test/OAuth/OAuthTest.php
+++ b/test/OAuth/OAuthTest.php
@@ -36,7 +36,7 @@ final class OAuthTest extends TestCase
         $PHPMailer = new PHPMailer(true);
         $reflection = new \ReflectionClass($PHPMailer);
         $property = $reflection->getProperty('oauth');
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue($PHPMailer, true);
         self::assertTrue($PHPMailer->getOAuth(), 'Initial value of oauth property is not true');
 

--- a/test/PHPMailer/FileIsAccessibleTest.php
+++ b/test/PHPMailer/FileIsAccessibleTest.php
@@ -39,9 +39,9 @@ final class FileIsAccessibleTest extends TestCase
     public function testFileIsAccessible($input, $expected)
     {
         $reflMethod = new ReflectionMethod(PHPMailer::class, 'fileIsAccessible');
-        $reflMethod->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke(null, $input);
-        $reflMethod->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
 
         self::assertSame($expected, $result);
     }
@@ -91,9 +91,9 @@ final class FileIsAccessibleTest extends TestCase
         chmod($file, octdec('0'));
 
         $reflMethod = new ReflectionMethod(PHPMailer::class, 'fileIsAccessible');
-        $reflMethod->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke(null, $file);
-        $reflMethod->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
 
         // Reset to the default for git files before running assertions.
         chmod($file, octdec('644'));

--- a/test/PHPMailer/IsPermittedPathTest.php
+++ b/test/PHPMailer/IsPermittedPathTest.php
@@ -35,9 +35,9 @@ final class IsPermittedPathTest extends TestCase
     public function testIsPermittedPath($input, $expected)
     {
         $reflMethod = new ReflectionMethod(PHPMailer::class, 'isPermittedPath');
-        $reflMethod->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke(null, $input);
-        $reflMethod->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
 
         self::assertSame($expected, $result);
     }

--- a/test/PHPMailer/LocalizationTest.php
+++ b/test/PHPMailer/LocalizationTest.php
@@ -423,9 +423,9 @@ final class LocalizationTest extends TestCase
         }
 
         $reflMethod = new ReflectionMethod($this->Mail, 'lang');
-        $reflMethod->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
         $result = $reflMethod->invoke($this->Mail, $input);
-        $reflMethod->setAccessible(false);
+        (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
 
         self::assertSame($expected, $result);
     }

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -253,7 +253,7 @@ EOT;
         $PHPMailer = new PHPMailer();
         $reflection = new \ReflectionClass($PHPMailer);
         $property = $reflection->getProperty('message_type');
-        $property->setAccessible(true);
+        (\PHP_VERSION_ID < 80100) && $property->setAccessible(true);
         $property->setValue($PHPMailer, 'inline');
         self::assertIsString($PHPMailer->createBody());
 


### PR DESCRIPTION
Since PHP 8.1, calling the `Reflection*::setAccessible()` methods is no longer necessary as reflected properties/methods/etc will always be accessible. However, the method calls are still needed for PHP < 8.1.

As of PHP 8.5, calling the `Reflection*::setAccessible()` methods is now formally deprecated and will yield a deprecation notice, which will fail test runs. As of PHP 9.0, the `setAccessible()` method(s) will be removed.

With the latter in mind, this commit prevents the deprecation notice by making the calls to `setAccessible()` conditional.

Silencing the deprecation would mean, this would need to be "fixed" again come PHP 9.0, while the current solution should be stable, including for PHP 9.0.

Ref: https://wiki.php.net/rfc/deprecations_php_8_5#extreflection_deprecations