### PR TITLE
Enhance 'interrupted system call' check to handle non-english locale

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -1340,7 +1340,16 @@ class SMTP
 
                 //stream_select returns false when the `select` system call is interrupted
                 //by an incoming signal, try the select again
-                if (stripos($message, 'interrupted system call') !== false) {
+                if (
+                    stripos($message, 'interrupted system call') !== false ||
+                    (
+                        // on applications with a different locale than english, the message above is not found because
+                        // it's translated. So we also check for the SOCKET_EINTR constant which is defined under
+                        // Windows and UNIX-like platforms (if available on the platform).
+                        defined('SOCKET_EINTR') &&
+                        stripos($message, 'stream_select(): Unable to select [' . SOCKET_EINTR . ']') !== false
+                    )
+                ) {
                     $this->edebug(
                         'SMTP -> get_lines(): retrying stream_select',
                         self::DEBUG_LOWLEVEL


### PR DESCRIPTION
This is a fix for https://github.com/PHPMailer/PHPMailer/issues/3183 – stream_select retry not working for other language (locale) than English

I received a great hint by @teefax – who pointed out that the `stream_select(): Unable to select` part of the php warning message is not translated for other locales. Only the `interrupted system call` part is translated.

That `Unable to select` is followed by an error number in square brackets. However that number can be different based on the operating system of the server. But PHP has a constant [SOCKET_EINTR](https://www.php.net/manual/en/sockets.constants.php#constant.socket-eintr) for that.

So the recommendation is to check for the SOCKET_EINTR constant which is defined under Windows and UNIX-like platforms (if available on the platform) and use that with the other english warning text to catch those interrupted system calls for non-english locale applications.

I left the existing check to avoid any potential unknown breaking change and extended the if-condition.

I tested this with our application and it worked as expected (without the setlocale workaround shared in https://github.com/PHPMailer/PHPMailer/issues/3183).