### PR TITLE
Making Translation Strings Test Informative

### DIFF
--- a/test/Language/TranslationCompletenessTest.php
+++ b/test/Language/TranslationCompletenessTest.php
@@ -91,13 +91,13 @@ final class TranslationCompletenessTest extends TestCase
             }
         }
 
-        // Make this test informational only: skip with details instead of failing.
+        // Make this test informational only.
         if ($err !== '') {
             $this->markTestSkipped("Translation completeness (informational):\n" . $err);
             return;
         }
 
-        // No differences found: count a dummy assertion so the test is not marked as risky.
+        // Avoid marking test as risky.
         $this->addToAssertionCount(1);
     }
 }

--- a/test/Language/TranslationCompletenessTest.php
+++ b/test/Language/TranslationCompletenessTest.php
@@ -91,7 +91,13 @@ final class TranslationCompletenessTest extends TestCase
             }
         }
 
-        // If we have no extra and no missing translations, $err will be empty.
-        self::assertEmpty($err, $err);
+        // Make this test informational only: skip with details instead of failing.
+        if ($err !== '') {
+            $this->markTestSkipped("Translation completeness (informational):\n" . $err);
+            return;
+        }
+
+        // No differences found: count a dummy assertion so the test is not marked as risky.
+        $this->addToAssertionCount(1);
     }
 }


### PR DESCRIPTION
Regarding this issue
https://github.com/PHPMailer/PHPMailer/issues/3194

With this patch, we make this test informative instead of mandatory to pass. There are a ton of translation strings missing, and given the rare languages available like Latin, I'm uncertain if they will be ever fully sorted out (unless using some automatic translator)