### PR TITLE
Grouping No MbString Tests

### DIFF
--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1346,6 +1346,8 @@ EOT;
     /**
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     * 
+     * @group mbstringExtRequired
      */
     public function testGivenIdnAddress_addAddress_returns_true()
     {

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -278,6 +278,9 @@ EOT;
 
     /**
      * Send a message containing ISO-8859-1 text.
+     * 
+     * @requires extension mbstring
+     * @group mbstringExtRequired
      */
     public function testHtmlIso8859()
     {

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -1117,6 +1117,8 @@ EOT;
 
     /**
      * Tests CharSet and Unicode -> ASCII conversions for addresses with IDN.
+     * 
+     * @group mbstringExtRequired
      */
     public function testConvertEncoding()
     {
@@ -1162,6 +1164,8 @@ EOT;
 
     /**
      * Tests removal of duplicate recipients and reply-tos.
+     * 
+     * @group mbstringExtRequired
      */
     public function testDuplicateIDNRemoved()
     {
@@ -1230,6 +1234,8 @@ EOT;
 
     /**
      * Test SMTPUTF8 usage, including when it is not to be used.
+     * 
+     * @group mbstringExtRequired
      */
     public function testSmtpUTF8()
     {

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -33,6 +33,7 @@ final class ParseAddressesTest extends TestCase
      * with the Mbstring extension available.
      *
      * @requires extension mbstring
+     * @group mbstringExtRequired
      *
      * @dataProvider dataAddressSplitting
      *
@@ -64,6 +65,7 @@ final class ParseAddressesTest extends TestCase
      *
      * @requires extension imap
      * @requires extension mbstring
+     * @group mbstringExtRequired
      *
      * @dataProvider dataAddressSplitting
      *
@@ -93,7 +95,7 @@ final class ParseAddressesTest extends TestCase
      * Test RFC822 address splitting using the PHPMailer native implementation
      * without the Mbstring extension.
      *
-     * @group nombstring
+     * @group mbstringExtDisabled
      * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr  The address list string.
@@ -128,7 +130,7 @@ final class ParseAddressesTest extends TestCase
      *
      * @requires extension imap
      *
-     * @group nombstring
+     * @group mbstringExtDisabled
      * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr  The address list string.

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -93,6 +93,7 @@ final class ParseAddressesTest extends TestCase
      * Test RFC822 address splitting using the PHPMailer native implementation
      * without the Mbstring extension.
      *
+     * @group nombstring
      * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr  The address list string.
@@ -127,6 +128,7 @@ final class ParseAddressesTest extends TestCase
      *
      * @requires extension imap
      *
+     * @group nombstring
      * @dataProvider dataAddressSplitting
      *
      * @param string $addrstr  The address list string.

--- a/test/PHPMailer/PunyencodeAddressTest.php
+++ b/test/PHPMailer/PunyencodeAddressTest.php
@@ -28,6 +28,8 @@ final class PunyencodeAddressTest extends TestCase
      *
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     * 
+     * @group mbstringExtRequired
      *
      * @dataProvider dataPunyencodeAddressConversion
      *

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -270,6 +270,8 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      *
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     * 
+     * @group mbstringExtRequired
      */
     public function testEnqueueAndAddIdnAddress()
     {
@@ -308,6 +310,8 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      *
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     * 
+     * @group mbstringExtRequired
      */
     public function testNoDuplicateReplyToAddresses()
     {
@@ -404,7 +408,7 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      * an 8bit character is passed and either the MbString or the Intl extension are
      * not available.
      *
-     * @group nombstring
+     * @group mbstringExtDisabled
      *
      * @covers \PHPMailer\PHPMailer\PHPMailer::addAnAddress
      */
@@ -424,6 +428,8 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      *
      * @requires extension mbstring
      * @requires function idn_to_ascii
+     * 
+     * @group mbstringExtRequired
      */
     public function testClearReplyTos()
     {

--- a/test/PHPMailer/ReplyToGetSetClearTest.php
+++ b/test/PHPMailer/ReplyToGetSetClearTest.php
@@ -404,6 +404,8 @@ final class ReplyToGetSetClearTest extends PreSendTestCase
      * an 8bit character is passed and either the MbString or the Intl extension are
      * not available.
      *
+     * @group nombstring
+     *
      * @covers \PHPMailer\PHPMailer\PHPMailer::addAnAddress
      */
     public function testAddReplyToFailsOn8BitCharInDomainWithoutOptionalExtensions()

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -190,6 +190,8 @@ final class SetFromTest extends TestCase
      * Test unsuccessfully setting the From, FromName and Sender properties when an email address
      * containing an 8bit character is passed and either the MbString or the Intl extension are
      * not available.
+     *
+     * @group nombstring
      */
     public function testSetFromFailsOn8BitCharInDomainWithoutOptionalExtensions()
     {

--- a/test/PHPMailer/SetFromTest.php
+++ b/test/PHPMailer/SetFromTest.php
@@ -191,7 +191,7 @@ final class SetFromTest extends TestCase
      * containing an 8bit character is passed and either the MbString or the Intl extension are
      * not available.
      *
-     * @group nombstring
+     * @group mbstringExtDisabled
      */
     public function testSetFromFailsOn8BitCharInDomainWithoutOptionalExtensions()
     {


### PR DESCRIPTION
Following this issue
https://github.com/PHPMailer/PHPMailer/issues/3196

The idea here is to group these 4 tests for purposes as explained in the issue.

It could be very useful to target them all at once.