### PR TITLE
Fix linting issue on PHP 8.5

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,7 +36,24 @@
         <exclude name="PHPCompatibility.ParameterValues.NewIDNVariantDefault.NotSet"/>
     </rule>
 
+
+    <!--
+    #############################################################################
+    SELECTIVE EXCLUSIONS
+    Exclude specific files for specific sniffs and/or exclude sub-groups in sniffs.
+    #############################################################################
+    -->
+
     <rule ref="Generic.Files.LineLength.TooLong">
         <exclude-pattern>*/language/phpmailer\.lang*\.php$</exclude-pattern>
     </rule>
+
+	<!-- Excludes related to linting ignore comment for one specific test file. -->
+    <rule ref="PSR12.Files.OpenTag.NotAlone">
+        <exclude-pattern>*/test/Fixtures/LocalizationTest/phpmailer.lang-yz\.php</exclude-pattern>
+    </rule>
+    <rule ref="PSR12.Files.FileHeader.SpacingAfterBlock">
+        <exclude-pattern>*/test/Fixtures/LocalizationTest/phpmailer.lang-yz\.php</exclude-pattern>
+    </rule>
+
 </ruleset>

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-yy.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-yy.php
@@ -12,6 +12,5 @@ echo $composer;
 
 $PHPMAILER_LANG['extension_missing'] = 'Confirming that test fixture was loaded correctly (yy).';
 $PHPMAILER_LANG['empty_message']     = $composer;
-$PHPMAILER_LANG['encoding']          = `ls -l`;
 $PHPMAILER_LANG['execute']           = exec('some harmful command');
 $PHPMAILER_LANG['signing']           = "Double quoted but not interpolated $composer";

--- a/test/Fixtures/LocalizationTest/phpmailer.lang-yz.php
+++ b/test/Fixtures/LocalizationTest/phpmailer.lang-yz.php
@@ -1,0 +1,14 @@
+<?php // lint < 8.5.
+
+/**
+ * Test fixture.
+ *
+ * Used in the `PHPMailer\LocalizationTest` to test that arbitrary code in translation files is disregarded.
+ *
+ * Note: this test fixture uses a syntax (backticks) which has been deprecated in PHP 8.5 and
+ * is slated for removal in PHP 9.0.
+ * For that reason, the file is excluded from the linting check on PHP 8.5 and above.
+ */
+
+$PHPMAILER_LANG['extension_missing'] = 'Confirming that test fixture was loaded correctly (yz).';
+$PHPMAILER_LANG['encoding']          = `ls -l`;

--- a/test/PHPMailer/LocalizationTest.php
+++ b/test/PHPMailer/LocalizationTest.php
@@ -305,13 +305,6 @@ final class LocalizationTest extends TestCase
             'The "empty_message" translation is not as expected'
         );
 
-        self::assertArrayHasKey('encoding', $lang, 'The "encoding" translation key was not found');
-        self::assertSame(
-            'Unknown encoding: ',
-            $lang['encoding'],
-            'The "encoding" translation is not as expected'
-        );
-
         self::assertArrayHasKey('execute', $lang, 'The "execute" translation key was not found');
         self::assertSame(
             'Could not execute: ',
@@ -324,6 +317,37 @@ final class LocalizationTest extends TestCase
             'Double quoted but not interpolated $composer',
             $lang['signing'],
             'The "signing" translation is not as expected'
+        );
+    }
+
+    /**
+     * Test that arbitrary code in a language file does not get executed.
+     */
+    public function testSetLanguageDoesNotExecuteCodeWithBackticksInLangFile()
+    {
+        $result = $this->Mail->setLanguage(
+            'yz', // Unassigned lang code.
+            dirname(__DIR__) . '/Fixtures/LocalizationTest/'
+        );
+        $lang   = $this->Mail->getTranslations();
+
+        self::assertTrue($result, 'Setting the language failed. Translations set to: ' . var_export($lang, true));
+        self::assertIsArray($lang, 'Translations is not an array');
+
+        // Verify that the fixture file was loaded.
+        self::assertArrayHasKey('extension_missing', $lang, 'The "extension_missing" translation key was not found');
+        self::assertSame(
+            'Confirming that test fixture was loaded correctly (yz).',
+            $lang['extension_missing'],
+            'The "extension_missing" translation is not as expected'
+        );
+
+        // Verify that arbitrary code in a translation file does not get processed.
+        self::assertArrayHasKey('encoding', $lang, 'The "encoding" translation key was not found');
+        self::assertSame(
+            'Unknown encoding: ',
+            $lang['encoding'],
+            'The "encoding" translation is not as expected'
         );
     }
 


### PR DESCRIPTION
As per the options described in https://github.com/PHPMailer/PHPMailer/pull/3202#issuecomment-3212478928.

Note: the linting ignore comment triggers some PHPCS errors (_sigh_), so I'm selectively excluding those.
Alternatively, it could be considered to exclude test fixture files completely from the PHPCS scan.