### PR TITLE
docs: remove duplicate 'Tests' status badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ If the documentation doesn't cover what you need, search the [many questions on 
 ## Tests
 [PHPMailer tests](https://github.com/PHPMailer/PHPMailer/tree/master/test/) use PHPUnit 9, with [a polyfill](https://github.com/Yoast/PHPUnit-Polyfills) to let 9-style tests run on older PHPUnit and PHP versions.
 
-[![Test status](https://github.com/PHPMailer/PHPMailer/workflows/Tests/badge.svg)](https://github.com/PHPMailer/PHPMailer/actions)
+
 
 If this isn't passing, is there something you can do to help?
 


### PR DESCRIPTION
The “Test status” badge appears twice (top of README and again in the Tests section).
Keeping a single badge at the top reduces duplication and visual noise. No content lost.
This PR removes only the duplicate badge under ## Tests.
