### PR TITLE
GH Actions: set permissions for each workflow/job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,14 +6,16 @@ on:
   # Allow manually triggering the workflow.
   workflow_dispatch:
 
-permissions:
-  contents: read # to fetch code (actions/checkout)
+permissions: {}
 
 jobs:
 
   coding-standard:
     runs-on: ubuntu-22.04
     name: Coding standards
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
 
     steps:
       - name: Check out code
@@ -56,6 +58,9 @@ jobs:
 
     name: "Lint: PHP ${{ matrix.php }}"
     continue-on-error: ${{ matrix.experimental }}
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
 
     steps:
       - name: Checkout code
@@ -128,6 +133,9 @@ jobs:
     name: "Test: PHP ${{ matrix.php }} - ${{ matrix.extensions }}"
 
     continue-on-error: ${{ matrix.experimental }}
+
+    permissions:
+      contents: read # to fetch code (actions/checkout)
 
     steps:
       - name: Check out code


### PR DESCRIPTION
> Users frequently over-scope their workflow and job permissions, or set broad workflow-level permissions without realizing that all jobs inherit those permissions.
>
> Furthermore, users often don't realize that the _default_ `GITHUB_TOKEN` permissions can be very broad, meaning that workflows that don't configure any permissions at all can _still_ provide excessive credentials to their individual jobs.
>
> **Remediation**
> In general, permissions should be declared as minimally as possible, and as close to their usage site as possible.
>
> In practice, this means that workflows should almost always set `permissions: {}` at the workflow level to disable all permissions by default, and then set specific job-level permissions as needed.

This was already addressed for the other two workflows, just not for the `tests` one.

As far as I can see, the jobs here do not need the `GITHUB_TOKEN` secret and even if they do, only for `content: read`, which for public repos does not need to be set explicitly, though it doesn't do any harm to have that set anyway.

Refs:
* https://docs.zizmor.sh/audits/#excessive-permissions