### PR TITLE
Add XOAUTH2 token exception handling

### DIFF
--- a/src/SMTP.php
+++ b/src/SMTP.php
@@ -633,7 +633,13 @@ class SMTP
                 if (null === $OAuth) {
                     return false;
                 }
-                $oauth = $OAuth->getOauth64();
+                try {
+                    $oauth = $OAuth->getOauth64();
+                } catch (\Exception $e) {
+                    // We catch all exceptions and convert them to PHPMailer exceptions to be able to
+                    // handle them correctly later
+                    throw new Exception("SMTP authentication error", 0, $e);
+                }
                 /*
                  * An SMTP command line can have a maximum length of 512 bytes, including the command name,
                  * so the base64-encoded OAUTH token has a maximum length of:


### PR DESCRIPTION
If generating an OAuth2 token fails in the provider and an exception is thrown, we never catch that exception, but just let exception propagate up to whatever.

I suggest this change, such that we can handle errors when generating oauth tokens. It is based on the fact that `League\OAuth2\Client\Provider\AbstractProvider` can throw exceptions during getting the oauth token, but we are nowhere near to knowing why.

I have decided on catching all exception (`\Exception`) because if someone uses another `OAuthTokenProvider` (it's just an interface, so it's possible), we won't know specifically which exceptions can be thrown here, so we need to catch them all.

By throwing a PHPMailer exception and adding the existing exception as the `$previous` variable, we can show a generic error message to regular users and advice how developers can get actually meaningful error messages from the previous exception.

As discussed in #3260 