### PR TITLE
Recreate Esperanto translations

### DIFF
--- a/language/phpmailer.lang-eo.php
+++ b/language/phpmailer.lang-eo.php
@@ -3,24 +3,35 @@
 /**
  * Esperanto PHPMailer language file: refer to English translation for definitive list
  * @package PHPMailer
+ * @author Robin van der Vliet <info@robinvandervliet.com>
  */
 
-$PHPMAILER_LANG['authenticate']         = 'Eraro de servilo SMTP : aŭtentigo malsukcesis.';
-$PHPMAILER_LANG['connect_host']         = 'Eraro de servilo SMTP : konektado al servilo malsukcesis.';
-$PHPMAILER_LANG['data_not_accepted']    = 'Eraro de servilo SMTP : neĝustaj datumoj.';
-$PHPMAILER_LANG['empty_message']        = 'Teksto de mesaĝo mankas.';
+$PHPMAILER_LANG['authenticate']         = 'SMTP-eraro: Ne eblis aŭtentigi.';
+$PHPMAILER_LANG['buggy_php']            = 'Via versio de PHP estas trafita de cimo, kiu povas kaŭzi difektitajn mesaĝojn. Por ripari tion, ŝanĝu al sendado per SMTP, malŝaltu la opcion mail.add_x_header en via php.ini, ŝanĝu al MacOS aŭ Linux, aŭ ĝisdatigu vian PHP al versio 7.0.17+ aŭ 7.1.3+.';
+$PHPMAILER_LANG['connect_host']         = 'SMTP-eraro: Ne eblis konektiĝi al la SMTP-gastiganto.';
+$PHPMAILER_LANG['data_not_accepted']    = 'SMTP-eraro: Datumoj ne akceptitaj.';
+$PHPMAILER_LANG['empty_message']        = 'Mesaĝokorpo malplena';
 $PHPMAILER_LANG['encoding']             = 'Nekonata kodoprezento: ';
-$PHPMAILER_LANG['execute']              = 'Lanĉi rulumadon ne eblis: ';
-$PHPMAILER_LANG['file_access']          = 'Aliro al dosiero ne sukcesis: ';
-$PHPMAILER_LANG['file_open']            = 'Eraro de dosiero: malfermo neeblas: ';
-$PHPMAILER_LANG['from_failed']          = 'Jena adreso de sendinto malsukcesis: ';
-$PHPMAILER_LANG['instantiate']          = 'Genero de retmesaĝa funkcio neeblis.';
-$PHPMAILER_LANG['invalid_address']      = 'Retadreso ne validas: ';
-$PHPMAILER_LANG['mailer_not_supported'] = ' mesaĝilo ne subtenata.';
-$PHPMAILER_LANG['provide_address']      = 'Vi devas tajpi almenaŭ unu recevontan retadreson.';
-$PHPMAILER_LANG['recipients_failed']    = 'Eraro de servilo SMTP : la jenaj poŝtrecivuloj kaŭzis eraron: ';
-$PHPMAILER_LANG['signing']              = 'Eraro de subskribo: ';
-$PHPMAILER_LANG['smtp_connect_failed']  = 'SMTP konektado malsukcesis.';
-$PHPMAILER_LANG['smtp_error']           = 'Eraro de servilo SMTP : ';
-$PHPMAILER_LANG['variable_set']         = 'Variablo ne pravalorizeblas aŭ ne repravalorizeblas: ';
-$PHPMAILER_LANG['extension_missing']    = 'Mankas etendo: ';
+$PHPMAILER_LANG['execute']              = 'Ne eblis plenumi: ';
+$PHPMAILER_LANG['extension_missing']    = 'Kromprogramo mankas: ';
+$PHPMAILER_LANG['file_access']          = 'Ne eblis aliri la dosieron: ';
+$PHPMAILER_LANG['file_open']            = 'Dosiera eraro: Ne eblis malfermi la dosieron: ';
+$PHPMAILER_LANG['from_failed']          = 'La sekva(j) sendinto(j) malsukcesis: ';
+$PHPMAILER_LANG['instantiate']          = 'Ne eblis funkciigi la retpoŝtan funkcion.';
+$PHPMAILER_LANG['invalid_address']      = 'Nevalida adreso: ';
+$PHPMAILER_LANG['invalid_header']       = 'Nevalida kaplinia nomo aŭ valoro';
+$PHPMAILER_LANG['invalid_hostentry']    = 'Nevalida enigo de gastiganto: ';
+$PHPMAILER_LANG['invalid_host']         = 'Nevalida gastiganto: ';
+$PHPMAILER_LANG['mailer_not_supported'] = ' retpoŝtilo ne estas subtenata.';
+$PHPMAILER_LANG['provide_address']      = 'Vi devas provizi almenaŭ unu retpoŝtadreson de ricevonto.';
+$PHPMAILER_LANG['recipients_failed']    = 'SMTP-eraro: La sekva(j) ricevonto(j) malsukcesis: ';
+$PHPMAILER_LANG['signing']              = 'Subskriba eraro: ';
+$PHPMAILER_LANG['smtp_code']            = 'SMTP-kodo: ';
+$PHPMAILER_LANG['smtp_code_ex']         = 'Pliaj SMTP-informoj: ';
+$PHPMAILER_LANG['smtp_connect_failed']  = 'La SMTP-konektiĝo malsukcesis.';
+$PHPMAILER_LANG['smtp_detail']          = 'Informoj: ';
+$PHPMAILER_LANG['smtp_error']           = 'Eraro de SMTP-servilo: ';
+$PHPMAILER_LANG['variable_set']         = 'Ne eblas agordi aŭ reagordi la variablon: ';
+$PHPMAILER_LANG['no_smtputf8']          = 'La servilo ne subtenas SMTPUTF8, kiu estas bezonata por sendi al Unicode-adresoj.';
+$PHPMAILER_LANG['imap_recommended']     = 'Uzado de la simpligita adresanalizilo ne estas rekomendita. Instalu la IMAP-kromprogramon por PHP por plena RFC822-analizado.';
+$PHPMAILER_LANG['deprecated_argument']  = 'Malrekomendita argumento: ';


### PR DESCRIPTION
There were a lot of translations missing from the Esperanto file, and the translations that were there had some typos and grammatical errors.

I took the English texts, translated and checked everything.