### PR TITLE
Composer: remove roave/security-advisories

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "php-parallel-lint/php-console-highlighter": "^1.0.0",
         "php-parallel-lint/php-parallel-lint": "^1.3.2",
         "phpcompatibility/php-compatibility": "^9.3.5",
-        "roave/security-advisories": "dev-latest",
         "squizlabs/php_codesniffer": "^3.7.2",
         "yoast/phpunit-polyfills": "^1.0.4"
     },


### PR DESCRIPTION
The `roave/security-advisories` package was an inventive method to block installation of known insecure versions of other dependencies (via a `conflict` annotation).

As of Composer 2.9, using the `roave/security-advisories` package for this purpose is no longer needed as Composer will now natively block installation of known insecure versions of dependencies.

And while not all contributors to this repo may be using Composer 2.9+ (yet), Composer 2.9+ **_will_** be used in CI and CI failing on Composer blocking an insecure dependency offers the same level of protection as the package previously offered.

Refs:
* https://blog.packagist.com/composer-2-9/
* https://github.com/composer/composer/releases/tag/2.9.0