### PR TITLE
GH Actions: update for the release of PHP 8.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,10 +50,10 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ['5.5', '7.2', '8.0', '8.4']
+        php: ['5.5', '7.2', '8.0', '8.5']
         experimental: [false]
         include:
-          - php: '8.5'
+          - php: 'nightly'
             experimental: true
 
     name: "Lint: PHP ${{ matrix.php }}"
@@ -85,11 +85,11 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Lint against parse errors
-        if: ${{ matrix.php != '8.5' }}
+        if: ${{ matrix.php != 'nightly' }}
         run: composer lint -- --checkstyle | cs2pr
 
-      - name: Lint against future parse errors (PHP 8.5)
-        if: ${{ matrix.php == '8.5' }}
+      - name: Lint against future parse errors (PHP nightly)
+        if: ${{ matrix.php == 'nightly' }}
         run: composer lint
 
   test:
@@ -97,7 +97,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php: ['5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         extensions: ['optimal', 'minimal']
         coverage: [false]
         experimental: [false]
@@ -111,21 +111,21 @@ jobs:
             extensions: 'minimal'
             coverage: true
             experimental: false
-          - php: '8.4'
+          - php: '8.5'
             extensions: 'optimal'
             coverage: true
             experimental: false
-          - php: '8.4'
+          - php: '8.5'
             extensions: 'minimal'
             coverage: true
             experimental: false
 
           # Experimental builds. These are allowed to fail.
-          - php: '8.5'
+          - php: '8.6'
             extensions: 'optimal'
             coverage: false
             experimental: true
-          - php: '8.5'
+          - php: '8.6'
             extensions: 'minimal'
             coverage: false
             experimental: true
@@ -181,7 +181,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
       - name: Install PHP packages - normal
-        if: ${{ matrix.php != '8.5' }}
+        if: ${{ matrix.php != '8.6' }}
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           composer-options: ${{ steps.set_extensions.outputs.COMPOSER_OPTIONS }}
@@ -189,7 +189,7 @@ jobs:
           custom-cache-suffix: $(date -u "+%Y-%m")
 
       - name: Install PHP packages - ignore-platform-reqs
-        if: ${{ matrix.php == '8.5' }}
+        if: ${{ matrix.php == '8.6' }}
         uses: "ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520" # 3.1.1
         with:
           composer-options: --ignore-platform-reqs ${{ steps.set_extensions.outputs.COMPOSER_OPTIONS }}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 - Protects against header injection attacks
 - Error messages in over 50 languages!
 - DKIM and S/MIME signing support
-- Compatible with PHP 5.5 and later, including PHP 8.4
+- Compatible with PHP 5.5 and later, including PHP 8.5
 - Namespaced to prevent name clashes
 - Much more!
 


### PR DESCRIPTION
... which is expected to be released this Thursday.

* Builds against PHP 8.5 are no longer allowed to fail.
* Update PHP version on which code coverage is run (high should now be 8.5).
* Add _allowed to fail_ build against PHP 8.6.
* Update the README.

Note: for some jobs I use "nightly" for the "next" PHP version, for some `8.6`. While it may appear there is no difference and this is true for the better part of the year, there is a difference for about two months.

To illustrate, consider PHP 8.5:
* PHP "nightly" refers to the PHP `master` branch, so was PHP 8.5 until the PHP 8.5 was branched off when the first RC was cut in September.
* As of that moment, "nightly" basically became PHP 8.6, so to test against PHP 8.5, one would need to explicitly request `8.5`.
* As of the release of PHP 8.5, it is expected for "nightly" to be PHP 8.6, so the difference is moot again.

For that reason, the unit test workflow uses the explicit `8.6` version for PHP "next".

P.S.: this time I checked and didn't see a prep branch from @Synchro ;-)