### PR TITLE
Fixing troubles with mailSend and Sender enabled

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -221,6 +221,13 @@ class PHPMailer
     public $Sendmail = '/usr/sbin/sendmail';
 
     /**
+     * Parsed sendmail parameters extracted from sendmail_path.
+     *
+     * @var array<string, string>
+     */
+    private $SendmailParams = [];
+
+    /**
      * Whether mail() uses a fully sendmail-compatible MTA.
      * One which supports sendmail's "-oi -f" options.
      *
@@ -989,6 +996,57 @@ class PHPMailer
     }
 
     /**
+     * Extract supported sendmail parameters from a path string.
+     *
+     * @param string $sendmailPath
+     *
+     * @return string The sendmail path without the parsed parameters
+     */
+    private function parseSendmailPath($sendmailPath)
+    {
+        $sendmailPath = trim((string)$sendmailPath);
+        if ($sendmailPath === '') {
+            return $sendmailPath;
+        }
+
+        $parts = preg_split('/\s+/', $sendmailPath);
+        if (empty($parts)) {
+            return $sendmailPath;
+        }
+
+        $command = array_shift($parts);
+        $remainder = [];
+
+        // Parse only -t, -i, and -f parameters.
+        for ($i = 0; $i < count($parts); ++$i) {
+            $part = $parts[$i];
+            if (preg_match('/^-(i|t)$/', $part, $matches)) {
+                $this->SendmailParams[$matches[0]] = '';
+                continue;
+            }
+            if (preg_match('/^-f(.*)$/', $part, $matches)) {
+                $address = $matches[1];
+                if ($address === '' && isset($parts[$i + 1]) && strpos($parts[$i + 1], '-') !== 0) {
+                    $address = $parts[++$i];
+                }
+                if (static::validateAddress($address)) {
+                    $this->SendmailParams['-f'] = $address;
+                    continue;
+                }
+            }
+
+            $remainder[] = $part;
+        }
+
+        // The params that are not parsed are added back to the command.
+        if (!empty($remainder)) {
+            $command .= ' ' . implode(' ', $remainder);
+        }
+
+        return $command;
+    }
+
+    /**
      * Send messages using $Sendmail.
      */
     public function isSendmail()
@@ -996,10 +1054,9 @@ class PHPMailer
         $ini_sendmail_path = ini_get('sendmail_path');
 
         if (false === stripos($ini_sendmail_path, 'sendmail')) {
-            $this->Sendmail = '/usr/sbin/sendmail';
-        } else {
-            $this->Sendmail = $ini_sendmail_path;
+            $ini_sendmail_path = '/usr/sbin/sendmail';
         }
+        $this->Sendmail = $this->parseSendmailPath($ini_sendmail_path);
         $this->Mailer = 'sendmail';
     }
 
@@ -1011,10 +1068,9 @@ class PHPMailer
         $ini_sendmail_path = ini_get('sendmail_path');
 
         if (false === stripos($ini_sendmail_path, 'qmail')) {
-            $this->Sendmail = '/var/qmail/bin/qmail-inject';
-        } else {
-            $this->Sendmail = $ini_sendmail_path;
+            $ini_sendmail_path = '/var/qmail/bin/qmail-inject';
         }
+        $this->Sendmail = $this->parseSendmailPath($ini_sendmail_path);
         $this->Mailer = 'qmail';
     }
 
@@ -1860,29 +1916,34 @@ class PHPMailer
             //PHP config has a sender address we can use
             $this->Sender = ini_get('sendmail_from');
         }
-        //CVE-2016-10033, CVE-2016-10045: Don't pass -f if characters will be escaped.
-        if (!empty($this->Sender) && static::validateAddress($this->Sender) && self::isShellSafe($this->Sender)) {
-            if ($this->Mailer === 'qmail') {
-                $sendmailFmt = '%s -f%s';
-            } else {
-                if (strpos($this->Sendmail, '-f') === false) {
-                    $sendmailFmt = '%s -f%s -oi -t';
-                } else {
-                    $sendmailFmt = '%s -oi -t';
-                }
-            }
-        } elseif ($this->Mailer === 'qmail') {
-            $sendmailFmt = '%s';
-        } else {
-            //Allow sendmail to choose a default envelope sender. It may
-            //seem preferable to force it to use the From header as with
-            //SMTP, but that introduces new problems (see
-            //<https://github.com/PHPMailer/PHPMailer/issues/2298>), and
-            //it has historically worked this way.
-            $sendmailFmt = '%s -oi -t';
+
+        $sendmailArgs = [];
+
+        // CVE-2016-10033, CVE-2016-10045: Don't pass -f if characters will be escaped.
+        // Also don't add the -f automatically unless it has been set either via Sender
+        // or sendmail_path. Otherwise it can introduce new problems.
+        // @see http://github.com/PHPMailer/PHPMailer/issues/2298
+        if (isset($this->SendmailParams['-f']) && self::isShellSafe($this->SendmailParams['-f'])) {
+            $sendmailArgs[] = '-f' . $this->SendmailParams['-f'];
+        } elseif (!empty($this->Sender) && static::validateAddress($this->Sender) && self::isShellSafe($this->Sender)) {
+            $sendmailArgs[] = '-f' . $this->Sender;
         }
 
-        $sendmail = sprintf($sendmailFmt, escapeshellcmd($this->Sendmail), $this->Sender);
+        // Qmail doesn't accept all the sendmail parameters
+        // @see https://github.com/PHPMailer/PHPMailer/issues/3189
+        if ($this->Mailer !== 'qmail') {
+            if (isset($this->SendmailParams['-i'])) {
+                $sendmailArgs[] = '-i';
+            }
+
+            if (isset($this->SendmailParams['-t'])) {
+                $sendmailArgs[] = '-t';
+            }
+        }
+
+        $resultArgs = (empty($sendmailArgs) ? '' : ' ' . implode(' ', $sendmailArgs));
+
+        $sendmail = trim(escapeshellcmd($this->Sendmail) . $resultArgs);
         $this->edebug('Sendmail path: ' . $this->Sendmail);
         $this->edebug('Sendmail command: ' . $sendmail);
         $this->edebug('Envelope sender: ' . $this->Sender);
@@ -2066,8 +2127,8 @@ class PHPMailer
             $this->Sender = ini_get('sendmail_from');
         }
         if (!empty($this->Sender) && static::validateAddress($this->Sender)) {
-            $phpmailer_path = ini_get('sendmail_path');
-            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, '-f') === false) {
+            $this->parseSendmailPath(ini_get('sendmail_path'));
+            if (self::isShellSafe($this->Sender) && !isset($this->SendmailParams['-f'])) {
                 $params = sprintf('-f%s', $this->Sender);
             }
             $old_from = ini_get('sendmail_from');

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -989,11 +989,11 @@ class PHPMailer
     }
 
     /**
-     * Extract supported sendmail parameters from a path string.
+     * Extract sendmail path and parse to deal with known parameters.
      *
-     * @param string $sendmailPath
+     * @param string $sendmailPath The sendmail path as set in php.ini
      *
-     * @return string The sendmail path without the parsed parameters
+     * @return string The sendmail path without the known parameters
      */
     private function parseSendmailPath($sendmailPath)
     {

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1010,10 +1010,10 @@ class PHPMailer
         $command = array_shift($parts);
         $remainder = [];
 
-        // Parse only -t, -i, and -f parameters.
+        // Parse only -t, -i, -oi and -f parameters.
         for ($i = 0; $i < count($parts); ++$i) {
             $part = $parts[$i];
-            if (preg_match('/^-(i|t)$/', $part, $matches)) {
+            if (preg_match('/^-(i|oi|t)$/', $part, $matches)) {
                 continue;
             }
             if (preg_match('/^-f(.*)$/', $part, $matches)) {

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1865,7 +1865,11 @@ class PHPMailer
             if ($this->Mailer === 'qmail') {
                 $sendmailFmt = '%s -f%s';
             } else {
-                $sendmailFmt = '%s -oi -f%s -t';
+                if (strpos($this->Sendmail, '-f') === false) {
+                    $sendmailFmt = '%s -f%s -oi -t';
+                } else {
+                    $sendmailFmt = '%s -oi -t';
+                }
             }
         } elseif ($this->Mailer === 'qmail') {
             $sendmailFmt = '%s';

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2062,7 +2062,8 @@ class PHPMailer
             $this->Sender = ini_get('sendmail_from');
         }
         if (!empty($this->Sender) && static::validateAddress($this->Sender)) {
-            if (self::isShellSafe($this->Sender)) {
+            $phpmailer_path = ini_get('sendmail_path');
+            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, '-f') !== false) {
                 $params = sprintf('-f%s', $this->Sender);
             }
             $old_from = ini_get('sendmail_from');

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2063,7 +2063,7 @@ class PHPMailer
         }
         if (!empty($this->Sender) && static::validateAddress($this->Sender)) {
             $phpmailer_path = ini_get('sendmail_path');
-            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, '-f') !== false) {
+            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, '-f') === false) {
                 $params = sprintf('-f%s', $this->Sender);
             }
             $old_from = ini_get('sendmail_from');

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -2111,7 +2111,7 @@ class PHPMailer
         }
         if (!empty($this->Sender) && static::validateAddress($this->Sender)) {
             $phpmailer_path = ini_get('sendmail_path');
-            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, '-f') === false) {
+            if (self::isShellSafe($this->Sender) && strpos($phpmailer_path, ' -f') === false) {
                 $params = sprintf('-f%s', $this->Sender);
             }
             $old_from = ini_get('sendmail_from');

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -184,9 +184,9 @@ final class MailTransportTest extends SendTestCase
      *
      * @param string $sendmailPath The sendmail path to parse.
      * @param string $expectedCommand The expected command after parsing.
-     * @param array  $expectedParams The expected parameters after parsing.
+     * @param string  $expectedSender The expected Sender (-f parameter) after parsing.
      */
-    public function testParseSendmailPath($sendmailPath, $expectedCommand, array $expectedParams)
+    public function testParseSendmailPath($sendmailPath, $expectedCommand, $expectedSender)
     {
         $mailer = $this->Mail;
 
@@ -199,21 +199,18 @@ final class MailTransportTest extends SendTestCase
         );
         $command = $parseSendmailPath($sendmailPath);
 
-        $getSendmailParams = \Closure::bind(
-            function () {
-                return $this->{'SendmailParams'};
-            },
-            $mailer,
-            \PHPMailer\PHPMailer\PHPMailer::class
-        );
-        $params = $getSendmailParams();
-
-        self::assertSame($expectedCommand, $command);
-        self::assertSame($expectedParams, $params);
+        self::assertSame($expectedCommand, $command, 'Sendmail command not parsed correctly');
+        self::assertSame($expectedSender, $mailer->Sender, 'Sender property not set correctly');
     }
 
     /**
      * Data provider for testParseSendmailPath.
+     *
+     * @return array<string, array<int, string>> {
+     *   @type string $0 The sendmail path to parse.
+     *   @type string $1 The expected command after parsing.
+     *   @type string $2 The expected Sender (-f parameter) after parsing.
+     * }
      */
 
     public function sendmailPathProvider()
@@ -222,27 +219,27 @@ final class MailTransportTest extends SendTestCase
             'path only' => [
                 '/usr/sbin/sendmail',
                 '/usr/sbin/sendmail',
-                [],
+                ''
             ],
             'with i and t' => [
                 '/usr/sbin/sendmail -i -t',
                 '/usr/sbin/sendmail',
-                ['-i' => '', '-t' => ''],
+                ''
             ],
             'with f concatenated' => [
                 '/usr/sbin/sendmail -frpath@example.org -i',
                 '/usr/sbin/sendmail',
-                ['-f' => 'rpath@example.org', '-i' => ''],
+                'rpath@example.org'
             ],
             'with f separated' => [
                 '/usr/sbin/sendmail -f rpath@example.org -t',
                 '/usr/sbin/sendmail',
-                ['-f' => 'rpath@example.org', '-t' => ''],
+                'rpath@example.org',
             ],
             'with extra flags preserved' => [
-                '/opt/sendmail -fuser@example.org -x -y',
+                '/opt/sendmail -x -y -fuser@example.org',
                 '/opt/sendmail -x -y',
-                ['-f' => 'user@example.org'],
+                'user@example.org',
             ],
         ];
     }

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -190,21 +190,23 @@ final class MailTransportTest extends SendTestCase
     {
         $mailer = $this->Mail;
 
-        $command = \Closure::bind(
+        $parseSendmailPath = \Closure::bind(
             function ($path) {
                 return $this->{'parseSendmailPath'}($path);
             },
             $mailer,
             \PHPMailer\PHPMailer\PHPMailer::class
-        )($sendmailPath);
+        );
+        $command = $parseSendmailPath($sendmailPath);
 
-        $params = \Closure::bind(
+        $getSendmailParams = \Closure::bind(
             function () {
                 return $this->{'SendmailParams'};
             },
             $mailer,
             \PHPMailer\PHPMailer\PHPMailer::class
-        )();
+        );
+        $params = $getSendmailParams();
 
         self::assertSame($expectedCommand, $command);
         self::assertSame($expectedParams, $params);

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -241,6 +241,21 @@ final class MailTransportTest extends SendTestCase
                 '/opt/sendmail -x -y',
                 'user@example.org',
             ],
+            "extra flags with values preserved" => [
+                '/opt/sendmail -X /path/to/logfile -fuser@example.org',
+                '/opt/sendmail -X /path/to/logfile',
+                'user@example.org',
+            ],
+            "extra flags concatenated preserved" => [
+                '/opt/sendmail -X/path/to/logfile -t -i',
+                '/opt/sendmail -X/path/to/logfile',
+                '',
+            ],
+            "option values with regular parameters" => [
+                '/opt/sendmail -oi -t',
+                '/opt/sendmail',
+                '',
+            ],
         ];
     }
 }

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -121,13 +121,13 @@ final class MailTransportTest extends SendTestCase
      * Test sending using PHP mail() function with Sender address
      * and explicit sendmail_from ini set.
      * Test running required with:
-     * php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.com" ./vendor/bin/phpunit
+     * php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.org" ./vendor/bin/phpunit
      *
      * @covers \PHPMailer\PHPMailer\PHPMailer::isMail
      */
     public function testMailSendWithSendmailParams()
     {
-        if (strpos(ini_get('sendmail_path'), 'rpath@example.com') === false) {
+        if (strpos(ini_get('sendmail_path'), 'rpath@example.org') === false) {
             self::markTestSkipped('Custom Sendmail php.ini not available');
         }
 

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -123,11 +123,14 @@ final class MailTransportTest extends SendTestCase
      * Test running required with:
      * php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.org" ./vendor/bin/phpunit
      *
+     * @group sendmailparams
      * @covers \PHPMailer\PHPMailer\PHPMailer::isMail
      */
     public function testMailSendWithSendmailParams()
     {
-        if (strpos(ini_get('sendmail_path'), 'rpath@example.org') === false) {
+        $sender = 'rpath@example.org';
+
+        if (strpos(ini_get('sendmail_path'), $sender) === false) {
             self::markTestSkipped('Custom Sendmail php.ini not available');
         }
 
@@ -137,11 +140,37 @@ final class MailTransportTest extends SendTestCase
         $this->Mail->clearAddresses();
         $this->setAddress('testmailsend@example.com', 'totest');
 
-        $sender = 'rpath@example.org';
-
         ini_set('sendmail_from', $sender);
         $this->Mail->createHeader();
         $this->Mail->isMail();
+
+        self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
+    }
+
+    /**
+     * Test sending using SendMail with Sender address
+     * and explicit sendmail_from ini set.
+     * Test running required with:
+     * php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.org" ./vendor/bin/phpunit
+     *
+     * @group sendmailparams
+     * @covers \PHPMailer\PHPMailer\PHPMailer::isSendmail
+     */
+    public function testSendmailSendWithSendmailParams()
+    {
+        $sender = 'rpath@example.org';
+
+        if (strpos(ini_get('sendmail_path'), $sender) === false) {
+            self::markTestSkipped('Custom Sendmail php.ini not available');
+        }
+
+        $this->Mail->Body = 'Sending via sendmail';
+        $this->buildBody();
+        $subject = $this->Mail->Subject;
+
+        $this->Mail->Subject = $subject . ': sendmail';
+        ini_set('sendmail_from', $sender);
+        $this->Mail->isSendmail();
 
         self::assertTrue($this->Mail->send(), $this->Mail->ErrorInfo);
     }

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -82,12 +82,6 @@ final class MailTransportTest extends SendTestCase
      */
     public function testMailSend()
     {
-        $sendmail = ini_get('sendmail_path');
-        // No path in sendmail_path.
-        if (strpos($sendmail, '/') === false) {
-            ini_set('sendmail_path', '/usr/sbin/sendmail -t -i ');
-        }
-
         $this->Mail->Body = 'Sending via mail()';
         $this->buildBody();
         $this->Mail->Subject = $this->Mail->Subject . ': mail()';

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -117,6 +117,14 @@ final class MailTransportTest extends SendTestCase
         self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
     }
 
+    /**
+     * Test sending using PHP mail() function with Sender address
+     * and explicit sendmail_from ini set.
+     * Test running required with:
+     * php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.com" ./vendor/bin/phpunit
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::isMail
+     */
     public function testMailSendWithSendmailParams()
     {
         if (strpos(ini_get('sendmail_path'), 'rpath@example.com') === false) {

--- a/test/PHPMailer/MailTransportTest.php
+++ b/test/PHPMailer/MailTransportTest.php
@@ -206,10 +206,10 @@ final class MailTransportTest extends SendTestCase
     /**
      * Data provider for testParseSendmailPath.
      *
-     * @return array<string, array<int, string>> {
-     *   @type string $0 The sendmail path to parse.
-     *   @type string $1 The expected command after parsing.
-     *   @type string $2 The expected Sender (-f parameter) after parsing.
+     * @return array{
+     *   0: string, // The sendmail path to parse.
+     *   1: string, // The expected command after parsing.
+     *   2: string  // The expected Sender (-f parameter) after parsing.
      * }
      */
 


### PR DESCRIPTION
Fixes #3282

Here is the problem: 
If the users already had defined the `sendmail_path` we were adding again to params the `-f` when the Sender was specified. 

This provoked a double sender (one from params and one from the sender path)

This patch simply check if the `-f` has been already set to avoid setting it again. 

About the Testing, it has been a little more complex than I expected
The problem here is that `sendmail_path` is `PHP_INI_SYSTEM` so it's impossible to modifiy this in runtime, so the only way to modify it is through the `php.ini` or passing the parameter to the PHPUnit binary run as I explain below.

I was checking the previous tests like `testMailSend` assuming that they were right as they were setting 
```php
ini_set('sendmail_path', '/usr/sbin/sendmail -t -i ');
```

But this is basically not doing anything as this cannot be set. 

The only way to execute the test with a different `sendmail_path` is through running something like this:

```
php -d sendmail_path="/usr/sbin/sendmail -t -i -frpath@example.org" ./vendor/bin/phpunit --filter  testMailSendWithSendmailParams
```

On the other side `sendmail_from` can be set as its not a `PHP_INI_SYSTEM` parameter. 

Note that the logic is very interesting in:

https://github.com/PHPMailer/PHPMailer/blob/360ae911ce62e25e11249f6140fa58939f556ebe/src/PHPMailer.php#L2059-L2070

Because adding a `sendmail_from` , enables the Sender in L2062 (regardless if the `setFrom` is `true` or not and then the L2064 validates the condition. This was the reason here https://github.com/PHPMailer/PHPMailer/discussions/3281 enabling it, despite being a non-Windows parameter, was changing the course of action (and this is why I thought it was a Poltergeist 🤣 because, how was it possible, that `sendmail_from` was doing something if the PHP docs explicitely said that this was a Windows-only parameter?). I reviewed the whole mail code in PHP and Sendmail server to only find that the problem was here...

This fix is somewhat time-sensitive to be rolled out in a new PHPMailer version because I need to send the patch downstream for next WP 6.9.1 release with the next version of PHPMailer to fix everyone's problems.