### PR TITLE
Fix fallback address parsing for display names containing commas

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1354,7 +1354,7 @@ class PHPMailer
         trigger_error(self::lang('imap_recommended'), E_USER_NOTICE);
 
         $addresses = [];
-        $list = explode(',', $addrstr);
+        $list = static::splitAddressList($addrstr);
         foreach ($list as $address) {
             $address = trim($address);
             //Is there a separate name part?
@@ -1379,6 +1379,94 @@ class PHPMailer
                 }
             }
         }
+
+        return $addresses;
+    }
+
+    /**
+     * Split a comma-separated address list while preserving commas inside quoted names,
+     * comments, and angle-bracketed address literals.
+     *
+     * @param string $addrstr The address list string.
+     *
+     * @return string[]
+     */
+    private static function splitAddressList($addrstr)
+    {
+        $addresses = [];
+        $current = '';
+        $inquote = false;
+        $quoteChar = '';
+        $escape = false;
+        $angleLevel = 0;
+        $commentLevel = 0;
+        $length = strlen($addrstr);
+
+        for ($i = 0; $i < $length; ++$i) {
+            $char = $addrstr[$i];
+
+            if ($escape) {
+                $current .= $char;
+                $escape = false;
+                continue;
+            }
+
+            if ($char === '\\') {
+                $current .= $char;
+                $escape = true;
+                continue;
+            }
+
+            if ($inquote) {
+                if ($char === $quoteChar) {
+                    $inquote = false;
+                    $quoteChar = '';
+                }
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === '"' || $char === '\'') {
+                $inquote = true;
+                $quoteChar = $char;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === '(') {
+                ++$commentLevel;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ')' && $commentLevel > 0) {
+                --$commentLevel;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === '<') {
+                ++$angleLevel;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === '>' && $angleLevel > 0) {
+                --$angleLevel;
+                $current .= $char;
+                continue;
+            }
+
+            if ($char === ',' && $angleLevel === 0 && $commentLevel === 0) {
+                $addresses[] = $current;
+                $current = '';
+                continue;
+            }
+
+            $current .= $char;
+        }
+
+        $addresses[] = $current;
 
         return $addresses;
     }

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -96,6 +96,69 @@ final class ParseAddressesTest extends TestCase
         ];
     }
 
+    /**
+     * Verify native parsing results while suppressing the runtime notice that recommends IMAP.
+     *
+     * @dataProvider dataAddressSplittingNativeRegression
+     * @covers \PHPMailer\PHPMailer\PHPMailer::parseSimplerAddresses
+     *
+     * @param string $addrstr The address list string.
+     * @param array  $expected The expected function output.
+     * @param string $charset Optional. The charset to use.
+     */
+    public function testAddressSplittingNativeRegression(
+        $addrstr,
+        $expected,
+        $charset = PHPMailer::CHARSET_ISO88591
+    ) {
+        set_error_handler(static function ($errno, $errstr) {
+            if ($errno === E_USER_NOTICE && strpos($errstr, PHPMailer::lang('imap_recommended')) === 0) {
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $reflMethod = new ReflectionMethod(PHPMailer::class, 'parseSimplerAddresses');
+            (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(true);
+            $parsed = $reflMethod->invoke(null, $addrstr, $charset);
+            (\PHP_VERSION_ID < 80100) && $reflMethod->setAccessible(false);
+
+            $this->verifyExpectations($parsed, $expected);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Data provider for native parser regression coverage.
+     *
+     * @return array
+     *      addrstr: string,
+     *      expected: array{name: string, address: string}[]
+     *      charset: string
+     */
+    public static function dataAddressSplittingNativeRegression()
+    {
+        return [
+            'Valid address: quoted comma in display name' => [
+                'addrstr'  => '"Doe, Jane" <jane@example.com>, Bob User <bob@example.net>',
+                'expected' => [
+                    ['name' => 'Doe, Jane', 'address' => 'jane@example.com'],
+                    ['name' => 'Bob User', 'address' => 'bob@example.net'],
+                ],
+            ],
+            'Valid address: comma inside comment' => [
+                'addrstr'  => 'Joe User (Primary, Billing) <joe@example.com>, Jill User <jill@example.net>',
+                'expected' => [
+                    ['name' => 'Joe User (Primary, Billing)', 'address' => 'joe@example.com'],
+                    ['name' => 'Jill User', 'address' => 'jill@example.net'],
+                ],
+            ],
+        ];
+    }
+
      /**
      * Test if email addresses are parsed and split into a name and address.
      *


### PR DESCRIPTION
The fallback RFC822 address parser in `PHPMailer::parseSimplerAddresses()` was splitting recipient lists with a plain `explode(',')`. That caused valid address lists to break in environments without the IMAP extension when display names or comments contained commas, for example `"Doe, Jane" <jane@example.com>`.

This change replaces the naive split with a parser-aware address list splitter that preserves commas inside quoted names, comments, and angle-bracketed address forms. It also adds regression tests covering quoted display names with commas and comments containing commas.

Testing:
Unable to run PHPUnit in this environment because `php`/`phpunit` are not installed locally.