### PR TITLE
Restore deprecated useimap boolean compatibility

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1284,26 +1284,27 @@ class PHPMailer
     /**
      * Parse and validate a string containing one or more RFC822-style comma-separated email addresses
      * of the form "display name <address>" into an array of name/address pairs.
-     * Uses the imap_rfc822_parse_adrlist function if the IMAP extension is available.
+     * Uses the imap_rfc822_parse_adrlist function if the IMAP extension is available and
+     * the deprecated $useimap argument is truthy.
      * Note that quotes in the name part are removed.
      *
      * @see https://www.andrew.cmu.edu/user/agreen1/testing/mrbs/web/Mail/RFC822.php A more careful implementation
      *
      * @param string $addrstr The address list string
      * @param bool|null $useimap Deprecated in PHPMailer 6.11.0.
-     *                           Previously this argument determined whether to use
-     *                           the IMAP extension to parse the list and accepted a boolean value.
+     *                           Truthy values request the deprecated IMAP parser
+     *                           and trigger a deprecation warning.
      * @param string $charset The charset to use when decoding the address list string.
      *
      * @return array
      */
     public static function parseAddresses($addrstr, $useimap = null, $charset = self::CHARSET_ISO88591)
     {
-        if ($useimap !== null && !is_bool($useimap)) {
+        if ($useimap == true) {
             trigger_error(self::lang('deprecated_argument') . '$useimap', E_USER_DEPRECATED);
         }
         $addresses = [];
-        if ($useimap !== false && function_exists('imap_rfc822_parse_adrlist')) {
+        if ($useimap == true && function_exists('imap_rfc822_parse_adrlist')) {
             //Use this built-in parser if it's available
             // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imap_rfc822_parse_adrlistRemoved -- wrapped in function_exists()
             $list = imap_rfc822_parse_adrlist($addrstr, '');

--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -1289,20 +1289,20 @@ class PHPMailer
      * @see https://www.andrew.cmu.edu/user/agreen1/testing/mrbs/web/Mail/RFC822.php A more careful implementation
      *
      * @param string $addrstr The address list string
-     * @param null   $useimap Unused. Argument has been deprecated in PHPMailer 6.11.0.
-     *                        Previously this argument determined whether to use
-     *                        the IMAP extension to parse the list and accepted a boolean value.
+     * @param bool|null $useimap Deprecated in PHPMailer 6.11.0.
+     *                           Previously this argument determined whether to use
+     *                           the IMAP extension to parse the list and accepted a boolean value.
      * @param string $charset The charset to use when decoding the address list string.
      *
      * @return array
      */
     public static function parseAddresses($addrstr, $useimap = null, $charset = self::CHARSET_ISO88591)
     {
-        if ($useimap !== null) {
+        if ($useimap !== null && !is_bool($useimap)) {
             trigger_error(self::lang('deprecated_argument') . '$useimap', E_USER_DEPRECATED);
         }
         $addresses = [];
-        if (function_exists('imap_rfc822_parse_adrlist')) {
+        if ($useimap !== false && function_exists('imap_rfc822_parse_adrlist')) {
             //Use this built-in parser if it's available
             // phpcs:ignore PHPCompatibility.FunctionUse.RemovedFunctions.imap_rfc822_parse_adrlistRemoved -- wrapped in function_exists()
             $list = imap_rfc822_parse_adrlist($addrstr, '');

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -70,11 +70,14 @@ final class ParseAddressesTest extends TestCase
     }
 
     /**
-     * Test that the deprecated $useimap argument still accepts historical boolean values.
+     * Test that falsy $useimap values use the simpler parser without a deprecation warning.
      *
+     * @dataProvider dataParseAddressesFalsyUseimapValues
      * @covers \PHPMailer\PHPMailer\PHPMailer::parseAddresses
+     *
+     * @param mixed $useimap The $useimap argument.
      */
-    public function testParseAddressesAcceptsDeprecatedUseimapBoolean()
+    public function testParseAddressesWithFalsyUseimapValues($useimap)
     {
         set_error_handler(static function ($errno, $errstr) {
             if ($errno === E_USER_DEPRECATED) {
@@ -88,12 +91,68 @@ final class ParseAddressesTest extends TestCase
             $expected = [
                 ['name' => '', 'address' => 'joe@example.com'],
             ];
-
-            $this->verifyExpectations(PHPMailer::parseAddresses('joe@example.com', true), $expected);
-            $this->verifyExpectations(PHPMailer::parseAddresses('joe@example.com', false), $expected);
+            $this->verifyExpectations(PHPMailer::parseAddresses('joe@example.com', $useimap), $expected);
         } finally {
             restore_error_handler();
         }
+    }
+
+    /**
+     * Test that truthy $useimap values request the deprecated IMAP parser.
+     *
+     * @dataProvider dataParseAddressesTruthyUseimapValues
+     * @covers \PHPMailer\PHPMailer\PHPMailer::parseAddresses
+     *
+     * @param mixed $useimap The $useimap argument.
+     */
+    public function testParseAddressesWithTruthyUseimapValues($useimap)
+    {
+        set_error_handler(static function ($errno, $errstr) {
+            if ($errno === E_USER_DEPRECATED) {
+                throw new \Exception($errstr, $errno);
+            }
+
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $this->expectException(\Exception::class);
+            $this->expectExceptionCode(E_USER_DEPRECATED);
+            PHPMailer::parseAddresses('joe@example.com', $useimap);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Data provider for falsy $useimap values.
+     *
+     * @return array
+     */
+    public static function dataParseAddressesFalsyUseimapValues()
+    {
+        return [
+            'null' => [null],
+            'false' => [false],
+            'zero integer' => [0],
+            'empty string' => [''],
+            'zero string' => ['0'],
+        ];
+    }
+
+    /**
+     * Data provider for truthy $useimap values.
+     *
+     * @return array
+     */
+    public static function dataParseAddressesTruthyUseimapValues()
+    {
+        return [
+            'true' => [true],
+            'one integer' => [1],
+            'one string' => ['1'],
+            'yes string' => ['yes'],
+        ];
     }
 
     /**
@@ -186,7 +245,15 @@ final class ParseAddressesTest extends TestCase
      */
     public function testAddressSplitting($addrstr, $expected)
     {
-        $parsed = PHPMailer::parseAddresses($addrstr, null, PHPMailer::CHARSET_UTF8);
+        set_error_handler(static function () {
+            return true;
+        }, E_USER_DEPRECATED);
+
+        try {
+            $parsed = PHPMailer::parseAddresses($addrstr, true, PHPMailer::CHARSET_UTF8);
+        } finally {
+            restore_error_handler();
+        }
 
         $this->verifyExpectations($parsed, $expected);
     }

--- a/test/PHPMailer/ParseAddressesTest.php
+++ b/test/PHPMailer/ParseAddressesTest.php
@@ -70,6 +70,33 @@ final class ParseAddressesTest extends TestCase
     }
 
     /**
+     * Test that the deprecated $useimap argument still accepts historical boolean values.
+     *
+     * @covers \PHPMailer\PHPMailer\PHPMailer::parseAddresses
+     */
+    public function testParseAddressesAcceptsDeprecatedUseimapBoolean()
+    {
+        set_error_handler(static function ($errno, $errstr) {
+            if ($errno === E_USER_DEPRECATED) {
+                throw new \Exception($errstr, $errno);
+            }
+
+            return true;
+        }, E_USER_NOTICE | E_USER_DEPRECATED);
+
+        try {
+            $expected = [
+                ['name' => '', 'address' => 'joe@example.com'],
+            ];
+
+            $this->verifyExpectations(PHPMailer::parseAddresses('joe@example.com', true), $expected);
+            $this->verifyExpectations(PHPMailer::parseAddresses('joe@example.com', false), $expected);
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
      * Data provider for testAddressSplittingNative.
      *
      * @return array


### PR DESCRIPTION
## Summary

This restores backward compatibility for the deprecated `$useimap` argument in `PHPMailer::parseAddresses()`.

Previously, passing `true` or `false` was valid. The argument is now deprecated, but recent behavior triggered an `E_USER_DEPRECATED` warning for boolean values and ignored `false`, which could break applications that support multiple PHPMailer versions or convert PHP warnings into exceptions.

## Changes

- Keep accepting historical boolean values for `$useimap` without emitting a runtime deprecation warning.
- Restore the previous behavior where `$useimap === false` forces the simpler non-IMAP parser.
- Add a regression test covering both `true` and `false`.

## Tests

```powershell
.\vendor\bin\phpunit --no-coverage test\PHPMailer\ParseAddressesTest.php

Result : OK (26 tests, 40 assertions)
```

---

Note: this is my first contribution here. I noticed the branch protection requires verified signatures; I can re-sign the commit if needed.
