### PR TITLE
Clarify Gmail app password usage in Gmail SMTP example

### DIFF
--- a/examples/gmail.phps
+++ b/examples/gmail.phps
@@ -48,6 +48,8 @@ $mail->SMTPAuth = true;
 $mail->Username = 'username@gmail.com';
 
 //Password to use for SMTP authentication
+//For Gmail, use an app password if you have 2-Step Verification enabled.
+//For XOAUTH2 authentication, see the gmail_xoauth.phps example.
 $mail->Password = 'yourpassword';
 
 //Set who the message is to be sent from

--- a/examples/gmail.phps
+++ b/examples/gmail.phps
@@ -48,8 +48,8 @@ $mail->SMTPAuth = true;
 $mail->Username = 'username@gmail.com';
 
 //Password to use for SMTP authentication
-//For Gmail, use an app password if you have 2-Step Verification enabled.
-//For XOAUTH2 authentication, see the gmail_xoauth.phps example.
+//For Gmail accounts with 2-Step Verification enabled, use an app password:
+//https://support.google.com/accounts/answer/185833
 $mail->Password = 'yourpassword';
 
 //Set who the message is to be sent from


### PR DESCRIPTION
This PR updates the Gmail SMTP example to clarify that Gmail users should use an app password when 2-Step Verification is enabled.

It also points users to the XOAUTH2 example for OAuth-based authentication.