### PR TITLE
Fix smtps DSN encryption mode

### DIFF
--- a/src/DSNConfigurator.php
+++ b/src/DSNConfigurator.php
@@ -140,7 +140,7 @@ class DSNConfigurator
         $isSMTPS = 'smtps' === $config['scheme'];
 
         if ($isSMTPS) {
-            $mailer->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+            $mailer->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
         }
 
         $mailer->Host = $config['host'];

--- a/test/PHPMailer/DSNConfiguratorTest.php
+++ b/test/PHPMailer/DSNConfiguratorTest.php
@@ -157,7 +157,7 @@ final class DSNConfiguratorTest extends TestCase
         $configurator->configure($this->Mail, 'smtps://user:pass@remotehost');
 
         self::assertEquals($this->Mail->Mailer, 'smtp');
-        self::assertEquals($this->Mail->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+        self::assertEquals($this->Mail->SMTPSecure, PHPMailer::ENCRYPTION_SMTPS);
 
         self::assertEquals($this->Mail->Host, 'remotehost');
         self::assertEquals($this->Mail->Port, SMTP::DEFAULT_SECURE_PORT);
@@ -206,7 +206,7 @@ final class DSNConfiguratorTest extends TestCase
         $mailer = DSNConfigurator::mailer('smtps://user@gmail.com:secret@smtp.gmail.com?SMTPDebug=3&Timeout=1000');
 
         self::assertEquals($mailer->Mailer, 'smtp');
-        self::assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_STARTTLS);
+        self::assertEquals($mailer->SMTPSecure, PHPMailer::ENCRYPTION_SMTPS);
 
         self::assertEquals($mailer->Host, 'smtp.gmail.com');
         self::assertEquals($mailer->Port, SMTP::DEFAULT_SECURE_PORT);


### PR DESCRIPTION
## Summary

- Map `smtps://` DSNs to `PHPMailer::ENCRYPTION_SMTPS` instead of `PHPMailer::ENCRYPTION_STARTTLS`.
- Update DSNConfigurator tests to assert implicit TLS behavior for `smtps://` URLs.

## Rationale

`smtps://` represents implicit TLS, and DSNConfigurator already applies `SMTP::DEFAULT_SECURE_PORT` for that scheme. Mapping it to `ENCRYPTION_STARTTLS` is inconsistent with the scheme semantics and makes SMTPS DSNs use the STARTTLS mode instead of an implicit TLS connection.

Fixes #3344.

## Testing

- `git diff --check`
- `/private/tmp/phpmailer-audit/php-runtime/bin/php7/bin/php -n /private/tmp/phpmailer-audit/vendor/bin/phpunit --bootstrap /private/tmp/phpmailer-audit/vendor/autoload.php --no-coverage test/PHPMailer/DSNConfiguratorTest.php`
