### PR TITLE
GH Actions: fail "setup-php" if requested tooling could not be installed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,6 +29,8 @@ jobs:
           php-version: 'latest'
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -75,6 +77,8 @@ jobs:
           ini-values: error_reporting=-1, display_errors=On, display_startup_errors=On
           coverage: none
           tools: cs2pr
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer
@@ -177,6 +181,8 @@ jobs:
           coverage: ${{ matrix.coverage && 'xdebug' || 'none' }}
           ini-values: sendmail_path=/usr/sbin/sendmail -t -i, error_reporting=-1, display_errors=On, display_startup_errors=On
           extensions: ${{ steps.set_extensions.outputs.EXT }}
+        env:
+          fail-fast: true
 
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-php-dependencies-with-composer


### PR DESCRIPTION
Setup-PHP will normally "gracefully" show a warning and not fail the build when an extension or tool failed to install.

In most cases, this is not particularly useful as that means that either there will be a failure later on in the build due to the extension or tool missing, or the build will not be representative of what is supposed to be tested.

This commit changes this behaviour to fail select builds at the `setup-php` step, which also makes debugging these type of build failures much more straight-forward.

Ref: https://github.com/shivammathur/setup-php?tab=readme-ov-file#fail-fast-optional