### PR TITLE
Normalise line breaks in S/MIME signed messages

### DIFF
--- a/src/PHPMailer.php
+++ b/src/PHPMailer.php
@@ -3320,8 +3320,9 @@ class PHPMailer
                     @unlink($signed);
                     //The message returned by openssl contains both headers and body, so need to split them up
                     $parts = explode("\n\n", $body, 2);
-                    $this->MIMEHeader .= $parts[0] . static::$LE . static::$LE;
-                    $body = $parts[1];
+                    //openssl emits bare LF breaks, which SMTP servers may reject
+                    $this->MIMEHeader .= static::normalizeBreaks($parts[0]) . static::$LE . static::$LE;
+                    $body = static::normalizeBreaks($parts[1]);
                 } else {
                     @unlink($signed);
                     throw new Exception(self::lang('signing') . openssl_error_string());

--- a/test/PHPMailer/PHPMailerTest.php
+++ b/test/PHPMailer/PHPMailerTest.php
@@ -971,6 +971,11 @@ EOT;
 
         $msg = $this->Mail->getSentMIMEMessage();
         self::assertStringNotContainsString("\r\n\r\nMIME-Version:", $msg, 'Incorrect MIME headers');
+        self::assertSame(
+            0,
+            preg_match_all("/(?<!\r)\n/", $msg),
+            'Signed message contains bare line feeds'
+        );
         unlink($certfile);
         unlink($keyfile);
     }


### PR DESCRIPTION
Fixes #3067.

`openssl_pkcs7_sign()` returns its headers and body with bare LF line breaks.
`createBody()` copied both into the message verbatim, so every S/MIME signed
message went out with LF-only line endings, and servers that enforce RFC 5321
line endings reject them with `550 5.6.11 SMTPSEND.BareLinefeedsAreIllegal`.

This runs openssl's output through the existing `normalizeBreaks()` helper,
matching what `DKIM_Sign()` already does with `$signHeader`.

Counted on a message built with `preSend()` and a self-signed certificate:

|                | bare LF | CRLF |
| -------------- | ------- | ---- |
| unsigned       | 0       | 11   |
| signed, before | 46      | 14   |
| signed, after  | 0       | 60   |

Unsigned messages are unaffected — every bare LF came from the signing step.

Normalising after signing does not invalidate the signature: S/MIME
canonicalises to CRLF before digesting, and `openssl smime -verify` reports
`Verification successful` both before and after the change.

`testSigning()` gained an assertion that the sent message contains no bare
linefeeds. It fails with 50 of them on `master` and passes with this change.

One note on the report: it also suggested normalising *before* signing, but the
body already has no bare LF at that point, so that half is not needed. The
header does need it — `MIME-Version:` lands on the fifth line.
